### PR TITLE
Added missing config parameter linfinity_cap with default value

### DIFF
--- a/demo/income_prediction/src/main/resources/income_prediction.conf
+++ b/demo/income_prediction/src/main/resources/income_prediction.conf
@@ -66,6 +66,7 @@ spline_model {
   dropout : 0.2
   rank_threshold : 0.0
   smoothing_tolerance : 0.03
+  linfinity_cap : 0.0
   linfinity_threshold : 0.01
   context_transform : identity_transform
   item_transform : identity_transform


### PR DESCRIPTION
While executing `sh job_runner.sh TrainModel` in the income prediction demo, there is an error thrown due to a missing configuration parameter.

This pull request adds the parameter with the default value found in code.