### PR TITLE
Support regression trees in DecisionTreeTrainer

### DIFF
--- a/training/src/main/scala/com/airbnb/aerosolve/training/DecisionTreeTrainer.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/DecisionTreeTrainer.scala
@@ -149,6 +149,7 @@ object DecisionTreeTrainer {
           sum += labelValue
         }
 
+        // In regression case, leaf is the average of all the associated values
         rec.setFeatureWeight(sum / count)
       }
       case _ => {

--- a/training/src/main/scala/com/airbnb/aerosolve/training/DecisionTreeTrainer.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/DecisionTreeTrainer.scala
@@ -51,7 +51,6 @@ object DecisionTreeTrainer {
         .map(x => Util.flattenFeature(x.example(0)))
         .filter(x => x.contains(rankKey))
         .take(candidateSize)
-        .toArray
     
     val stumps = new util.ArrayList[ModelRecord]()
     stumps.append(new ModelRecord)
@@ -59,8 +58,6 @@ object DecisionTreeTrainer {
     
     val model = new DecisionTreeModel()
     model.setStumps(stumps)
-
-    log.info("Dot model=> %s".format(model.toDot))
 
     model
   }
@@ -80,8 +77,6 @@ object DecisionTreeTrainer {
       return
     }
     val split = getBestSplit(examples, rankKey, rankThreshold, numTries, minLeafCount, splitCriteria)
-
-    log.info("**** Best split => %s".format(split))
 
     if (split == None) {
       stumps(currIdx) = makeLeaf(examples, rankKey, rankThreshold, splitCriteria)

--- a/training/src/main/scala/com/airbnb/aerosolve/training/DecisionTreeTrainer.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/DecisionTreeTrainer.scala
@@ -289,6 +289,7 @@ object DecisionTreeTrainer {
   }
 
   // Evaluate a regression-type split
+  // See http://www.stat.cmu.edu/~cshalizi/350-2006/lecture-10.pdf for overview of algorithm used
   def evaluateRegressionSplit(
       examples : Array[util.Map[java.lang.String, util.Map[java.lang.String, java.lang.Double]]],
       rankKey : String,

--- a/training/src/main/scala/com/airbnb/aerosolve/training/DecisionTreeTrainer.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/DecisionTreeTrainer.scala
@@ -9,7 +9,6 @@ import com.airbnb.aerosolve.core.ModelRecord
 import com.airbnb.aerosolve.core.util.Util
 import com.typesafe.config.Config
 import org.apache.spark.SparkContext
-import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -18,9 +17,22 @@ import scala.util.Try
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
 
+// Types of split criteria
+object SplitCriteriaTypes extends Enumeration {
+  val Classification, Regression = Value
+}
+
 // The decision tree is meant to be a prior for the spline model / linear model
 object DecisionTreeTrainer {
   private final val log: Logger = LoggerFactory.getLogger("DecisionTreeTrainer")
+
+  // Mapping from each valid splitCriterion to its type
+  private final val SplitCriteria = Map(
+    "gini" -> SplitCriteriaTypes.Classification,
+    "information_gain" -> SplitCriteriaTypes.Classification,
+    "hellinger" -> SplitCriteriaTypes.Classification,
+    "variance" -> SplitCriteriaTypes.Regression
+  )
 
   def train(sc : SparkContext,
             input : RDD[Example],
@@ -48,6 +60,8 @@ object DecisionTreeTrainer {
     val model = new DecisionTreeModel()
     model.setStumps(stumps)
 
+    log.info("Dot model=> %s".format(model.toDot))
+
     model
   }
   
@@ -62,14 +76,18 @@ object DecisionTreeTrainer {
                 minLeafCount : Int,
                 splitCriteria : String) : Unit = {
     if (currDepth >= maxDepth) {
-      stumps(currIdx) = makeLeaf(examples, rankKey, rankThreshold)
+      stumps(currIdx) = makeLeaf(examples, rankKey, rankThreshold, splitCriteria)
       return
     }
     val split = getBestSplit(examples, rankKey, rankThreshold, numTries, minLeafCount, splitCriteria)
+
+    log.info("**** Best split => %s".format(split))
+
     if (split == None) {
-      stumps(currIdx) = makeLeaf(examples, rankKey, rankThreshold)
+      stumps(currIdx) = makeLeaf(examples, rankKey, rankThreshold, splitCriteria)
       return
     }
+
     // This is a split node.
     stumps(currIdx) = split.get    
     val left = stumps.size
@@ -103,22 +121,46 @@ object DecisionTreeTrainer {
   
   def makeLeaf(examples :  Array[util.Map[java.lang.String, util.Map[java.lang.String, java.lang.Double]]],
                rankKey : String,
-               rankThreshold : Double) = {
-    var numPos = 0.0
-    var numNeg = 0.0
-    for (example <- examples) {
-      val label = if (example.get(rankKey).asScala.head._2 <= rankThreshold) false else true
-      if (label) numPos += 1.0 else numNeg += 1.0
-    }
+               rankThreshold : Double,
+               splitCriteria : String) = {
     val rec = new ModelRecord()
-    val sum = numPos + numNeg
-    if (sum > 0.0) {
-      // Convert from percentage positive to the -1 to 1 range
-      val frac = numPos / sum
-      rec.setFeatureWeight(2.0 * frac - 1.0)
-    } else {
-      rec.setFeatureWeight(0.0)
+
+    SplitCriteria.get(splitCriteria) match {
+      case Some(SplitCriteriaTypes.Classification) => {
+        var numPos = 0.0
+        var numNeg = 0.0
+        for (example <- examples) {
+          val label = if (example.get(rankKey).asScala.head._2 <= rankThreshold) false else true
+          if (label) numPos += 1.0 else numNeg += 1.0
+        }
+        val sum = numPos + numNeg
+        if (sum > 0.0) {
+          // Convert from percentage positive to the -1 to 1 range
+          val frac = numPos / sum
+          rec.setFeatureWeight(2.0 * frac - 1.0)
+        } else {
+          rec.setFeatureWeight(0.0)
+        }
+
+      }
+      case Some(SplitCriteriaTypes.Regression) => {
+        var count: Double = 0.0
+        var sum: Double = 0.0
+
+        for (example <- examples) {
+          val labelValue = example.get(rankKey).asScala.head._2
+
+          count += 1.0
+          sum += labelValue
+        }
+
+        rec.setFeatureWeight(sum / count)
+      }
+      case _ => {
+        log.error("Unrecognized criteria type: %s".format(splitCriteria))
+      }
     }
+
     rec
   }
 
@@ -129,94 +171,171 @@ object DecisionTreeTrainer {
                    numTries : Int,
                    minLeafCount : Int,
                    splitCriteria : String) : Option[ModelRecord] = {
-    var record : Option[ModelRecord] = None
-    var best : Double = -1e10
+    var bestRecord : Option[ModelRecord] = None
+    var bestValue : Double = -1e10
     val rnd = new Random()
     for (i <- 0 until numTries) {
       // Pick an example index randomly
       val idx = rnd.nextInt(examples.size)
       val ex = examples(idx)
       val candidateOpt = getCandidateSplit(ex, rankKey, rnd)
-      if (candidateOpt != None) {
-        var leftPos : Double = 0.0
-        var rightPos : Double = 0.0
-        var leftNeg : Double = 0.0
-        var rightNeg : Double = 0.0
-        for (example <- examples) {
-          val response = BoostedStumpsModel.getStumpResponse(candidateOpt.get, example)
-          val label = if (example.get(rankKey).asScala.head._2 <= rankThreshold) false else true
-          if (response) {
-            if (label) {
-              rightPos += 1.0
-            } else {
-              rightNeg += 1.0
-            }
-          } else {
-            if (label) {
-              leftPos += 1.0
-            } else {
-              leftNeg += 1.0
-            }
+      if (candidateOpt.isDefined) {
+        val candidateValue = SplitCriteria.get(splitCriteria) match {
+          case Some(SplitCriteriaTypes.Classification) => {
+            evaluateClassificationSplit(
+              examples, rankKey,
+              rankThreshold,
+              minLeafCount,
+              splitCriteria, candidateOpt
+            )
           }
+          case Some(SplitCriteriaTypes.Regression) => {
+            evaluateRegressionSplit(
+              examples, rankKey,
+              minLeafCount,
+              splitCriteria, candidateOpt
+            )
+          }
+          case _ =>
+            log.error("Unrecognized split criteria: %s".format(splitCriteria))
+            None
         }
-        val rightCount = rightPos + rightNeg
-        val leftCount = leftPos + leftNeg
-        if (rightCount >= minLeafCount && leftCount >= minLeafCount) {
-          val p1 = rightPos / rightCount
-          val n1 = rightNeg / rightCount
-          val f1 = rightCount / (leftCount + rightCount)
-          val p2 = leftPos / leftCount
-          val n2 = leftNeg / leftCount
-          val f2 = leftCount / (leftCount + rightCount)
-          splitCriteria match {
-            case "gini" => {
-              // Using negative gini since we are maximizing.
-              val gini = - (f1 * (p1 * (1.0 - p1)  + n1 * (1.0 - n1)) +
-                  f2 * (n2 * (1.0 - n2) + p2 * (1.0 - p2)))
-              if (gini > best) {
-                best = gini
-                record = candidateOpt
-              }
-            }
-            case "information_gain" => {
-              var ig = 0.0
-              if (p1 > 0) {
-                ig += f1 * p1 * scala.math.log(p1)
-              }
-              if (n1 > 0) {
-                ig += f1 * n1 * scala.math.log(n1)
-              }
-              if (p2 > 0) {
-                ig += f2 * p2 * scala.math.log(p2)
-              }
-              if (n2 > 0) {
-                ig += f2 * n2 * scala.math.log(n2)
-              }              
-              if (ig > best) {
-                best = ig
-                record = candidateOpt
-              }
-            }
-            case "hellinger" => {
-              val scale = 1.0 / (leftCount * rightCount)
-              // http://en.wikipedia.org/wiki/Bhattacharyya_distance
-              val bhattacharyya = math.sqrt(leftPos * rightPos * scale) + math.sqrt(leftNeg * rightNeg * scale)
-              // http://en.wikipedia.org/wiki/Hellinger_distance
-              val hellinger = math.sqrt(1.0 - bhattacharyya)
-              if (hellinger > best) {
-                best = hellinger
-                record = candidateOpt
-              }              
-            }
-            case _ => log.error("Unknown split criteria %s".format(splitCriteria))
-          }
+
+        if (candidateValue.isDefined && candidateValue.get > bestValue) {
+          bestValue = candidateValue.get
+          bestRecord = candidateOpt
         }
       }
     }
     
-    record
+    bestRecord
   }
-  
+
+  // Evaluate a classification-type split
+  def evaluateClassificationSplit(
+      examples : Array[util.Map[java.lang.String, util.Map[java.lang.String, java.lang.Double]]],
+      rankKey : String,
+      rankThreshold : Double,
+      minLeafCount : Int,
+      splitCriteria : String,
+      candidateOpt : Option[ModelRecord]): Option[Double] = {
+    var leftPos : Double = 0.0
+    var rightPos : Double = 0.0
+    var leftNeg : Double = 0.0
+    var rightNeg : Double = 0.0
+
+    for (example <- examples) {
+      val response = BoostedStumpsModel.getStumpResponse(candidateOpt.get, example)
+      val label = if (example.get(rankKey).asScala.head._2 <= rankThreshold) false else true
+      if (response) {
+        if (label) {
+          rightPos += 1.0
+        } else {
+          rightNeg += 1.0
+        }
+      } else {
+        if (label) {
+          leftPos += 1.0
+        } else {
+          leftNeg += 1.0
+        }
+      }
+    }
+    val rightCount = rightPos + rightNeg
+    val leftCount = leftPos + leftNeg
+
+    if (rightCount >= minLeafCount && leftCount >= minLeafCount) {
+      val p1 = rightPos / rightCount
+      val n1 = rightNeg / rightCount
+      val f1 = rightCount / (leftCount + rightCount)
+      val p2 = leftPos / leftCount
+      val n2 = leftNeg / leftCount
+      val f2 = leftCount / (leftCount + rightCount)
+      splitCriteria match {
+        case "gini" => {
+          // Using negative gini since we are maximizing.
+          val gini = -(
+              f1 * (p1 * (1.0 - p1) + n1 * (1.0 - n1)) +
+                  f2 * (n2 * (1.0 - n2) + p2 * (1.0 - p2))
+              )
+
+          Some(gini)
+        }
+        case "information_gain" => {
+          var ig = 0.0
+          if (p1 > 0) {
+            ig += f1 * p1 * scala.math.log(p1)
+          }
+          if (n1 > 0) {
+            ig += f1 * n1 * scala.math.log(n1)
+          }
+          if (p2 > 0) {
+            ig += f2 * p2 * scala.math.log(p2)
+          }
+          if (n2 > 0) {
+            ig += f2 * n2 * scala.math.log(n2)
+          }
+
+          Some(ig)
+        }
+        case "hellinger" => {
+          val scale = 1.0 / (leftCount * rightCount)
+          // http://en.wikipedia.org/wiki/Bhattacharyya_distance
+          val bhattacharyya = math.sqrt(leftPos * rightPos * scale) + math.sqrt(leftNeg * rightNeg * scale)
+          // http://en.wikipedia.org/wiki/Hellinger_distance
+          val hellinger = math.sqrt(1.0 - bhattacharyya)
+
+          Some(hellinger)
+        }
+      }
+    } else {
+      None
+    }
+  }
+
+  // Evaluate a regression-type split
+  def evaluateRegressionSplit(
+      examples : Array[util.Map[java.lang.String, util.Map[java.lang.String, java.lang.Double]]],
+      rankKey : String,
+      minLeafCount : Int,
+      splitCriteria : String,
+      candidateOpt : Option[ModelRecord]): Option[Double] = {
+    var rightCount: Double = 0.0
+    var rightMean: Double = 0.0
+    var rightSumSq: Double = 0.0
+    var leftCount: Double = 0.0
+    var leftMean: Double = 0.0
+    var leftSumSq: Double = 0.0
+
+    for (example <- examples) {
+      val response = BoostedStumpsModel.getStumpResponse(candidateOpt.get, example)
+      val labelValue = example.get(rankKey).asScala.head._2
+
+      // Using "online algorithm" for computing mean and sum-squared errors as
+      // described in https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
+      if (response) {
+        rightCount += 1
+        val delta = labelValue - rightMean
+        rightMean += delta / rightCount
+        rightSumSq += delta * (labelValue - rightMean)
+      } else {
+        leftCount += 1
+        val delta = labelValue - leftMean
+        leftMean += delta / leftCount
+        leftSumSq += delta * (labelValue - leftMean)
+      }
+    }
+
+    if (rightCount >= minLeafCount && leftCount >= minLeafCount) {
+      splitCriteria match {
+        case "variance" =>
+          Some(-(leftSumSq + rightSumSq))
+      }
+    } else {
+      None
+    }
+  }
+
   // Returns a candidate split sampled from an example.
   def getCandidateSplit(ex : util.Map[java.lang.String, util.Map[java.lang.String, java.lang.Double]],
                         rankKey : String,
@@ -238,6 +357,7 @@ object DecisionTreeTrainer {
     rec.setFeatureFamily(features(idx)._1)
     rec.setFeatureName(features(idx)._2)
     rec.setThreshold(features(idx)._3)
+
     Some(rec)
   }
 

--- a/training/src/main/scala/com/airbnb/aerosolve/training/DecisionTreeTrainer.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/DecisionTreeTrainer.scala
@@ -308,8 +308,10 @@ object DecisionTreeTrainer {
       val response = BoostedStumpsModel.getStumpResponse(candidateOpt.get, example)
       val labelValue = example.get(rankKey).asScala.head._2
 
-      // Using "online algorithm" for computing mean and sum-squared errors as
-      // described in https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
+      // Using Welford's Method for computing mean and sum-squared errors in numerically stable way;
+      // more details can be found in http://jonisalonen.com/2013/deriving-welfords-method-for-computing-variance
+      //
+      // See unit test for verification that it is consistent with standard, two-pass approach
       if (response) {
         rightCount += 1
         val delta = labelValue - rightMean

--- a/training/src/test/scala/com/airbnb/aerosolve/training/TrainingTestHelper.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/TrainingTestHelper.scala
@@ -21,9 +21,9 @@ object TrainingTestHelper {
     loc.put("x", x)
     loc.put("y", y)
     example.addToExample(item)
-    return example
+    example
   }
-  
+
   def makeClassificationExamples = {
     val examples = ArrayBuffer[Example]()
     val label = ArrayBuffer[Double]()
@@ -51,14 +51,15 @@ object TrainingTestHelper {
     val rnd = new java.util.Random(1234)
 
     for (i <- 0 until 200) {
-      val x = 2.0 * rnd.nextDouble() - 1.0
-      val y = 10.0 * (2.0 * rnd.nextDouble() - 1.0)
+      val x = 4.0 * (2.0 * rnd.nextDouble() - 1.0)
+      val y = 4.0 * (2.0 * rnd.nextDouble() - 1.0)
 
-      val quadradtic = x * x + y * y
+      val quadradtic = x * x - 2 * y * y - 0.5 * x + 0.2 * y
 
       examples += makeExample(x, y, quadradtic)
+      label += quadradtic
     }
 
-    examples
+    (examples, label)
   }
 }

--- a/training/src/test/scala/com/airbnb/aerosolve/training/TrainingTestHelper.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/TrainingTestHelper.scala
@@ -1,9 +1,6 @@
 package com.airbnb.aerosolve.training
 
 import com.airbnb.aerosolve.core.{Example, FeatureVector}
-import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
-import org.junit.Test
 import org.slf4j.LoggerFactory
 import scala.collection.mutable.ArrayBuffer
 
@@ -27,11 +24,11 @@ object TrainingTestHelper {
     return example
   }
   
-  def makeClassificationExamples() = {
+  def makeClassificationExamples = {
     val examples = ArrayBuffer[Example]()
     val label = ArrayBuffer[Double]()
     val rnd = new java.util.Random(1234)
-    var numPos : Int = 0;
+    var numPos : Int = 0
     for (i <- 0 until 200) {
       val x = 2.0 * rnd.nextDouble() - 1.0
       val y = 10.0 * (2.0 * rnd.nextDouble() - 1.0)
@@ -46,5 +43,22 @@ object TrainingTestHelper {
       examples += makeExample(x, y, rank)
     }
     (examples, label, numPos)
+  }
+
+  def makeRegressionExamples = {
+    val examples = ArrayBuffer[Example]()
+    val label = ArrayBuffer[Double]()
+    val rnd = new java.util.Random(1234)
+
+    for (i <- 0 until 200) {
+      val x = 2.0 * rnd.nextDouble() - 1.0
+      val y = 10.0 * (2.0 * rnd.nextDouble() - 1.0)
+
+      val quadradtic = x * x + y * y
+
+      examples += makeExample(x, y, quadradtic)
+    }
+
+    examples
   }
 }

--- a/training/src/test/scala/com/airbnb/aerosolve/training/TrainingTestHelper.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/TrainingTestHelper.scala
@@ -54,10 +54,11 @@ object TrainingTestHelper {
       val x = 4.0 * (2.0 * rnd.nextDouble() - 1.0)
       val y = 4.0 * (2.0 * rnd.nextDouble() - 1.0)
 
-      val quadradtic = x * x - 2 * y * y - 0.5 * x + 0.2 * y
+      // Curve will be a "saddle" with flat regions where, for instance, x = 0 and y > 2.06 or y < -1.96
+      val flattenedQuadratic = math.max(x * x - 2 * y * y - 0.5 * x + 0.2 * y, -8.0)
 
-      examples += makeExample(x, y, quadradtic)
-      label += quadradtic
+      examples += makeExample(x, y, flattenedQuadratic)
+      label += flattenedQuadratic
     }
 
     (examples, label)


### PR DESCRIPTION
- Modify existing DecisionTreeTrainer to support both classification- and regression-type splits; see http://www.stat.cmu.edu/~cshalizi/350-2006/lecture-10.pdf for a good overview of the latter.
- Misc. cleanups to associated files

@hectorgon can you take a look? Thanks.