### PR TITLE
fix possible output overwrite problem for transforms

### DIFF
--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/ApproximatePercentileTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/ApproximatePercentileTransform.java
@@ -1,6 +1,8 @@
 package com.airbnb.aerosolve.core.transforms;
 
 import com.airbnb.aerosolve.core.FeatureVector;
+import com.airbnb.aerosolve.core.util.Util;
+
 import com.typesafe.config.Config;
 
 import java.util.HashMap;
@@ -72,12 +74,7 @@ public class ApproximatePercentileTransform extends Transform {
       return;
     }
 
-    Map<String, Double> output = floatFeatures.get(outputName);
-
-    if (output == null) {
-      output = new HashMap<>();
-      floatFeatures.put(outputName, output);
-    }
+    Map<String, Double> output = Util.getOrCreateFloatFeature(outputName, floatFeatures);
 
     Double outVal = 0.0;
     if (val <= low) {

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/BucketFloatTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/BucketFloatTransform.java
@@ -1,6 +1,8 @@
 package com.airbnb.aerosolve.core.transforms;
 
 import com.airbnb.aerosolve.core.FeatureVector;
+import com.airbnb.aerosolve.core.util.Util;
+
 import com.typesafe.config.Config;
 
 import java.util.HashMap;
@@ -36,11 +38,7 @@ public class BucketFloatTransform extends Transform {
       return;
     }
 
-    Map<String, Double> output = floatFeatures.get(outputName);
-    if (output == null) {
-      output = new HashMap<>();
-      floatFeatures.put(outputName, output);
-    }
+    Map<String, Double> output = Util.getOrCreateFloatFeature(outputName, floatFeatures);
 
     for (Entry<String, Double> feature : feature1.entrySet()) {
       Double dbl = LinearLogQuantizeTransform.quantize(feature.getValue(), bucket);

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/CustomLinearLogQuantizeTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/CustomLinearLogQuantizeTransform.java
@@ -105,11 +105,7 @@ public class CustomLinearLogQuantizeTransform extends Transform {
 
     Util.optionallyCreateStringFeatures(featureVector);
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
-    Set<String> output = stringFeatures.get(outputName);
-    if (output == null) {
-      output = new HashSet<>();
-      stringFeatures.put(outputName, output);
-    }
+    Set<String> output = Util.getOrCreateStringFeature(outputName, stringFeatures);
 
     StringBuilder sb = new StringBuilder();
     for (Entry<String, Double> feature : feature1.entrySet()) {

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/CustomMultiscaleQuantizeTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/CustomMultiscaleQuantizeTransform.java
@@ -49,10 +49,9 @@ public class CustomMultiscaleQuantizeTransform extends Transform {
       return;
     }
 
-    Set<String> output = new HashSet<>();
     Util.optionallyCreateStringFeatures(featureVector);
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
-    stringFeatures.put(outputName, output);
+    Set<String> output = Util.getOrCreateStringFeature(outputName, stringFeatures);
 
     for (Entry<String, Double> feature : feature1.entrySet()) {
       if ((excludeFeatures == null || !excludeFeatures.contains(feature.getKey())) &&

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/DateDiffTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/DateDiffTransform.java
@@ -2,6 +2,8 @@ package com.airbnb.aerosolve.core.transforms;
 
 
 import com.airbnb.aerosolve.core.FeatureVector;
+import com.airbnb.aerosolve.core.util.Util;
+
 import com.typesafe.config.Config;
 
 import java.text.DateFormat;
@@ -45,7 +47,7 @@ public class DateDiffTransform extends Transform {
       return ;
     }
 
-    Map<String, Double> output = new HashMap<>();
+    Map<String, Double> output = Util.getOrCreateFloatFeature(outputName, floatFeatures);
 
     try {
       for (String endDateStr : feature1) {
@@ -61,7 +63,5 @@ public class DateDiffTransform extends Transform {
       e.printStackTrace();
       return ;
     }
-
-    floatFeatures.put(outputName, output);
   }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/DateTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/DateTransform.java
@@ -1,6 +1,8 @@
 package com.airbnb.aerosolve.core.transforms;
 
 import com.airbnb.aerosolve.core.FeatureVector;
+import com.airbnb.aerosolve.core.util.Util;
+
 import com.typesafe.config.Config;
 
 import java.text.SimpleDateFormat;
@@ -37,7 +39,7 @@ public class DateTransform extends Transform {
       return ;
     }
 
-    Map<String, Double> output = new HashMap<>();
+    Map<String, Double> output = Util.getOrCreateFloatFeature(outputName, floatFeatures);
 
     for (String dateStr: feature1) {
       try {
@@ -70,7 +72,5 @@ public class DateTransform extends Transform {
         continue ;
       }
     }
-
-    floatFeatures.put(outputName, output);
   }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/DivideTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/DivideTransform.java
@@ -1,6 +1,8 @@
 package com.airbnb.aerosolve.core.transforms;
 
 import com.airbnb.aerosolve.core.FeatureVector;
+import com.airbnb.aerosolve.core.util.Util;
+
 import com.typesafe.config.Config;
 
 import java.util.HashMap;
@@ -56,8 +58,7 @@ public class DivideTransform extends Transform {
     }
 
     Double scale = 1.0 / (constant + div);
-
-    Map<String, Double> output = new HashMap<>();
+    Map<String, Double> output = Util.getOrCreateFloatFeature(outputName, floatFeatures);
 
     for (Entry<String, Double> f1 : feature1.entrySet()) {
       String key = f1.getKey();
@@ -68,6 +69,5 @@ public class DivideTransform extends Transform {
         }
       }
     }
-    floatFeatures.put(outputName, output);
   }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/FloatFeatureMathTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/FloatFeatureMathTransform.java
@@ -1,6 +1,8 @@
 package com.airbnb.aerosolve.core.transforms;
 
 import com.airbnb.aerosolve.core.FeatureVector;
+import com.airbnb.aerosolve.core.util.Util;
+
 import com.typesafe.config.Config;
 
 import java.util.HashMap;
@@ -54,7 +56,8 @@ public class FloatFeatureMathTransform extends Transform {
     if (feature1 == null) {
       return;
     }
-    Map<String, Double> output = new HashMap<>();
+
+    Map<String, Double> output = Util.getOrCreateFloatFeature(outputName, floatFeatures);
     for (String key : keys) {
       Double v = feature1.get(key);
       if (v != null) {
@@ -64,7 +67,6 @@ public class FloatFeatureMathTransform extends Transform {
         }
       }
     }
-    floatFeatures.put(outputName, output);
   }
 
   private Optional<DoubleFunction<Double>> getFunction() {

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/KDTreeTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/KDTreeTransform.java
@@ -69,10 +69,9 @@ public class KDTreeTransform extends Transform {
       return;
     }
 
-    Set<String> output = new HashSet<>();
     Util.optionallyCreateStringFeatures(featureVector);
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
-    stringFeatures.put(outputName, output);
+    Set<String> output = Util.getOrCreateStringFeature(outputName, stringFeatures);
 
     ArrayList<Integer> result = modelOptional.get().query(v1, v2);
     int count = Math.min(result.size(), maxCount);

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/LinearLogQuantizeTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/LinearLogQuantizeTransform.java
@@ -133,10 +133,9 @@ public class LinearLogQuantizeTransform extends Transform {
       return;
     }
 
-    Set<String> output = new HashSet<>();
     Util.optionallyCreateStringFeatures(featureVector);
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
-    stringFeatures.put(outputName, output);
+    Set<String> output = Util.getOrCreateStringFeature(outputName, stringFeatures);
 
     for (Entry<String, Double> feature : feature1.entrySet()) {
       output.add(logQuantize(feature.getKey(), feature.getValue()));

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/MoveFloatToStringTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/MoveFloatToStringTransform.java
@@ -46,10 +46,7 @@ public class MoveFloatToStringTransform extends Transform {
 
     Util.optionallyCreateStringFeatures(featureVector);
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
-    if (!stringFeatures.containsKey(outputName)) {
-      stringFeatures.put(outputName, new HashSet<String>());
-    }
-    Set<String> output = stringFeatures.get(outputName);
+    Set<String> output = Util.getOrCreateStringFeature(outputName, stringFeatures);
 
     for (String key : keys) {
       if (feature1.containsKey(key)) {

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/MultiscaleGridQuantizeTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/MultiscaleGridQuantizeTransform.java
@@ -46,11 +46,9 @@ public class MultiscaleGridQuantizeTransform extends Transform {
       return;
     }
 
-    Set<String> output = new HashSet<>();
     Util.optionallyCreateStringFeatures(featureVector);
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
-    stringFeatures.put(outputName, output);
-
+    Set<String> output = Util.getOrCreateStringFeature(outputName, stringFeatures);
     transformFeature(v1, v2, buckets, output);
   }
 

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/MultiscaleMoveFloatToStringTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/MultiscaleMoveFloatToStringTransform.java
@@ -46,12 +46,7 @@ public class MultiscaleMoveFloatToStringTransform extends Transform {
 
     Util.optionallyCreateStringFeatures(featureVector);
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
-    Set<String> output = new HashSet<>();
-    if (stringFeatures.containsKey(outputName)) {
-      output = stringFeatures.get(outputName);
-    } else {
-      stringFeatures.put(outputName, output);
-    }
+    Set<String> output = Util.getOrCreateStringFeature(outputName, stringFeatures);
 
     for (String key : keys) {
       if (feature1.containsKey(key)) {

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/MultiscaleQuantizeTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/MultiscaleQuantizeTransform.java
@@ -35,10 +35,9 @@ public class MultiscaleQuantizeTransform extends Transform {
       return;
     }
 
-    Set<String> output = new HashSet<>();
     Util.optionallyCreateStringFeatures(featureVector);
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
-    stringFeatures.put(outputName, output);
+    Set<String> output = Util.getOrCreateStringFeature(outputName, stringFeatures);
 
     for (Entry<String, Double> feature : feature1.entrySet()) {
       transformAndAddFeature(buckets,

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/NearestTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/NearestTransform.java
@@ -48,8 +48,9 @@ public class NearestTransform extends Transform {
     if (sub == null) {
       return;
     }
-
-    Set<String> output = new HashSet<>();
+    
+    Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
+    Set<String> output = Util.getOrCreateStringFeature(outputName, stringFeatures);
     String nearest = "nothing";
     double bestDist = 1e10;
 
@@ -63,7 +64,5 @@ public class NearestTransform extends Transform {
     output.add(key2 + "~=" + nearest);
 
     Util.optionallyCreateStringFeatures(featureVector);
-    Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
-    stringFeatures.put(outputName, output);
   }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/ProductTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/ProductTransform.java
@@ -1,6 +1,8 @@
 package com.airbnb.aerosolve.core.transforms;
 
 import com.airbnb.aerosolve.core.FeatureVector;
+import com.airbnb.aerosolve.core.util.Util;
+
 import com.typesafe.config.Config;
 import java.util.List;
 import java.util.Map;
@@ -37,7 +39,7 @@ public class ProductTransform extends Transform {
     }
 
     Double prod = 1.0;
-    Map<String, Double> output = new HashMap<>();
+    Map<String, Double> output = Util.getOrCreateFloatFeature(outputName, floatFeatures);
     for (String key : keys) {
       Double dbl = feature1.get(key);
       if (dbl != null) {
@@ -45,6 +47,5 @@ public class ProductTransform extends Transform {
       }
     }
     output.put("*", prod);
-    floatFeatures.put(outputName, output);
   }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/QuantizeTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/QuantizeTransform.java
@@ -37,10 +37,10 @@ public class QuantizeTransform extends Transform {
       return;
     }
 
-    Set<String> output = new HashSet<>();
     Util.optionallyCreateStringFeatures(featureVector);
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
-    stringFeatures.put(outputName, output);
+
+    Set<String> output = Util.getOrCreateStringFeature(outputName, stringFeatures);
 
     for (Entry<String, Double> feature : feature1.entrySet()) {
       transformAndAddFeature(scale,

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/SelfCrossTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/SelfCrossTransform.java
@@ -1,6 +1,8 @@
 package com.airbnb.aerosolve.core.transforms;
 
 import com.airbnb.aerosolve.core.FeatureVector;
+import com.airbnb.aerosolve.core.util.Util;
+
 import com.typesafe.config.Config;
 import java.util.HashSet;
 import java.util.Set;
@@ -28,11 +30,7 @@ public class SelfCrossTransform extends Transform {
     Set<String> set1 = stringFeatures.get(fieldName1);
     if (set1 == null) return;
 
-    Set<String> output = stringFeatures.get(outputName);
-    if (output == null) {
-      output = new HashSet<>();
-      stringFeatures.put(outputName, output);
-    }
+    Set<String> output = Util.getOrCreateStringFeature(outputName, stringFeatures);
 
     selfCross(set1, output);
   }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/StringCrossFloatTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/StringCrossFloatTransform.java
@@ -1,6 +1,8 @@
 package com.airbnb.aerosolve.core.transforms;
 
 import com.airbnb.aerosolve.core.FeatureVector;
+import com.airbnb.aerosolve.core.util.Util;
+
 import com.typesafe.config.Config;
 import java.util.HashMap;
 import java.util.Set;
@@ -30,8 +32,7 @@ public class StringCrossFloatTransform extends Transform {
     Map<String, Double> list2 = floatFeatures.get(fieldName2);
     if (list2 == null || list2.isEmpty()) return;
 
-    Map<String, Double> output = new HashMap<>();
-    floatFeatures.put(outputName, output);
+    Map<String, Double> output = Util.getOrCreateFloatFeature(outputName, floatFeatures);
 
     for (String s1 : list1) {
       for (Map.Entry<String, Double> s2 : list2.entrySet()) {

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/StuffIdIntoFeatureTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/StuffIdIntoFeatureTransform.java
@@ -1,6 +1,8 @@
 package com.airbnb.aerosolve.core.transforms;
 
 import com.airbnb.aerosolve.core.FeatureVector;
+import com.airbnb.aerosolve.core.util.Util;
+
 import com.typesafe.config.Config;
 
 import java.util.HashMap;
@@ -61,12 +63,7 @@ public class StuffIdIntoFeatureTransform extends Transform {
       return;
     }
 
-    Map<String, Double> output = floatFeatures.get(outputName);
-
-    if (output == null) {
-      output = new HashMap<>();
-      floatFeatures.put(outputName, output);
-    }
+    Map<String, Double> output = Util.getOrCreateFloatFeature(outputName, floatFeatures);
 
     String newname = key2 + '@' + v1.longValue();
     output.put(newname, v2);

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/SubtractTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/SubtractTransform.java
@@ -1,6 +1,8 @@
 package com.airbnb.aerosolve.core.transforms;
 
 import com.airbnb.aerosolve.core.FeatureVector;
+import com.airbnb.aerosolve.core.util.Util;
+
 import com.typesafe.config.Config;
 
 import java.util.HashMap;
@@ -55,7 +57,7 @@ public class SubtractTransform extends Transform {
       return;
     }
 
-    Map<String, Double> output = new HashMap<>();
+    Map<String, Double> output = Util.getOrCreateFloatFeature(outputName, floatFeatures);
 
     for (Entry<String, Double> f1 : feature1.entrySet()) {
       String key = f1.getKey();
@@ -66,6 +68,5 @@ public class SubtractTransform extends Transform {
         }
       }
     }
-    floatFeatures.put(outputName, output);
   }
 }

--- a/core/src/test/java/com/airbnb/aerosolve/core/transforms/DivideTransformTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/transforms/DivideTransformTest.java
@@ -18,31 +18,6 @@ import static org.junit.Assert.assertTrue;
 public class DivideTransformTest {
   private static final Logger log = LoggerFactory.getLogger(DivideTransformTest.class);
 
-  public FeatureVector makeFeatureVector() {
-    Map<String, Set<String>> stringFeatures = new HashMap<>();
-    Map<String, Map<String, Double>> floatFeatures = new HashMap<>();
-
-    Set list = new HashSet<String>();
-    list.add("aaa");
-    list.add("bbb");
-    stringFeatures.put("strFeature1", list);
-
-    Map<String, Double> map = new HashMap<>();
-    map.put("lat", 37.7);
-    map.put("long", 40.0);
-    map.put("z", -1.0);
-    floatFeatures.put("loc", map);
-
-    Map<String, Double> map2 = new HashMap<>();
-    map2.put("foo", 1.5);
-    floatFeatures.put("F", map2);
-
-    FeatureVector featureVector = new FeatureVector();
-    featureVector.setStringFeatures(stringFeatures);
-    featureVector.setFloatFeatures(floatFeatures);
-    return featureVector;
-  }
-
   public String makeConfig() {
     return "test_divide {\n" +
         " transform : divide\n" +
@@ -79,7 +54,27 @@ public class DivideTransformTest {
   public void testTransform() {
     Config config = ConfigFactory.parseString(makeConfig());
     Transform transform = TransformFactory.createTransform(config, "test_divide");
-    FeatureVector featureVector = makeFeatureVector();
+    FeatureVector featureVector = TransformTestingHelper.makeFeatureVector();
+    transform.doTransform(featureVector);
+    Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
+    assertTrue(stringFeatures.size() == 1);
+
+    Map<String, Double> out = featureVector.floatFeatures.get("bar");
+    for (Map.Entry<String, Double> entry : out.entrySet()) {
+      log.info(entry.getKey() + "=" + entry.getValue());
+    }
+    assertTrue(out.size() == 4);
+    assertEquals(37.7 / 1.6, out.get("lat-d-foo"), 0.1);
+    assertEquals(40.0 / 1.6, out.get("long-d-foo"), 0.1);
+    assertEquals(-20.0 / 1.6, out.get("z-d-foo"), 0.1);
+    assertEquals(1.0, out.get("bar_fv"), 0.1);
+  }
+
+  @Test
+  public void testTransformWithKeys() {
+    Config config = ConfigFactory.parseString(makeConfigWithKeys());
+    Transform transform = TransformFactory.createTransform(config, "test_divide");
+    FeatureVector featureVector = TransformTestingHelper.makeFeatureVector();
     transform.doTransform(featureVector);
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
     assertTrue(stringFeatures.size() == 1);
@@ -89,25 +84,8 @@ public class DivideTransformTest {
       log.info(entry.getKey() + "=" + entry.getValue());
     }
     assertTrue(out.size() == 3);
-    assertEquals(37.7 / 1.6, out.get("lat-d-foo"), 0.1);
-    assertEquals(40.0 / 1.6, out.get("long-d-foo"), 0.1);
-    assertEquals(-1.0 / 1.6, out.get("z-d-foo"), 0.1);
-  }
-
-  @Test
-  public void testTransformWithKeys() {
-    Config config = ConfigFactory.parseString(makeConfigWithKeys());
-    Transform transform = TransformFactory.createTransform(config, "test_divide");
-    FeatureVector featureVector = makeFeatureVector();
-    transform.doTransform(featureVector);
-    Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
-    assertTrue(stringFeatures.size() == 1);
-
-    Map<String, Double> out = featureVector.floatFeatures.get("bar");
-    for (Map.Entry<String, Double> entry : out.entrySet()) {
-      log.info(entry.getKey() + "=" + entry.getValue());
-    }
-    assertTrue(out.size() == 2);
+    // the existing features under the family "bar" should not be deleted
+    assertEquals(1.0, out.get("bar_fv"), 0.1);
     assertEquals(37.7 / 1.6, out.get("lat-d-foo"), 0.1);
     assertEquals(40.0 / 1.6, out.get("long-d-foo"), 0.1);
   }

--- a/core/src/test/java/com/airbnb/aerosolve/core/transforms/FloatFeatureMathTransformTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/transforms/FloatFeatureMathTransformTest.java
@@ -24,7 +24,7 @@ public class FloatFeatureMathTransformTest {
         " transform : math_float\n" +
         " field1 : loc\n" +
         " keys : [lat,long,z]\n" +
-        " output : new_loc\n" +
+        " output : bar\n" +
         " function : " + functionName +
         "}";
   }
@@ -54,12 +54,14 @@ public class FloatFeatureMathTransformTest {
     assertEquals(40.0, feat1.get("long"), 0.1);
     assertEquals(-20.0, feat1.get("z"), 0.1);
 
-    Map<String, Double> feat2 = featureVector.getFloatFeatures().get("new_loc");
-    assertEquals(2, feat2.size());
+    Map<String, Double> feat2 = featureVector.getFloatFeatures().get("bar");
+    assertEquals(3, feat2.size());
     assertEquals(Math.log10(37.7), feat2.get("lat"), 0.1);
     assertEquals(Math.log10(40.0), feat2.get("long"), 0.1);
     // for negative value, it would be a missing feature
     assertTrue(!feat2.containsKey("z"));
+    // existing feature in 'bar' should not change
+    assertEquals(1.0, feat2.get("bar_fv"), 0.1);
 
     // test an undefined function
     Config config2 = ConfigFactory.parseString(makeConfig("tan"));
@@ -67,12 +69,14 @@ public class FloatFeatureMathTransformTest {
     FeatureVector featureVector2 = TransformTestingHelper.makeFeatureVector();
     transform2.doTransform(featureVector2);
     // the original features are unchanged
-    assertEquals(3, featureVector2.getFloatFeatures().get("loc").size());
-    Map<String, Double> feat3 = featureVector.getFloatFeatures().get("loc");
+    Map<String, Double> feat3 = featureVector2.getFloatFeatures().get("loc");
+    assertEquals(3, feat3.size());
     assertEquals(37.7, feat3.get("lat"), 0.1);
     assertEquals(40.0, feat3.get("long"), 0.1);
     assertEquals(-20.0, feat3.get("z"), 0.1);
     // new features should not exist
-    assertTrue(!featureVector2.getFloatFeatures().containsKey("new_loc"));
+    Map<String, Double> feat4 = featureVector2.getFloatFeatures().get("bar");
+    assertEquals(1, feat4.size());
+    assertEquals(1.0, feat4.get("bar_fv"), 0.1);
   }
 }

--- a/core/src/test/java/com/airbnb/aerosolve/core/transforms/SubtractTransformTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/transforms/SubtractTransformTest.java
@@ -18,30 +18,6 @@ import static org.junit.Assert.assertTrue;
 public class SubtractTransformTest {
   private static final Logger log = LoggerFactory.getLogger(SubtractTransformTest.class);
 
-  public FeatureVector makeFeatureVector() {
-    Map<String, Set<String>> stringFeatures = new HashMap<>();
-    Map<String, Map<String, Double>> floatFeatures = new HashMap<>();
-
-    Set list = new HashSet<String>();
-    list.add("aaa");
-    list.add("bbb");
-    stringFeatures.put("strFeature1", list);
-
-    Map<String, Double> map = new HashMap<>();
-    map.put("lat", 37.7);
-    map.put("long", 40.0);
-    floatFeatures.put("loc", map);
-
-    Map<String, Double> map2 = new HashMap<>();
-    map2.put("foo", 1.0);
-    floatFeatures.put("F", map2);
-
-    FeatureVector featureVector = new FeatureVector();
-    featureVector.setStringFeatures(stringFeatures);
-    featureVector.setFloatFeatures(floatFeatures);
-    return featureVector;
-  }
-
   public String makeConfig() {
     return "test_subtract {\n" +
            " transform : subtract\n" +
@@ -76,7 +52,27 @@ public class SubtractTransformTest {
   public void testTransform() {
     Config config = ConfigFactory.parseString(makeConfig());
     Transform transform = TransformFactory.createTransform(config, "test_subtract");
-    FeatureVector featureVector = makeFeatureVector();
+    FeatureVector featureVector = TransformTestingHelper.makeFeatureVector();
+    transform.doTransform(featureVector);
+    Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
+    assertTrue(stringFeatures.size() == 1);
+
+    Map<String, Double> out = featureVector.floatFeatures.get("bar");
+    for (Map.Entry<String, Double> entry : out.entrySet()) {
+      log.info(entry.getKey() + "=" + entry.getValue());
+    }
+    assertTrue(out.size() == 4);
+    assertEquals(36.2, out.get("lat-foo"), 0.1);
+    assertEquals(38.5, out.get("long-foo"), 0.1);
+    assertEquals(-21.5, out.get("z-foo"), 0.1);
+    assertEquals(1.0, out.get("bar_fv"), 0.1);
+  }
+
+  @Test
+  public void testTransformWithKeys() {
+    Config config = ConfigFactory.parseString(makeConfigWithKeys());
+    Transform transform = TransformFactory.createTransform(config, "test_subtract");
+    FeatureVector featureVector = TransformTestingHelper.makeFeatureVector();
     transform.doTransform(featureVector);
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
     assertTrue(stringFeatures.size() == 1);
@@ -86,24 +82,7 @@ public class SubtractTransformTest {
       log.info(entry.getKey() + "=" + entry.getValue());
     }
     assertTrue(out.size() == 2);
-    assertEquals(36.7, out.get("lat-foo"), 0.1);
-    assertEquals(39.0, out.get("long-foo"), 0.1);
-  }
-
-  @Test
-  public void testTransformWithKeys() {
-    Config config = ConfigFactory.parseString(makeConfigWithKeys());
-    Transform transform = TransformFactory.createTransform(config, "test_subtract");
-    FeatureVector featureVector = makeFeatureVector();
-    transform.doTransform(featureVector);
-    Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
-    assertTrue(stringFeatures.size() == 1);
-
-    Map<String, Double> out = featureVector.floatFeatures.get("bar");
-    for (Map.Entry<String, Double> entry : out.entrySet()) {
-      log.info(entry.getKey() + "=" + entry.getValue());
-    }
-    assertTrue(out.size() == 1);
-    assertEquals(36.7, out.get("lat-foo"), 0.1);
+    assertEquals(36.2, out.get("lat-foo"), 0.1);
+    assertEquals(1.0, out.get("bar_fv"), 0.1);
   }
 }

--- a/core/src/test/java/com/airbnb/aerosolve/core/transforms/TransformTestingHelper.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/transforms/TransformTestingHelper.java
@@ -23,6 +23,14 @@ public class TransformTestingHelper {
     map.put("z", -20.0);
     floatFeatures.put("loc", map);
 
+    Map<String, Double> map2 = new HashMap<>();
+    map2.put("foo", 1.5);
+    floatFeatures.put("F", map2);
+
+    Map<String, Double> map3 = new HashMap<>();
+    map3.put("bar_fv", 1.0);
+    floatFeatures.put("bar", map3);
+
     FeatureVector featureVector = new FeatureVector();
     featureVector.setStringFeatures(stringFeatures);
     featureVector.setFloatFeatures(floatFeatures);


### PR DESCRIPTION
If a transform outputs to an existing feature family. Some of our transforms would overwrite the content of existing feature family. This PR makes sure all transforms won't have this behavior by always using `Util.getOrCreateFloatFeature` or `Util.getOrCreateStringFeature` to generate new output.

to: @hectorgon @jq @yolken 