### PR TITLE
add debugScoreComponent for linear model

### DIFF
--- a/core/src/main/java/com/airbnb/aerosolve/core/models/LinearModel.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/models/LinearModel.java
@@ -131,8 +131,26 @@ public class LinearModel extends AbstractModel {
 
   @Override
   public List<DebugScoreRecord> debugScoreComponents(FeatureVector combinedItem) {
-    // (TODO) implement debugScoreComponents
+    // linear model takes only string features
+    Map<String, Set<String>> stringFeatures = combinedItem.getStringFeatures();
     List<DebugScoreRecord> scoreRecordsList = new ArrayList<>();
+    if (stringFeatures == null || weights == null) {
+      return scoreRecordsList;
+    }
+    for (Entry<String, Set<String>> entry : stringFeatures.entrySet()) {
+      String family = entry.getKey();
+      Map<String, Float> inner = weights.get(family);
+      if (inner == null) continue;
+      for (String value : entry.getValue()) {
+        DebugScoreRecord record = new DebugScoreRecord();
+        record.setFeatureFamily(family);
+        record.setFeatureName(value);
+        // 1.0 if the string feature exists, 0.0 otherwise
+        record.setFeatureValue(1.0);
+        record.setFeatureWeight(inner.get(value));
+        scoreRecordsList.add(record);
+      }
+    }
     return scoreRecordsList;
   }
 

--- a/core/src/test/java/com/airbnb/aerosolve/core/models/LinearModelTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/models/LinearModelTest.java
@@ -1,5 +1,6 @@
 package com.airbnb.aerosolve.core.models;
 
+import com.airbnb.aerosolve.core.DebugScoreRecord;
 import com.airbnb.aerosolve.core.FeatureVector;
 import com.airbnb.aerosolve.core.ModelHeader;
 import com.airbnb.aerosolve.core.ModelRecord;
@@ -11,6 +12,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.HashSet;
@@ -120,6 +122,24 @@ public class LinearModelTest {
       writer.close();
     } catch (IOException e) {
       assertTrue("Could not save", false);
+    }
+  }
+
+  @Test
+  public void testDebugScoreComponents() {
+    LinearModel model = makeLinearModel();
+    FeatureVector fv = makeFeatureVector();
+    List<DebugScoreRecord> scoreRecordsList = model.debugScoreComponents(fv);
+    assertTrue(scoreRecordsList.size() == 2);
+    for (DebugScoreRecord record : scoreRecordsList) {
+      assertTrue(record.featureFamily == "string_feature");
+      assertTrue(record.featureName == "aaa" || record.featureName == "bbb");
+      assertTrue(record.featureValue == 1.0);
+      if (record.featureName == "aaa") {
+        assertTrue(record.featureWeight == 0.5f);
+      } else {
+        assertTrue(record.featureWeight == 0.25f);
+      }
     }
   }
 }


### PR DESCRIPTION
I was trying to run debugCompare for the mini model, then I realized we don't have this in aerosolve

to: @hectorgon @sdemars 