### PR TITLE
Add FloatCrossFloatTransform

### DIFF
--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/FloatCrossFloatTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/FloatCrossFloatTransform.java
@@ -7,6 +7,11 @@ import java.util.Map;
 
 import com.typesafe.config.Config;
 
+/**
+ * Takes the floats in fieldName1, quantizes them into buckets, converts them to strings, then
+ * crosses them with the floats in fieldName2 and then stores the result in a new float feature
+ * output specified by outputName.
+ */
 public class FloatCrossFloatTransform extends Transform {
   private String fieldName1;
   private double bucket;

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/FloatCrossFloatTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/FloatCrossFloatTransform.java
@@ -1,0 +1,72 @@
+package com.airbnb.aerosolve.core.transforms;
+
+import com.airbnb.aerosolve.core.FeatureVector;
+import com.airbnb.aerosolve.core.util.Util;
+
+import java.util.Map;
+
+import com.typesafe.config.Config;
+
+public class FloatCrossFloatTransform extends Transform {
+  private String fieldName1;
+  private double bucket;
+  private double cap;
+  private String fieldName2;
+  private String outputName;
+
+  @Override
+  public void configure(Config config, String key) {
+    fieldName1 = config.getString(key + ".field1");
+    bucket = config.getDouble(key + ".bucket");
+    if (config.hasPath(key + ".cap")) {
+      cap = config.getDouble(key + ".cap");
+    } else {
+      cap = 1e10;
+    }
+    fieldName2 = config.getString(key + ".field2");
+    outputName = config.getString(key + ".output");
+  }
+
+  @Override
+  public void doTransform(FeatureVector featureVector) {
+    Map<String, Map<String, Double>> floatFeatures = featureVector.floatFeatures;
+
+    if (floatFeatures == null || floatFeatures.isEmpty()) {
+      return;
+    }
+
+    Map<String, Double> map1 = floatFeatures.get(fieldName1);
+
+    if (map1 == null || map1.isEmpty()) {
+      return;
+    }
+
+    Map<String, Double> map2 = floatFeatures.get(fieldName2);
+
+    if (map2 == null || map2.isEmpty()) {
+      return;
+    }
+
+    Map<String, Double> output = Util.getOrCreateFloatFeature(outputName, floatFeatures);
+
+    for (Map.Entry<String, Double> entry1 : map1.entrySet()) {
+      String float1Key = entry1.getKey();
+      Double float1Value = entry1.getValue();
+
+      if (float1Value > cap) {
+        float1Value = cap;
+      }
+
+      Double float1Quantized = LinearLogQuantizeTransform.quantize(float1Value, bucket);
+
+      for (Map.Entry<String, Double> entry2 : map2.entrySet()) {
+        String float2Key = entry2.getKey();
+        Double float2Value = entry2.getValue();
+
+        String outputKey = float1Key + "=" + float1Quantized + "^" + float2Key;
+
+        output.put(outputKey, float2Value);
+      }
+    }
+  }
+}

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/TransformFactory.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/TransformFactory.java
@@ -172,6 +172,10 @@ public class TransformFactory {
         result = new ReplaceAllStringsTransform();
         break;
       }
+      case "float_cross_float" : {
+        result = new FloatCrossFloatTransform();
+        break;
+      }
     }
     if (result != null) {
       result.configure(config, key);

--- a/core/src/test/java/com/airbnb/aerosolve/core/transforms/FloatCrossFloatTransformTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/transforms/FloatCrossFloatTransformTest.java
@@ -1,0 +1,97 @@
+package com.airbnb.aerosolve.core.transforms;
+
+import com.airbnb.aerosolve.core.FeatureVector;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by christhetree on 4/8/16.
+ */
+public class FloatCrossFloatTransformTest {
+  private static final Logger log = LoggerFactory.getLogger(FloatCrossFloatTransformTest.class);
+
+  public String makeConfig() {
+    return "test_float_cross_float {\n" +
+        " transform : float_cross_float\n" +
+        " field1 : floatFeature1\n" +
+        " bucket : 1.0\n" +
+        " cap : 1000.0\n" +
+        " field2 : floatFeature2\n" +
+        " output : out\n" +
+        "}";
+  }
+
+  public FeatureVector makeFeatureVector() {
+    Map<String, Map<String, Double>> floatFeatures = new HashMap<>();
+
+    Map<String, Double> floatFeature1 = new HashMap<>();
+
+    floatFeature1.put("x", 50.0);
+    floatFeature1.put("y", 1.3);
+    floatFeature1.put("z", 2000.0);
+
+    Map<String, Double> floatFeature2 = new HashMap<>();
+
+    floatFeature2.put("i", 1.2);
+    floatFeature2.put("j", 3.4);
+    floatFeature2.put("k", 5.6);
+
+    floatFeatures.put("floatFeature1", floatFeature1);
+    floatFeatures.put("floatFeature2", floatFeature2);
+
+    FeatureVector featureVector = new FeatureVector();
+    featureVector.setFloatFeatures(floatFeatures);
+    return featureVector;
+  }
+
+  @Test
+  public void testEmptyFeatureVector() {
+    Config config = ConfigFactory.parseString(makeConfig());
+    Transform transform = TransformFactory.createTransform(config, "test_float_cross_float");
+    FeatureVector featureVector = new FeatureVector();
+    transform.doTransform(featureVector);
+
+    assertTrue(featureVector.getFloatFeatures() == null);
+  }
+
+  @Test
+  public void testTransform() {
+    Config config = ConfigFactory.parseString(makeConfig());
+    Transform transform = TransformFactory.createTransform(config, "test_float_cross_float");
+    FeatureVector featureVector = makeFeatureVector();
+
+    transform.doTransform(featureVector);
+
+    Map<String, Map<String, Double>> floatFeatures = featureVector.getFloatFeatures();
+
+    assertNotNull(floatFeatures);
+    assertEquals(3, floatFeatures.size());
+
+    Map<String, Double> out = floatFeatures.get("out");
+
+    assertEquals(9, out.size());
+
+    assertEquals(1.2, out.get("x=50.0^i"), 0.0);
+    assertEquals(1.2, out.get("y=1.0^i"), 0.0);
+    assertEquals(1.2, out.get("z=1000.0^i"), 0.0);
+    assertEquals(3.4, out.get("x=50.0^j"), 0.0);
+    assertEquals(3.4, out.get("y=1.0^j"), 0.0);
+    assertEquals(3.4, out.get("z=1000.0^j"), 0.0);
+    assertEquals(5.6, out.get("x=50.0^k"), 0.0);
+    assertEquals(5.6, out.get("y=1.0^k"), 0.0);
+    assertEquals(5.6, out.get("z=1000.0^k"), 0.0);
+  }
+}


### PR DESCRIPTION
to: @jq 
cc: @deerzq 

Content:
This is just a quick foundation of what I envisioned a float cross float transform might look like (essentially a MoveFloatToString transform followed by a StringCrossFloat transform, but without deleting the original float feature or creating an intermediate string feature which would occur if these two transforms were applied back to back). The ability to specify which keys to cross could be added as well instead of crossing the entire family.

Please let me know what you think / if this is what you need. Once we're on the same page I'll add comments and tests. Thanks!