### PR TITLE
Add rmse evaluation for regression

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-currentVersion=0.1.20
+currentVersion=0.1.21
 bintray_user=fake_user
 bintray_key=fake_key

--- a/training/src/main/scala/com/airbnb/aerosolve/training/Evaluation.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/Evaluation.scala
@@ -96,6 +96,24 @@ object Evaluation {
     metrics
   }
 
+  def evaluateRegression(records : RDD[EvaluationRecord]) : Array[(String, Double)] = {
+    val metricsMap = records
+      .flatMap(x => evaluateRecordRegression(x))
+      .reduceByKey(_ + _)
+      .collectAsMap
+
+    val metrics = metricsMap.toBuffer
+    val te = metricsMap.getOrElse("TRAIN_SQERR", 0.0)
+    val tc = metricsMap.getOrElse("TRAIN_COUNT", 0.0)
+    metrics.append(("!TRAIN_RMSE", Math.sqrt(te / tc)))
+    val he = metricsMap.getOrElse("HOLD_SQERR", 0.0)
+    val hc = metricsMap.getOrElse("HOLD_COUNT", 0.0)
+    metrics.append(("!HOLD_RMSE", Math.sqrt(he / hc)))
+    metrics
+      .sortWith((a, b) => a._1 < b._1)
+      .toArray
+  }
+
   private def evaluateBinaryClassificationAUC(records : RDD[EvaluationRecord],
                                               metrics : Buffer[(String, Double)]) = {
     val COUNT = 5
@@ -208,6 +226,15 @@ object Evaluation {
       case 2 => (score, (0, 0, 1, 0))
       case 3 => (score, (0, 0, 0, 1))
     }
+  }
+
+  private def evaluateRecordRegression(record : EvaluationRecord) : Iterator[(String, Double)] = {
+    val out = collection.mutable.ArrayBuffer[(String, Double)]()
+
+    val prefix = if (record.is_training) "TRAIN_" else "HOLD_"
+    out.append((prefix + "SQERR", (record.label - record.score) * (record.label - record.score)))
+    out.append((prefix + "COUNT", 1.0))
+    out.iterator
   }
 
   // Given a record and a threshold compute if it is a true/false positive/negative


### PR DESCRIPTION
For regression the binary classification metrics don't really make sense anyway and don't calculate RMSE in the same way.  This adds a new short evaluation for regression which for now is just train and hold RMSE.  (Let me know if naming seems okay or should be changed as some of those other metrics might make sense for regression on binary events, this is intended for regression where the labels are real values so could make name more specific if you think that makes sense).

to: @hectorgon @deerzq 