### PR TITLE
fix the evaluation

### DIFF
--- a/training/src/main/scala/com/airbnb/aerosolve/training/Evaluation.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/Evaluation.scala
@@ -224,7 +224,7 @@ object Evaluation {
         out.append((prefix + "FP", 1.0))
       }
     } else {
-      if (record.label < 0) {
+      if (record.label <= 0) {
         out.append((prefix + "TN", 1.0))
       } else {
         out.append((prefix + "FN", 1.0))


### PR DESCRIPTION
Assume label = 0 corresponds to negative label because it seems people also tend to use 0 as negative label. Without the fix, we are not counting true negatives for label=0
@hectorgon