### PR TITLE
Allow to specify label min count in FullRankTrainer

### DIFF
--- a/training/src/test/scala/com/airbnb/aerosolve/training/BoostedForestTrainerTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/BoostedForestTrainerTest.scala
@@ -60,7 +60,7 @@ class BoostedForestTrainerTest {
   @Test
   def testBoostedForestTrainerMulticlassHellingerNonlinear() = {
     val config = ConfigFactory.parseString(makeConfig("multiclass_hellinger", "uniform"))
-    ForestTrainerTestHelper.testForestTrainerMulticlassNonlinear(config, true, 0.7)
+    ForestTrainerTestHelper.testForestTrainerMulticlassNonlinear(config, true, 0.6)
   }
 
    @Test

--- a/training/src/test/scala/com/airbnb/aerosolve/training/DecisionTreeModelTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/DecisionTreeModelTest.scala
@@ -45,12 +45,12 @@ class DecisionTreeModelTest {
 
   @Test
   def testDecisionTreeTrainerMulticlassHellinger() = {
-    testDecisionTreeMulticlassTrainer("multiclass_hellinger", 0.7)
+    testDecisionTreeMulticlassTrainer("multiclass_hellinger", 0.6)
   }
 
   @Test
   def testDecisionTreeTrainerMulticlassGini() = {
-    testDecisionTreeMulticlassTrainer("multiclass_gini", 0.7)
+    testDecisionTreeMulticlassTrainer("multiclass_gini", 0.6)
   }
 
   @Test

--- a/training/src/test/scala/com/airbnb/aerosolve/training/DecisionTreeModelTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/DecisionTreeModelTest.scala
@@ -40,7 +40,7 @@ class DecisionTreeModelTest {
 
   @Test
   def testDecisionTreeTrainerHellinger() = {
-    testDecisionTreeClassificationTrainer("hellinger", 0.7)
+    testDecisionTreeClassificationTrainer("hellinger", 0.6)
   }
 
   @Test
@@ -55,12 +55,12 @@ class DecisionTreeModelTest {
 
   @Test
   def testDecisionTreeTrainerGini() = {
-    testDecisionTreeClassificationTrainer("gini", 0.7)
+    testDecisionTreeClassificationTrainer("gini", 0.6)
   }
 
   @Test
   def testDecisionTreeTrainerInformationGain() = {
-    testDecisionTreeClassificationTrainer("information_gain", 0.7)
+    testDecisionTreeClassificationTrainer("information_gain", 0.6)
   }
 
   @Test

--- a/training/src/test/scala/com/airbnb/aerosolve/training/MlpModelTrainerTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/MlpModelTrainerTest.scala
@@ -102,7 +102,7 @@ class MlpModelTrainerTest {
 
   @Test
   def testRegressionWithDropout: Unit = {
-    testRegressionModel(0.05, "", 0, weightDecay = 0.0, epsilon = 0.1, learningRateInit = 0.2)
+    testRegressionModel(0.01, "", 0, weightDecay = 0.0, epsilon = 0.1, learningRateInit = 0.2)
   }
 
   def testMlpModelTrainer(loss : String,


### PR DESCRIPTION
There are cases when a particular type of label occurs really rarely, less than the feature min count, the full rank trainer will throw null pointer error. This PR allows user to specify a different min_count value for label 

to: @jq @Patrick1860 
cc: @hectorgon 