### PR TITLE
[pricing] Add generic pipeline to aerosolve

### DIFF
--- a/training/build.gradle
+++ b/training/build.gradle
@@ -40,9 +40,11 @@ dependencies {
 
   provided 'org.apache.spark:spark-core_2.10:1.2.1'
   provided 'org.apache.spark:spark-hive_2.10:1.2.1'
+  provided 'org.apache.spark:spark-mllib_2.10:1.2.1'
 
   testCompile 'org.apache.spark:spark-core_2.10:1.2.1'
   testCompile 'org.apache.spark:spark-hive_2.10:1.2.1'
+  testCompile 'org.apache.spark:spark-mllib_2.10:1.2.1'
   testCompile 'org.mockito:mockito-all:1.9.5'
   testCompile 'org.slf4j:slf4j-simple:1.7.7'
 }

--- a/training/build.gradle
+++ b/training/build.gradle
@@ -40,11 +40,9 @@ dependencies {
 
   provided 'org.apache.spark:spark-core_2.10:1.2.1'
   provided 'org.apache.spark:spark-hive_2.10:1.2.1'
-  provided 'org.apache.spark:spark-mllib_2.10:1.2.1'
 
   testCompile 'org.apache.spark:spark-core_2.10:1.2.1'
   testCompile 'org.apache.spark:spark-hive_2.10:1.2.1'
-  testCompile 'org.apache.spark:spark-mllib_2.10:1.2.1'
   testCompile 'org.mockito:mockito-all:1.9.5'
   testCompile 'org.slf4j:slf4j-simple:1.7.7'
 }

--- a/training/build.gradle
+++ b/training/build.gradle
@@ -41,9 +41,10 @@ dependencies {
   provided 'org.apache.spark:spark-core_2.10:1.2.1'
   provided 'org.apache.spark:spark-hive_2.10:1.2.1'
 
-  testCompile 'org.slf4j:slf4j-simple:1.7.7'
   testCompile 'org.apache.spark:spark-core_2.10:1.2.1'
   testCompile 'org.apache.spark:spark-hive_2.10:1.2.1'
+  testCompile 'org.mockito:mockito-all:1.9.5'
+  testCompile 'org.slf4j:slf4j-simple:1.7.7'
 }
 
 compileScala {

--- a/training/build.gradle
+++ b/training/build.gradle
@@ -35,17 +35,20 @@ bintray {
 dependencies {
   compile project(':core')
   compile 'com.fasterxml.jackson.module:jackson-module-scala_2.10:2.4.2'
+  compile 'joda-time:joda-time:2.5'
+  compile 'org.apache.hadoop:hadoop-client:2.2.0'
+
   provided 'org.apache.spark:spark-core_2.10:1.2.1'
   provided 'org.apache.spark:spark-hive_2.10:1.2.1'
-  compile 'joda-time:joda-time:2.5'
+
   testCompile 'org.slf4j:slf4j-simple:1.7.7'
   testCompile 'org.apache.spark:spark-core_2.10:1.2.1'
   testCompile 'org.apache.spark:spark-hive_2.10:1.2.1'
 }
 
 compileScala {
-    scalaCompileOptions.fork = true
-    scalaCompileOptions.forkOptions.jvmArgs = ['-XX:MaxPermSize=512m']
+  scalaCompileOptions.fork = true
+  scalaCompileOptions.forkOptions.jvmArgs = ['-XX:MaxPermSize=512m']
 }
 
 shadowJar {
@@ -53,5 +56,5 @@ shadowJar {
 }
 
 test {
-    jvmArgs += [ "-XX:MaxPermSize=1024m" ]
+  jvmArgs += [ "-XX:MaxPermSize=1024m" ]
 }

--- a/training/src/main/resources/demo_train.conf
+++ b/training/src/main/resources/demo_train.conf
@@ -1,0 +1,278 @@
+job_name : "Generic Pipeline"
+
+training_data_version : 1
+model_version: "a"
+
+// Which model config to use
+model_type : "linear"
+model_config : ${model_type}"_model_config"
+demo_table : "pricing.income_training_raw"
+
+// Update this based on your HDFS directory layout
+prefix : "hdfs://"
+training_data : ${prefix}"/training_data"${training_data_version}
+eval_output : ${prefix}"/eval_output/"${training_data_version}_${model_version}".eval"
+model_name : ${prefix}"/model/"${training_data_version}_${model_version}_${model_type}".model"
+model_dump : ${model_name}".tsv"
+calibrated_model_name : ${prefix}"/calibrated_model/"${training_data_version}_${model_version}".model"
+
+train_subsample : 0.1
+eval_subsample : 0.1
+scoring_output : ${prefix}"/scores/"${training_data_version}
+
+// The convention is to name features FAMILY_SHORTNAME
+// The reason for feature familities is so we can apply transforms to families at a time.
+// By default two families are created
+// BIAS, B and
+// MISS, COLUMN_NAME for missing features
+// The exception is a special feature named "LABEL" which also has to be a double
+// For the example query, we use two family, i_ as number feature, and s_ as string feature
+
+generic_hive_query : """
+  select
+    if(LENGTH(label) = 5, -1, 1) as LABEL,
+    age as i_age,
+    workclass as s_workclass, fnlwgt as s_fnlwgt,
+    education as s_education,
+    education_num as i_educationnum,
+    marital_status as s_marital,
+    occupation as s_occupation,
+    relationship as s_relationship,
+    race as s_race, sex as s_sex,
+    capital_gain,
+    capital_loss,
+    hours_per_week as i_hours,
+    native_country as s_country
+"""
+
+debug_example {
+  hive_query : ${generic_hive_query}" from "${demo_table}
+  count : 10
+}
+
+debug_transforms {
+  hive_query : ${generic_hive_query}" from "${demo_table}
+  // Which model config to use when debugging
+  model_config : ${model_config}
+  count : 3
+}
+
+make_training {
+  hive_query : ${generic_hive_query}" from "${demo_table}
+  num_shards : 20
+  output : ${training_data}
+}
+
+train_model {
+  input : ${training_data}
+  subsample : ${train_subsample}
+  model_config : ${model_config}
+}
+
+eval_model {
+  input : ${training_data}
+  subsample : ${eval_subsample}
+  bins : 5
+  model_config : ${model_config}
+  is_probability : false
+  is_regression : false
+  metric_to_maximize : "!HOLD_F1"
+  model_name : ${model_name}
+}
+
+calibrate_model {
+  model_config : ${model_config}
+  model_name : ${model_name}
+  calibrated_model_output : ${calibrated_model_name}
+  input: ${training_data}
+  learning_rate : 0.01
+  rate_decay : 0.95
+  iterations : 100
+  num_bags : 10
+  tolerance : 0.01
+  subsample : 0.5
+}
+
+eval_model_calibrated {
+  input : ${training_data}
+  subsample : ${eval_subsample}
+  bins : 5
+  model_config : ${model_config}
+  is_probability : true
+  metric_to_maximize : "!HOLD_F1"
+  model_name : ${calibrated_model_name}
+}
+
+dump_model {
+  // Weights are the same calibrated or not it's just the probabilities that
+  // are different
+  model_name : ${model_name}
+  model_dump : ${model_dump}
+}
+
+score_table {
+  model_config : ${model_config}
+  model_name : ${calibrated_model_name}
+  hive_query : ${generic_hive_query}", id as UNIQUE_ID from training.demo_set"
+  num_shards : 20
+  output : ${scoring_output}
+}
+
+debug_score_table {
+  model_config : ${model_config}
+  model_name : ${calibrated_model_name}
+  hive_query : ${generic_hive_query}", id as UNIQUE_ID from training.demo_set"
+  count : 10
+}
+
+identity_transform {
+  transform : list
+  transforms : [ ]
+}
+
+quantize_capital {
+  transform : multiscale_quantize
+  field1 : "capital"
+  output : "capital"
+  buckets : [500, 2000]
+}
+
+move_age {
+  transform : multiscale_move_float_to_string
+  field1 : "i"
+  keys: [
+    "age"
+  ]
+  output : "A"
+  buckets : [5.0]
+}
+
+move_hours {
+  transform : multiscale_move_float_to_string
+  field1 : "i"
+  keys: [
+    "hours"
+  ]
+  output : "A"
+  buckets : [5.0]
+}
+
+move_edu {
+  transform : multiscale_move_float_to_string
+  field1 : "i"
+  keys: [
+    "educationnum"
+  ]
+  output : "A"
+  buckets : [3.0]
+}
+
+
+// Does this listing like people coming from a certain country?
+id_x_user {
+  transform : cross
+  field1 : "ID"
+  field2 : "USER"
+  output : "ID_x_USER"
+}
+
+combined_transform {
+  transform : list
+  transforms : [
+    "quantize_capital"
+    "move_age"
+    "move_hours"
+    "move_edu"
+  ]
+}
+
+// Config for a linear product quantization model. This model is heavily
+// dependent upon feature transforms being set up correctly as it only
+// handles discrete (i.e.) string features and all float features
+// have to be quantized. This is so that we can debug the model easily.
+linear_model_config {
+  trainer : "linear"
+  prior : [
+    "BIAS,B,0.0", // Set the priors using feature family, feature name, initial weight
+  ]
+  model_output : ${model_name}
+  rank_key : "LABEL"
+  loss : "hinge"
+  margin : 1.0
+  rank_threshold : 0.5
+  dropout : 0.1
+  learning_rate : 0.01
+  num_bags : 10
+  iterations : 10
+  lambda : 0.001
+  lambda2 : 0.01
+  context_transform : identity_transform
+  item_transform : identity_transform
+  combined_transform : combined_transform
+}
+
+// Forest of trees model. Less feature engineering needed but less debuggable.
+// Use this if you just want something fast and easy to use.
+forest_model_config {
+  trainer : "forest"
+  model_output : ${model_name}
+  rank_key : "LABEL"
+  rank_threshold : 0.5
+  // How many trees
+  num_trees : 100
+  // How many samples to use per tree
+  num_candidates : 100000
+  // Max depth of a tree
+  max_depth : 6
+  // Minimum number of samples in each leaf
+  min_leaf_items : 3000
+  // How many times per split to search for an optimal split
+  num_tries : 100
+  context_transform : identity_transform
+  item_transform : identity_transform
+  combined_transform : identity_transform
+}
+
+param_search {
+  // model type
+  model_config : ${model_config}
+  // optimization target
+  metric_to_maximize : "!HOLD_F1"
+  // path and prefix used to store all models
+  model_name_prefix : ${model_name}
+  // max number of trials in parameter search, each round has one training and one eval
+  max_round: 8
+  // strategies to conduct parameter search. "guided" will take all provide values and
+  // cross join them. "grid" will take an optional min (first val) and an optional max
+  // (second val) and generate equal splits for each parameter based on max_round.
+  search_strategy: "guided"
+  // list of parameters to tune (defined in model_config). In "guided" stategy, provide
+  // all parameters you want to try. In "grid" strategy, provide two optional values:
+  // first is a min (default 0), second is max (default 1).
+  param_to_tune: [
+    {
+      name: "lambda"
+      val: [0.001, 0.01, 0.1]
+    }
+    {
+      name: "lambda2"
+      val: [0.01, 0.06, 0.1]
+    }
+  ]
+  // example for grid strategy
+  //  param_to_tune: [
+  //    {
+  //      name: "lambda"
+  //      val: [0.001, 0.1]
+  //    }
+  //    {
+  //      name: "lambda2"
+  //      val: [0.01, 0.1]
+  //    }
+  //  ]
+  // optional, where you want to store the results. If omitted, results will not be stored.
+  // Results will be displayed in terminal log regardlessly.
+  output: ${prefix}"/paramsearch/"${training_data_version}_${model_version}_${model_type}".txt"
+  // optional, where you want to copy the best model to.
+  best_model_output: ${model_name}
+}

--- a/training/src/main/resources/demo_train.conf
+++ b/training/src/main/resources/demo_train.conf
@@ -6,10 +6,13 @@ model_version: "a"
 // Which model config to use
 model_type : "linear"
 model_config : ${model_type}"_model_config"
-demo_table : "pricing.income_training_raw"
+
+// Hive table where the data live
+demo_table : "income_training_raw"
 
 // Update this based on your HDFS directory layout
 prefix : "hdfs://"
+
 training_data : ${prefix}"/training_data"${training_data_version}
 eval_output : ${prefix}"/eval_output/"${training_data_version}_${model_version}".eval"
 model_name : ${prefix}"/model/"${training_data_version}_${model_version}_${model_type}".model"

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/EvalUtil.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/EvalUtil.scala
@@ -4,7 +4,6 @@ import com.airbnb.aerosolve.core.{EvaluationRecord, Example}
 import com.airbnb.aerosolve.core.models.AbstractModel
 import com.airbnb.aerosolve.core.transforms.Transformer
 import org.apache.spark.SparkContext
-import org.apache.spark.mllib.stat.Statistics
 import org.apache.spark.rdd.RDD
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -171,11 +170,5 @@ object EvalUtil {
       cs = (cs._1 + x._1, cs._2 + x._2)
     }
     auc / tot._1 / tot._2
-  }
-
-  def getCorrelation(records : RDD[EvaluationRecord], method : String = "pearson") : Double = {
-    val score: RDD[Double] = records.map(record => record.score)
-    val label: RDD[Double] = records.map(record => record.label)
-    Statistics.corr(score, label, method)
   }
 }

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/EvalUtil.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/EvalUtil.scala
@@ -1,0 +1,166 @@
+package com.airbnb.aerosolve.training.pipeline
+
+import com.airbnb.aerosolve.core.{EvaluationRecord, Example}
+import com.airbnb.aerosolve.core.models.AbstractModel
+import com.airbnb.aerosolve.core.transforms.Transformer
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.collection.JavaConverters._
+
+object EvalUtil {
+  val log: Logger = LoggerFactory.getLogger(this.getClass)
+
+  def scoreExamples(sc: SparkContext,
+                    transformer: Transformer,
+                    modelOpt: AbstractModel,
+                    examples : RDD[Example],
+                    isTraining: Example => Boolean,
+                    labelKey : String) : RDD[(Float, String)] = {
+    // output: RDD[(score, label)], label is "TRAIN_P", "HOLD_P", "TRAIN_N" or "HOLD_N"
+    val modelBC = sc.broadcast(modelOpt)
+    val transformerBC = sc.broadcast(transformer)
+    val scoreAndLabel = examples
+      .map(example => {
+        transformerBC.value.combineContextAndItems(example)
+        val score = modelBC.value.scoreItem(example.example.get(0))
+        val rank = example.example.get(0).floatFeatures.get(labelKey).get("")
+        val label = (if(isTraining(example)) "TRAIN_" else "HOLD_") + (if(rank > 0) "P" else "N")
+        (score, label)
+      })
+    scoreAndLabel
+  }
+
+  def scoreExamplesForEvaluation(sc: SparkContext,
+                                 transformer: Transformer,
+                                 modelOpt: AbstractModel,
+                                 examples : RDD[Example],
+                                 label : String,
+                                 useProb : Boolean,
+                                 isMulticlass: Boolean,
+                                 isTraining: Example => Boolean) : RDD[EvaluationRecord] = {
+    val modelBC = sc.broadcast(modelOpt)
+    val transformerBC = sc.broadcast(transformer)
+    examples.map(example => exampleToEvaluationRecord(
+      example, transformerBC.value,
+      modelBC.value, useProb, isMulticlass, label, isTraining)
+    )
+  }
+
+  def exampleToEvaluationRecord(example: Example,
+                                transformer: Transformer,
+                                model: AbstractModel,
+                                useProb: Boolean,
+                                isMulticlass: Boolean,
+                                label: String,
+                                isTraining: Example => Boolean): EvaluationRecord = {
+    val result = new EvaluationRecord
+    result.setIs_training(isTraining(example))
+    transformer.combineContextAndItems(example)
+
+    if (isMulticlass) {
+      val score = model.scoreItemMulticlass(example.example.get(0)).asScala
+      val multiclassLabel = example.example.get(0).floatFeatures.get(label).asScala
+      val evalScores = new java.util.HashMap[java.lang.String, java.lang.Double]()
+      val evalLabels = new java.util.HashMap[java.lang.String, java.lang.Double]()
+
+      result.setScores(evalScores)
+      result.setLabels(evalLabels)
+
+      for (s <- score) {
+        evalScores.put(s.label, s.score)
+      }
+
+      for (l <- multiclassLabel) {
+        evalLabels.put(l._1, l._2)
+      }
+    } else {
+      val score = model.scoreItem(example.example.get(0))
+      val prob = if (useProb) model.scoreProbability(score) else score
+      val rank = example.example.get(0).floatFeatures.get(label).values().iterator().next()
+
+      result.setScore(prob)
+      result.setLabel(rank)
+    }
+
+    result
+  }
+
+  def scoreExampleForEvaluation(sc: SparkContext,
+                                transformer: Transformer,
+                                modelOpt: AbstractModel,
+                                example: Example,
+                                isTraining: Example => Boolean) : EvaluationRecord = {
+    val modelBC = sc.broadcast(modelOpt)
+    val transformerBC = sc.broadcast(transformer)
+    val result = new EvaluationRecord
+    result.setIs_training(isTraining(example))
+
+    transformerBC.value.combineContextAndItems(example)
+    val score = modelBC.value.scoreItem(example.example.get(0))
+    val prob = modelBC.value.scoreProbability(score)
+    val rank = example.example.get(0).floatFeatures.get("$rank").get("")
+
+    result.setScore(prob)
+    result.setLabel(rank)
+    result
+  }
+
+  def getClassificationAUC(records : Seq[EvaluationRecord]) : Double = {
+    // find minimal and maximal scores
+    var minScore = records.head.score
+    var maxScore = minScore
+    records.foreach(record => {
+      val score = record.score
+      minScore = Math.min(minScore, score)
+      maxScore = Math.max(maxScore, score)
+    })
+
+    if(minScore >= maxScore) {
+      log.warn("max score smaller than or equal to min score (%f, %f).".format(minScore, maxScore))
+      maxScore = minScore + 1.0
+    }
+
+    // for AUC evaluation
+    val buckets = records
+      .map(x => evaluateRecordForAUC(x, minScore, maxScore))
+      .groupBy(_._1)
+      .map(x => x._2.reduce((a, b) => (a._1, (a._2._1 + b._2._1, a._2._2 + b._2._2))))
+      .toArray
+      .sortBy(x => x._1)
+
+    getAUC(buckets.map(x => (x._2._1, x._2._2)))
+  }
+
+  private def evaluateRecordForAUC(record : EvaluationRecord,
+                                   minScore : Double,
+                                   maxScore : Double) : (Long, (Long, Long)) = {
+    var offset = 0
+    if (record.label <= 0) {
+      offset += 1
+    }
+
+    val score : Long = ((record.score - minScore) / (maxScore - minScore) * 100).toLong
+
+    offset match {
+      case 0 => (score, (1, 0))
+      case 1 => (score, (0, 1))
+    }
+  }
+
+  // input is a list of (true positive, true negative) bucketized
+  // by ranker output scores in ascending order
+  private def getAUC(buckets: Array[(Long, Long)]): Double = {
+    val tot = buckets.reduce((x, y) => (x._1 + y._1, x._2 + y._2))
+    var auc = 0.0
+    var cs=(0L, 0L)
+    for (x <- buckets) {
+      // area for the current slice: (TP0+TP1)/2*(TN1-TN0)
+      auc += ((tot._1 - cs._1) + (tot._1 - cs._1 - x._1)) / 2.0 * x._2
+      // (TP0, TN0) -> (TP1, TN1)
+      cs = (cs._1 + x._1, cs._2 + x._2)
+    }
+    auc / tot._1 / tot._2
+  }
+}

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/GenericPipeline.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/GenericPipeline.scala
@@ -1,0 +1,708 @@
+package com.airbnb.aerosolve.training.pipeline
+
+import java.io.{BufferedWriter, OutputStreamWriter}
+
+import com.airbnb.aerosolve.core.{Example, FeatureVector, ModelRecord}
+import com.airbnb.aerosolve.core.models.{AbstractModel, ForestModel, FullRankLinearModel}
+import com.airbnb.aerosolve.core.transforms.Transformer
+import com.airbnb.aerosolve.core.util.Util
+import com.airbnb.aerosolve.training._
+import com.typesafe.config.{Config, ConfigValueFactory}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.io.compress.GzipCodec
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.spark.sql._
+import org.apache.spark.rdd.RDD
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.hive.HiveContext
+
+import scala.math.{ceil, max, pow}
+import scala.collection.JavaConverters._
+import scala.util.{Random, Try}
+
+/**
+  * This is a generic pipeline for building and testing aerosolve models.
+  */
+object GenericPipeline {
+  val log: Logger = LoggerFactory.getLogger("GenericPipeline")
+  val LABEL = "LABEL"
+
+  def makeTrainingRun(sc: SparkContext, config: Config) = {
+    val cfg = config.getConfig("make_training")
+    val query = cfg.getString("hive_query")
+    val output = cfg.getString("output")
+    val numShards = cfg.getInt("num_shards")
+    val isMulticlass = Try(cfg.getBoolean("is_multiclass")).getOrElse(false)
+    val training = makeTraining(sc, query, isMulticlass)
+
+    training
+      .coalesce(numShards, true)
+      .map(Util.encode)
+      .saveAsTextFile(output, classOf[GzipCodec])
+  }
+
+  def debugExampleRun(sc: SparkContext, config: Config) = {
+    val cfg = config.getConfig("debug_example")
+    val query = cfg.getString("hive_query")
+    val count = cfg.getInt("count")
+    val isMulticlass = Try(cfg.getBoolean("is_multiclass")).getOrElse(false)
+
+    makeTraining(sc, query, isMulticlass)
+      .take(count)
+      .foreach(logPrettyExample)
+  }
+
+  def debugTransformsRun(sc : SparkContext, config : Config) = {
+    val cfg = config.getConfig("debug_transforms")
+    val query = cfg.getString("hive_query")
+    val count = cfg.getInt("count")
+    val key = cfg.getString("model_config")
+    val isMulticlass = Try(cfg.getBoolean("is_multiclass")).getOrElse(false)
+
+    val input = makeTraining(sc, query, isMulticlass)
+    LinearRankerUtils
+      .makePointwiseFloat(input, config, key)
+      .take(count)
+      .foreach(logPrettyExample)
+  }
+
+  def trainingRun(sc: SparkContext, config: Config, isTraining: Example => Boolean = isTraining) = {
+    val cfg = config.getConfig("train_model")
+    val inputPattern = cfg.getString("input")
+    val subsample = cfg.getDouble("subsample")
+    val modelConfig = cfg.getString("model_config")
+
+    val input = getExamples(sc, inputPattern)
+      .filter(isTraining)
+
+    val filteredInput = input
+      .sample(false, subsample)
+    TrainingUtils.trainAndSaveToFile(sc, filteredInput, config, modelConfig)
+  }
+
+  def getModelAndTransform(config : Config,
+                           modelCfgName : String,
+                           modelName : String ) = {
+    val modelOpt = TrainingUtils.loadScoreModel(modelName)
+    if (modelOpt.isEmpty) {
+      log.error("Could not load model")
+      System.exit(-1)
+    }
+
+    val transformer = new Transformer(config, modelCfgName)
+    (modelOpt.get, transformer)
+  }
+
+  def evalRun(
+      sc: SparkContext,
+      config : Config, cfgKey : String,
+      isTraining: Example => Boolean = isTraining): Unit = {
+    val metrics = evalCompute(sc, config, cfgKey, isTraining)
+    metrics.foreach(x => log.info(x.toString))
+  }
+
+  def evalCompute(
+                   sc: SparkContext,
+                   config: Config,
+                   cfgKey: String,
+                   isTraining: Example => Boolean): Array[(String, Double)]  = {
+    val cfg = config.getConfig(cfgKey)
+    val modelCfgName = cfg.getString("model_config")
+    val modelName = cfg.getString("model_name")
+    val inputPattern = cfg.getString("input")
+    val subsample = cfg.getDouble("subsample")
+    val bins = cfg.getInt("bins")
+    val isProb = cfg.getBoolean("is_probability")
+    val isRegression = Try(cfg.getBoolean("is_regression")).getOrElse(false)
+    val isMulticlass = Try(cfg.getBoolean("is_multiclass")).getOrElse(false)
+    val metric = cfg.getString("metric_to_maximize")
+    val (model, transformer) = getModelAndTransform(config, modelCfgName, modelName)
+
+    val metrics = evalModelInternal(
+      sc,
+      transformer,
+      model,
+      inputPattern,
+      subsample,
+      bins,
+      isProb,
+      isRegression,
+      isMulticlass,
+      metric,
+      isTraining
+    )
+
+    metrics
+  }
+
+  def calibrateRun(
+                    sc: SparkContext,
+                    config: Config,
+                    isTraining: Example => Boolean = isTraining) = {
+    val plattsConfig = config.getConfig("calibrate_model")
+    val modelCfgName = plattsConfig.getString("model_config")
+    val modelName = plattsConfig.getString("model_name")
+
+    val (model, transformer) = getModelAndTransform(config, modelCfgName, modelName)
+    val input = plattsConfig.getString("input") // training_data_with_ds
+    // get calibration training data
+    val data = getExamples(sc, input)
+        .sample(false, plattsConfig.getDouble("subsample"))
+
+    val scoresAndLabel = EvalUtil.scoreExamples(sc, transformer, model, data, isTraining, LABEL)
+
+    // Use TRAIN data for train and HOLD data for eval
+    val calibrationTraining = scoresAndLabel
+      .filter(x => x._2.contains("TRAIN"))
+      .map(x => (x._1.toDouble, if(x._2 == "TRAIN_P") true else false))
+      .cache()
+
+    val calibrationHoldout = scoresAndLabel
+      .filter(x => x._2.contains("HOLD"))
+      // Create [score, label] Type: Array[(Double, Boolean)]
+      .map(x => (x._1.toDouble, if(x._2 == "HOLD_P") true else false))
+
+    val params = ScoreCalibrator.trainSGD(plattsConfig, calibrationTraining)
+
+    calibrationTraining.unpersist()
+    val offset = params(0)
+    val slope =  params(1)
+
+    // Evaluation
+    val errorTrainCalibrated =
+      evalCalibration(calibrationTraining, offset, slope, "")
+    val errorTrainNonCalibrated =
+      evalCalibration(calibrationTraining, 0, 1, "")
+    val errorHoldCalibrated =
+      evalCalibration(calibrationHoldout, offset, slope, "")
+    val errorHoldNonCalibrated = evalCalibration(calibrationHoldout, 0, 1, "")
+
+    log.info("Number of samples used for training: %d".format(calibrationTraining.count))
+    log.info("Training eval result: calibrated %f, non-calibrated %f".format(
+      errorTrainCalibrated, errorTrainNonCalibrated)
+    )
+    log.info("Holdout eval result: calibrated %f, non-calibrated %f".format(
+      errorHoldCalibrated, errorHoldNonCalibrated))
+    log.info("Calibration parameters: offset = %f slope = %f".format(offset, slope))
+
+    var success = true
+    if ((errorTrainNonCalibrated < errorTrainCalibrated) ||
+      (errorHoldNonCalibrated < errorHoldCalibrated)) {
+      log.error("Calibration is worse than Non-Calibration.")
+      success = false
+    }
+
+    if (success) {
+      // If calibration is successful, update offset and slope of the model
+      // otherwise, use the default offset = 0 and slope = 1 in the model
+      model.setOffset(offset)
+      model.setSlope(slope)
+    }
+
+    // Save the model with updated calibration parameters
+    try {
+      val output: String = plattsConfig.getString("calibrated_model_output")
+      val fileSystem = FileSystem.get(new java.net.URI(output), new Configuration())
+      val file = fileSystem.create(new Path(output), true)
+      val writer = new BufferedWriter(new OutputStreamWriter(file))
+      model.save(writer)
+      writer.close()
+      file.close()
+    } catch {
+      case _ : Throwable => log.error("Could not save model")
+    }
+  }
+
+  def modelRecordToString(x: ModelRecord) : String = {
+    if (x.weightVector != null && !x.weightVector.isEmpty) {
+      "%s\t%s\t%f\t%f\t%s".format(
+        x.featureFamily, x.featureName, x.minVal, x.maxVal, x.weightVector.toString)
+    } else {
+      "%s\t%s\t%f".format(x.featureFamily, x.featureName, x.featureWeight)
+    }
+  }
+
+  def dumpModelRun(sc: SparkContext, config: Config) = {
+    val cfg = config.getConfig("dump_model")
+    val modelName = cfg.getString("model_name")
+    val modelDump = cfg.getString("model_dump")
+    val model = sc
+      .textFile(modelName)
+      .map(Util.decodeModel)
+      .filter(x => x.featureName != null)
+      .map(modelRecordToString)
+    PipelineUtil.saveAndCommitAsTextFile(model, modelDump)
+  }
+
+  def dumpForestRun(sc : SparkContext, config: Config) = {
+    val cfg = config.getConfig("dump_forest")
+    val modelName = cfg.getString("model_name")
+    val modelDump = cfg.getString("model_dump")
+    val model = TrainingUtils.loadScoreModel(modelName).get
+
+    val forest = model.asInstanceOf[ForestModel]
+    val trees = forest.getTrees().asScala.toArray
+
+    val builder = new StringBuilder()
+    val count = trees.size
+    for (i <- 0 until count) {
+      val tree = trees(i)
+      builder ++= tree.toDot().replace("digraph g", "digraph tree_%d".format(i))
+    }
+
+    PipelineUtil.writeStringToFile(builder.toString, modelDump)
+  }
+
+  def dumpFullRankLinearRun(sc: SparkContext, config: Config) = {
+    val cfg = config.getConfig("dump_full_rank_linear_model")
+    val modelName = cfg.getString("model_name")
+    val modelDump = cfg.getString("model_dump")
+    val featuresPerLabel = cfg.getInt("features_per_label")
+    val model = TrainingUtils.loadScoreModel(modelName).get.asInstanceOf[FullRankLinearModel]
+
+    val builder = new StringBuilder()
+
+    model.getLabelDictionary.asScala.foreach(entry => {
+      val label = entry.getLabel
+      val count = entry.getCount
+      val index = model.getLabelToIndex.get(label)
+
+      val weights = model.getWeightVector.asScala.flatMap({
+        case (family, features) => features.asScala.map({
+          case (feature, fv) =>
+            Tuple3(family, feature, fv.getValues.apply(index))
+        })
+      }).toSeq
+
+      // Sort by weight, descending and take top featuresPerLabel
+      val sortedWeights = weights.sortBy(entry => -1.0 * entry._3).take(featuresPerLabel)
+
+      sortedWeights.foreach(weightTuple => {
+        builder ++= "%s\t%s\t%s\t%f\n".format(
+          label, weightTuple._1, weightTuple._2, weightTuple._3
+        )
+      })
+    })
+
+    PipelineUtil.writeStringToFile(builder.toString, modelDump)
+  }
+
+  def scoreTableRun(sc: SparkContext, config: Config) = {
+    val cfg = config.getConfig("score_table")
+    val query = cfg.getString("hive_query")
+    val output = cfg.getString("output")
+    val numShards = cfg.getInt("num_shards")
+    val modelCfgName = cfg.getString("model_config")
+    val modelName = cfg.getString("model_name")
+    val isMulticlass = Try(cfg.getBoolean("is_multiclass")).getOrElse(false)
+
+    val (model, transformer) = getModelAndTransform(config, modelCfgName, modelName)
+
+    val hc = new HiveContext(sc)
+    val hiveTraining = hc.sql(query)
+
+    val schema: Array[StructField] = hiveTraining.schema.fields.toArray
+    val lastIdx = schema.size - 1
+    if (!schema(lastIdx).name.equals("UNIQUE_ID")) {
+      log.error("Last row of the scoring table must be UNIQUE_ID")
+      System.exit(-1)
+    }
+    // What was the schema except for Unique ID
+    val origSchema = schema.dropRight(1)
+
+    val modelBC = sc.broadcast(model)
+    val transformerBC = sc.broadcast(transformer)
+
+    val examples = hiveTraining
+      // ID, example
+      .map(x => (x.getString(lastIdx), hiveTrainingToExample(x, origSchema, isMulticlass)))
+      .coalesce(numShards, true)
+
+    if (isMulticlass) {
+      examples.flatMap(x => {
+        scoreMulticlass(x._2, modelBC.value, transformerBC.value)
+          .map(result => {
+            "%s\t%s\t%f\t%f".format(x._1, result.getLabel, result.getScore, result.getProbability)
+          })
+      }).saveAsTextFile(output)
+    } else {
+      examples.map(x => (x._1, score(x._2, modelBC.value, transformerBC.value)))
+        .map(x => "%s\t%f\t%f".format(x._1, x._2._1, x._2._2))
+        .saveAsTextFile(output)
+    }
+  }
+
+  def debugScoreTableRun(sc : SparkContext, config: Config) = {
+    val cfg = config.getConfig("debug_score_table")
+    val query = cfg.getString("hive_query")
+    val modelCfgName = cfg.getString("model_config")
+    val modelName = cfg.getString("model_name")
+    val count = cfg.getInt("count")
+    val isMulticlass = Try(cfg.getBoolean("is_multiclass")).getOrElse(false)
+
+    val (model, transformer) = getModelAndTransform(config, modelCfgName, modelName)
+
+    val hc = new HiveContext(sc)
+    val hiveTraining = hc.sql(query)
+    val schema: Array[StructField] = hiveTraining.schema.fields.toArray
+    val lastIdx = schema.size - 1
+
+    if (!schema(lastIdx).name.equals("UNIQUE_ID")) {
+      log.error("Last row of the scoring table must be UNIQUE_ID")
+      System.exit(-1)
+    }
+
+    // What was the schema except for Unique ID
+    val origSchema = schema.dropRight(1)
+
+    val ex = hiveTraining
+      // ID, example
+      .map(x => (x.getString(lastIdx), hiveTrainingToExample(x, origSchema, isMulticlass)))
+      .take(count)
+
+    ex.foreach(ex => {
+      transformer.combineContextAndItems(ex._2)
+      val builder = new java.lang.StringBuilder()
+      val score = model.debugScoreItem(ex._2.example.get(0), builder)
+      builder.append("Debug score for %s\n".format(ex._1))
+      log.info(builder.toString)
+    })
+  }
+
+  def score(
+             example: Example,
+             model: AbstractModel,
+             transformer: Transformer) = {
+    transformer.combineContextAndItems(example)
+
+    val score = model.scoreItem(example.example.get(0))
+    val prob = model.scoreProbability(score)
+
+    (score, prob)
+  }
+
+  def scoreMulticlass(
+                       example: Example,
+                       model: AbstractModel,
+                       transformer: Transformer) = {
+    transformer.combineContextAndItems(example)
+
+    val multiclassResults = model.scoreItemMulticlass(example.example.get(0))
+    model.scoreToProbability(multiclassResults)
+
+    multiclassResults.asScala
+  }
+
+  private def evalModelInternal(
+                                 sc: SparkContext,
+                                 transformer: Transformer,
+                                 modelOpt: AbstractModel,
+                                 inputPattern: String,
+                                 subSample: Double,
+                                 bins: Int,
+                                 isProb: Boolean,
+                                 isRegression: Boolean,
+                                 isMulticlass: Boolean,
+                                 metric: String,
+                                 isTraining: Example => Boolean) : Array[(String, Double)] = {
+    val examples = sc.textFile(inputPattern)
+      .map(Util.decodeExample)
+      .sample(false, subSample)
+
+    val records = EvalUtil
+      .scoreExamplesForEvaluation(
+        sc,
+        transformer,
+        modelOpt,
+        examples,
+        LABEL,
+        isProb,
+        isMulticlass,
+        isTraining)
+      .cache()
+
+    // Find the best F1
+    val result = if (isRegression) {
+      Evaluation.evaluateRegression(records)
+    } else if (isMulticlass) {
+      Evaluation.evaluateMulticlassClassification(records)
+    } else {
+      Evaluation.evaluateBinaryClassification(records, bins, metric)
+    }
+
+    records.unpersist()
+    result
+  }
+
+  def logPrettyExample(ex : Example) = {
+    val fv = ex.example.get(0)
+    val builder = new StringBuilder()
+    builder ++= "\nString Features:"
+    if (fv.stringFeatures != null) {
+      fv.stringFeatures.asScala.foreach(x => {
+        builder ++= "FAMILY : " + x._1 + '\n'
+        x._2.asScala.foreach(y => {builder ++= "--> " + y + '\n'})
+      })
+    }
+    builder ++= "\nFloat Features:"
+    if (fv.floatFeatures != null) {
+      fv.floatFeatures.asScala.foreach(x =>  {
+        builder ++= "FAMILY : " + x._1 + '\n'
+        x._2.asScala.foreach(y => {builder ++= "--> " + y.toString + '\n'})
+      })
+    }
+    log.info(builder.toString)
+  }
+
+  def makeTraining(
+                    sc: SparkContext,
+                    query: String,
+                    isMulticlass: Boolean = false): RDD[Example] = {
+    val hc = new HiveContext(sc)
+    val hiveTraining = hc.sql(query)
+    val schema: Array[StructField] = hiveTraining.schema.fields.toArray
+    hiveTraining
+      .map(x => hiveTrainingToExample(x, schema, isMulticlass))
+  }
+
+  def isTraining(examples : Example) : Boolean = {
+    // Take the hash code mod 255 and keep the first 16 as holdout.
+    (examples.toString.hashCode & 0xFF) > 16
+  }
+
+  def isHoldout(examples : Example) : Boolean = {
+    // Take the hash code mod 255 and keep the first 16 as holdout.
+    (examples.toString.hashCode & 0xFF) <= 16
+  }
+
+  def getExamples(sc : SparkContext, inputPattern : String) : RDD[Example] = {
+    val examples : RDD[Example] = sc
+      .textFile(inputPattern)
+      .map(Util.decodeExample)
+    examples
+  }
+
+  def evalCalibration(input: RDD[(Double, Boolean)], offset : Double, slope : Double, output : String = ""): Double = {
+    val scoreLabelProb = input
+      // score, label, probability
+      .map{x => (x._1, x._2, 1.0 / (1.0 + math.exp(-offset - slope * x._1)))}
+    if (output.size > 0){
+      // save the (score, label, probability) tuple for offline evaluation
+      PipelineUtil
+        .saveAndCommitAsTextFile(scoreLabelProb.map(x => "%f,%s,%f".format(x._1, x._2, x._3)), output)
+    }
+    val probLabel = scoreLabelProb.map(x => (x._3, x._2)) // RDD[(probability, label)]
+    val error = computeCalibrationError(probLabel)
+    error
+  }
+
+  def computeCalibrationError(input: RDD[(Double, Boolean)]): Double = {
+    // input: RDD[(probability, label)], output: calibration error
+    val bucketSize = 0.01 // bucket-> (positiveCount, negativeCount)
+    val labelsAndPreds = input
+        .map{x => {
+          val label = x._2
+          val probability = x._1
+          val bucket = (probability / bucketSize).toLong
+          if (label) {
+            (bucket, (1, 0))
+          } else {
+            (bucket, (0, 1))
+          }}}
+        .reduceByKey((a, b) => (a._1 + b._1, a._2 + b._2))
+
+    val err = labelsAndPreds
+      .map(x => x._2._1.toDouble / (x._2._1 + x._2._2) - x._1 * bucketSize)
+      .map(x => x * x)
+      .collect()
+
+    Math.sqrt(err.sum / err.length.toDouble)
+  }
+
+  def paramSearch(sc : SparkContext, config : Config) = {
+    val cfg = config.getConfig("param_search")
+    val strategy = cfg.getString("search_strategy")
+    val paramCfg = cfg.getConfigList("param_to_tune")
+    val paramNames: Array[String] = Try(paramCfg.asScala.map(_.getString("name")).toArray)
+      .getOrElse(Array[String]())
+    val maxRound: Int = cfg.getInt("max_round")
+    val initParamVals: Array[Array[Double]] = Try(
+      paramCfg.asScala.map(_.getDoubleList("val").asScala
+        .map(_.doubleValue()).toArray).toArray).getOrElse(Array[Array[Double]]())
+
+    if (paramNames.size != initParamVals.size) {
+      log.error("incomplete parameter info")
+    }
+
+    val paramVals: Array[Array[Double]] = strategy match {
+      // TODO (hui_duan) can be extended to adopt more strategies
+      case "guided" => initParamVals
+      case "grid" => initParamVals.map((x:Array[Double]) => {
+        val low = if (x.size > 0) x(0) else 0
+        val high = if (x.size > 1) x(1) else 1
+        val count = max(ceil(pow(maxRound,1d / initParamVals.size)).toInt, 2)
+        val step = (high - low) / (count - 1)
+        (0 until count).map(_ * step + low).toArray
+      })
+      case _ => {
+        log.error("Unknown strategy " + strategy)
+        Array[Array[Double]]()
+      }
+    }
+
+    val paramSets : Array[Array[Double]] =
+      paramVals.foldLeft(Array[Array[Double]](Array[Double]()))(
+        (collector: Array[Array[Double]], ar: Array[Double]) => for (el <- collector; x <- ar)
+          yield el :+ x)
+    val metrics: Array[(String, Double)] = (if (maxRound >= paramSets.size) paramSets else
+      Random.shuffle(paramSets.toList).take(maxRound).toArray).map(
+      x => trainEvalForParamSearch(sc, paramNames.zip(x), config))
+    val bestMetric = metrics.reduceLeft((x, y) => if (x._2 > y._2) x else y)
+    val bestModelOutput = Try(cfg.getString("best_model_output")).getOrElse("")
+
+    if (bestModelOutput.length > 0) {
+      PipelineUtil.copyFiles(bestMetric._1, bestModelOutput)
+    }
+
+    val recordStarter = "----best trial: " + bestMetric._1 + " : " + bestMetric._2
+    val record = metrics.foldLeft(recordStarter)((str: String, x: (String, Double)) =>
+      str + "\n----record: " + x._1 + " : " + x._2)
+
+    val outputPath = Try(cfg.getString("output")).getOrElse("")
+    if (outputPath.length > 0) {
+      PipelineUtil.writeStringToFile(record, outputPath)
+    }
+
+    log.info(record)
+  }
+
+  def trainEvalForParamSearch(
+                               sc: SparkContext,
+                               paramSet: Array[(String,Double)],
+                               config: Config) : (String, Double) = {
+    val cfg = config.getConfig("param_search")
+    val modelConfig = cfg.getString("model_config")
+    val metricName: String = cfg.getString("metric_to_maximize")
+    val paramStr = paramSet.map(x => s"${x._1}_${x._2}").mkString("__")
+    val modelPrefix = cfg.getString("model_name_prefix")
+    val modelOutput = modelPrefix.concat("__").concat(paramStr).concat(".model")
+    // revise train_model.model_config, ${modelConfig}.model_output (for training)
+    val baseCfg = config.withValue("train_model.model_config",
+      ConfigValueFactory.fromAnyRef(modelConfig))
+      .withValue(modelConfig.concat(".").concat("model_output"),
+        ConfigValueFactory.fromAnyRef(modelOutput))
+      // revise eval_model.model_config, eval_model.metric_to_maximize,
+      // eval_model.model_name (for eval)
+      .withValue("eval_model.model_config", ConfigValueFactory.fromAnyRef(modelConfig))
+      .withValue("eval_model.metric_to_maximize", ConfigValueFactory.fromAnyRef(metricName))
+      .withValue("eval_model.model_name", ConfigValueFactory.fromAnyRef(modelOutput))
+    // revise ${modelConfig}.${param} for parameter setting
+    val finalCfg = paramSet.foldLeft(baseCfg)((
+                                                base: Config, param: (String, Double)) => base.withValue(
+      modelConfig.concat(".").concat(param._1), ConfigValueFactory.fromAnyRef(param._2)))
+    trainingRun(sc, finalCfg)
+    val evalResults = evalCompute(sc, finalCfg, "eval_model", isTraining)
+
+    (modelOutput, evalResults.find(_._1.equals(metricName)).getOrElse(("", -1d))._2)
+  }
+
+  def hiveTrainingToExample(
+                             row: Row,
+                             schema: Array[StructField],
+                             isMulticlass: Boolean = false): Example = {
+    val example = new Example()
+    val featureVector = new FeatureVector()
+    example.addToExample(featureVector)
+    val stringFeatures = new java.util.HashMap[String, java.util.Set[java.lang.String]]()
+    featureVector.setStringFeatures(stringFeatures)
+    val floatFeatures = new java.util.HashMap[String, java.util.Map[
+      java.lang.String, java.lang.Double]]()
+    featureVector.setFloatFeatures(floatFeatures)
+
+    val bias = new java.util.HashSet[java.lang.String]()
+    val missing = new java.util.HashSet[java.lang.String]()
+    bias.add("B")
+
+    stringFeatures.put("BIAS", bias)
+    stringFeatures.put("MISS", missing)
+
+    //val genericFloat = new java.util.HashMap[java.lang.String, java.lang.Double]()
+    for (i <- 0 until schema.length) {
+      val rowSchema = schema(i)
+      val name = rowSchema.name
+      val tokens = rowSchema.name.split("_")
+      if (tokens.size != 2) {
+        if (tokens(0) != LABEL) {
+          log.error("Column name not in FAMILY_NAME format or is not LABEL! %s".format(name))
+          System.exit(-1)
+        }
+      }
+      val featureFamily = tokens(0)
+      val featureName = if (tokens.size > 1) tokens(1) else ""
+
+      if (row.isNullAt(i)) {
+        missing.add(name)
+      } else {
+        rowSchema.dataType match {
+          case StringType =>
+            val str = row.getString(i)
+
+            if (isMulticlass && featureFamily == LABEL) {
+              str.split(",").foreach(classStr => {
+                val labelTokens = classStr.split(":").toIndexedSeq
+
+                if (labelTokens.size != 2) {
+                  log.error("Multiclass LABEL \"%s\" not in format [label1]:[weight1],...!"
+                    .format(str))
+                  System.exit(-1)
+                }
+
+                val feature = Util.getOrCreateFloatFeature(featureFamily, floatFeatures)
+
+                feature.put(labelTokens(0), labelTokens(1).toDouble)
+              })
+            } else {
+              val feature = Util.getOrCreateStringFeature(featureFamily, stringFeatures)
+
+              if (featureName == "RAW") {
+                // In RAW case, don't append feature name
+                feature.add(str)
+              } else {
+                feature.add(featureName + ':' + str)
+              }
+            }
+
+          case LongType =>
+            val lng = row.getLong(i)
+            val feature = Util.getOrCreateFloatFeature(featureFamily, floatFeatures)
+            feature.put(featureName, lng.toDouble)
+
+          case IntegerType =>
+            val int = row.getInt(i)
+            val feature = Util.getOrCreateFloatFeature(featureFamily, floatFeatures)
+            feature.put(featureName, int.toDouble)
+
+          case FloatType =>
+            val dbl = row.getFloat(i)
+            val feature = Util.getOrCreateFloatFeature(featureFamily, floatFeatures)
+            feature.put(featureName, dbl.toDouble)
+
+          case DoubleType =>
+            val dbl = row.getDouble(i)
+            val feature = Util.getOrCreateFloatFeature(featureFamily, floatFeatures)
+            feature.put(featureName, dbl.toDouble)
+
+          case BooleanType =>
+            val bool = row.getBoolean(i)
+            val feature = Util.getOrCreateStringFeature(featureFamily, stringFeatures)
+            val str = if (bool) "T" else "F"
+            feature.add(featureName + ':' + str)
+        }
+      }
+    }
+
+    example
+  }
+}

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/GenericPipeline.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/GenericPipeline.scala
@@ -643,9 +643,9 @@ object GenericPipeline {
   }
 
   def hiveTrainingToExample(
-                             row: Row,
-                             schema: Array[StructField],
-                             isMulticlass: Boolean = false): Example = {
+      row: Row,
+      schema: Array[StructField],
+      isMulticlass: Boolean = false): Example = {
     val example = new Example()
     val featureVector = new FeatureVector()
     example.addToExample(featureVector)
@@ -669,12 +669,14 @@ object GenericPipeline {
       val rowSchema = schema(i)
       val name = rowSchema.name
       val tokens = rowSchema.name.split("_")
+
       if (tokens.size != 2) {
         if (tokens(0) != LABEL) {
           log.error("Column name not in FAMILY_NAME format or is not LABEL! %s".format(name))
           System.exit(-1)
         }
       }
+
       val featureFamily = tokens(0)
       val featureName = if (tokens.size > 1) tokens(1) else ""
 

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/JobRunner.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/JobRunner.scala
@@ -6,11 +6,14 @@ import com.typesafe.config.ConfigFactory
 
 import scala.collection.JavaConversions._
 
+/*
+ * Entry-point for running the generic pipeline.
+ */
 object JobRunner {
   def main(args: Array[String]): Unit = {
     val log: Logger = LoggerFactory.getLogger("Job.Runner")
 
-  if (args.length < 1) {
+    if (args.length < 1) {
       log.error("Usage: Job.Runner config_name job1,job2...")
       System.exit(-1)
     }
@@ -35,7 +38,7 @@ object JobRunner {
     val sc = new SparkContext(conf)
 
     for (job <- jobs) {
-      log.info("Running " + job)
+      log.info("Running job: %s".format(job))
       try {
         job match {
           case "GenericMakeExamples" => GenericPipeline
@@ -67,14 +70,13 @@ object JobRunner {
           case _ => log.error("Unknown job " + job)
         }
       } catch {
-        case e : Exception => log.error("Exception on job %s : %s".format(job, e.toString))
+        case e : Exception => log.error("Exception on job %s: %s".format(job, e.toString))
           System.exit(-1)
       }
     }
 
     log.info("Job(s) finished successfully")
     sc.stop()
-
     System.exit(0)
   }
 }

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/JobRunner.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/JobRunner.scala
@@ -1,0 +1,80 @@
+package com.airbnb.aerosolve.training.pipeline
+
+import org.apache.spark.{SparkContext, SparkConf}
+import org.slf4j.{LoggerFactory, Logger}
+import com.typesafe.config.ConfigFactory
+
+import scala.collection.JavaConversions._
+
+object JobRunner {
+  def main(args: Array[String]): Unit = {
+    val log: Logger = LoggerFactory.getLogger("Job.Runner")
+
+  if (args.length < 1) {
+      log.error("Usage: Job.Runner config_name job1,job2...")
+      System.exit(-1)
+    }
+
+    log.info("Loading config from " + args(0))
+
+    val config = ConfigFactory.load(args(0))
+
+    val jobs : Seq[String] = if (args.length == 1) {
+      config.getStringList("jobs")
+    } else {
+      args(1).split(',')
+    }
+
+    val name = try {
+      config.getString("job_name")
+    } catch {
+      case e : Exception => "JobRunner"
+    }
+
+    val conf = new SparkConf().setAppName(name)
+    val sc = new SparkContext(conf)
+
+    for (job <- jobs) {
+      log.info("Running " + job)
+      try {
+        job match {
+          case "GenericMakeExamples" => GenericPipeline
+            .makeTrainingRun(sc, config)
+          case "GenericDebugExamples" => GenericPipeline
+            .debugExampleRun(sc, config)
+          case "GenericDebugTransforms" => GenericPipeline
+            .debugTransformsRun(sc, config)
+          case "GenericDebugScores" => GenericPipeline
+            .debugScoreTableRun(sc, config)
+          case "GenericTrainModel" => GenericPipeline
+            .trainingRun(sc, config)
+          case "GenericEvalModel" => GenericPipeline
+            .evalRun(sc, config, "eval_model")
+          case "GenericCalibrateModel" => GenericPipeline
+            .calibrateRun(sc, config)
+          case "GenericEvalModelCalibrated" => GenericPipeline
+            .evalRun(sc, config, "eval_model_calibrated")
+          case "GenericDumpModel" => GenericPipeline
+            .dumpModelRun(sc, config)
+          case "GenericDumpForest" => GenericPipeline
+            .dumpForestRun(sc, config)
+          case "GenericDumpFullRankLinearModel" => GenericPipeline
+            .dumpFullRankLinearRun(sc, config)
+          case "GenericScoreTable" => GenericPipeline
+            .scoreTableRun(sc, config)
+          case "GenericParamSearch" => GenericPipeline
+            .paramSearch(sc, config)
+          case _ => log.error("Unknown job " + job)
+        }
+      } catch {
+        case e : Exception => log.error("Exception on job %s : %s".format(job, e.toString))
+          System.exit(-1)
+      }
+    }
+
+    log.info("Job(s) finished successfully")
+    sc.stop()
+
+    System.exit(0)
+  }
+}

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/PipelineUtil.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/PipelineUtil.scala
@@ -1,0 +1,278 @@
+package com.airbnb.aerosolve.training.pipeline
+
+import java.io.{BufferedReader, BufferedWriter, InputStreamReader, OutputStreamWriter}
+import java.net.URI
+import java.util.GregorianCalendar
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, FileUtil, Path}
+import org.apache.hadoop.io.compress.GzipCodec
+import org.apache.spark.SparkContext._
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.hive.HiveContext
+import org.apache.spark.{Accumulator, SparkContext}
+import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
+import org.joda.time.{DateTime, Days}
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
+
+object PipelineUtil {
+  val log: Logger = LoggerFactory.getLogger("PipelineUtil")
+  val hadoopConfiguration = new Configuration()
+
+  def saveAndCommitAsTextFile[U](rdd: RDD[U], dest: String): Unit = {
+    saveAndCommitAsTextFile(rdd, dest, 0)
+  }
+
+  def saveAndCommitAsTextFile[U](rdd: RDD[U], dest: String, overwrite: Boolean): Unit = {
+    saveAndCommitAsTextFile(rdd, dest, 0, overwrite)
+  }
+
+  def saveAndCommitAsTextFile[U](rdd: RDD[U], dest: String, partition: Int,
+                                 overwrite: Boolean = false): Unit = {
+    log.info("Saving data to %s".format(dest))
+
+    val hfs = FileSystem.get(
+      new java.net.URI(dest), new Configuration())
+
+    val tmpPath = new Path(dest + ".tmp")
+    val destPath = new Path(dest)
+
+    if (!hfs.exists(destPath) || overwrite) {
+      try {
+        if (hfs.exists(tmpPath)) {
+          hfs.delete(tmpPath, true)
+          log.info("deleted old tmp directory: " + tmpPath)
+        }
+        if (partition > 0) {
+          // shuffle it to prevent imbalance output, which slows down the whole job.
+          rdd.coalesce(partition, true)
+            .saveAsTextFile(dest + ".tmp", classOf[GzipCodec])
+        } else {
+          rdd.saveAsTextFile(dest + ".tmp", classOf[GzipCodec])
+        }
+        if (hfs.exists(destPath)) {
+          hfs.delete(destPath, true)
+          log.info("deleted old directory: " + destPath)
+        }
+        log.info("committing " + dest)
+        hfs.rename(tmpPath, destPath)
+        log.info("committed " + dest)
+      } catch {
+        case e: Exception => {
+          log.error("exception during save: ", e)
+          log.info("deleting failed data for " + dest + ".tmp")
+          hfs.delete(tmpPath, true)
+          log.info("deleted " + dest + ".tmp")
+          throw e
+        }
+      }
+    } else {
+      log.info("data already exists for " + dest)
+    }
+  }
+
+  def getLastPartition(hc: HiveContext, table: String): String = {
+    val query = "SHOW PARTITIONS %s".format(table)
+    val partitions = hc.sql(query).collect.map(_.getString(0)).sorted
+    partitions
+      .last /* e.g. ds=2015-01-01 */
+      .split("=")
+      .apply(1)
+  }
+
+  def ts(year: Int, month: Int, day: Int) : Long = {
+    val date = new GregorianCalendar(year, month - 1, day)
+    (date.getTimeInMillis()/1000)/86400
+  }
+
+  def ts(ds: String): Long  = {
+    ts(ds.substring(0,4).toInt, ds.substring(5,7).toInt, ds.substring(8,10).toInt)
+  }
+
+  // Returns a date iterator from start to end date.
+  def dateRange(from: String, to: String): Seq[DateTime] = {
+    val formatter : DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
+    val startDate = formatter.parseDateTime(from)
+    val endDate = formatter.parseDateTime(to)
+    val numberOfDays = Days.daysBetween(startDate, endDate).getDays()
+
+    for(n <- 0 to numberOfDays) yield startDate.plusDays(n)
+  }
+
+  // Returns a date iterator from today - from to today = to
+  def dateRangeFromToday(from : Int, to : Int): Seq[DateTime] = {
+    val now = new DateTime()
+    val today = now.toLocalDate()
+
+    val startDate = now.plusDays(from)
+    val endDate = now.plusDays(to)
+    val numberOfDays = Days.daysBetween(startDate, endDate).getDays()
+
+    for (n <- 0 to numberOfDays) yield startDate.plusDays(n)
+  }
+
+  def dateDiff(from: String, to: String): Int = {
+    val formatter : DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
+    val startDate = formatter.parseDateTime(from)
+    val endDate = formatter.parseDateTime(to)
+    val numberOfDays = Days.daysBetween(startDate, endDate).getDays()
+    numberOfDays
+  }
+
+  def dateMinus(date: String, days: Int): String = {
+    // return a string for the date which is 'days' earlier than 'date'
+    // e.g. dateMinus("2015-06-01", 1) returns "2015-05-31"
+    val formatter : DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
+    val dateFmt = formatter.parseDateTime(date)
+    formatter.print(dateFmt.minusDays(days))
+  }
+
+  def datePlus(date: String, days: Int): String = {
+    // return a string for the date which is 'days' earlier than 'date'
+    // e.g. datePlus("2015-06-01", 1) returns "2015-06-02"
+    dateMinus(date, -days)
+  }
+
+  // Returns a date range starting numDays before and ending at the desired date
+  def dateRangeUntil(to: String, numDays: Int): Seq[DateTime] = {
+    val formatter : DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
+    val endDate = formatter.parseDateTime(to)
+
+    for(n <- numDays to 0 by -1) yield endDate.minusDays(n)
+  }
+
+  def dayOfYear(date: String): Int = {
+    // return day of year of a date
+    // e.g. dayOfYear("2015-01-01") returns 1
+    val formatter : DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
+    val dateFmt = formatter.parseDateTime(date)
+    dateFmt.dayOfYear().get()
+  }
+
+  def dayOfWeek(date: String): Int = {
+    // return day of week of a date
+    // e.g. if date is Monday, returns 1,
+    // if date is Sunday, returns 0 (this is to be consistent with the pricing training data)
+    val formatter : DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
+    val dateFmt = formatter.parseDateTime(date)
+    dateFmt.dayOfWeek().get() % 7
+  }
+
+  def deleteHDFSFiles(path: String) = {
+    log.info("Deleting files at " + path)
+    val hfs = FileSystem.get(new Configuration())
+    hfs.delete(new Path(path), true)
+    log.info("Deleted.")
+  }
+
+  def rowIsNotNull(row : Row, count : Int) : Boolean = {
+    for (i <- 0 until count) {
+      if (row.isNullAt(i)) return false
+    }
+    return true
+  }
+
+  // Create a pair of spark accumulators that track (success, failure) counts.
+  def addStatusAccumulators(sc: SparkContext,
+                            accName: String,
+                            accumulators: mutable.Map[String, Accumulator[Int]]): Unit = {
+    accumulators.put(accName + ".success", sc.accumulator(0, accName + ".success"))
+    accumulators.put(accName + ".failure", sc.accumulator(0, accName + ".failure"))
+  }
+
+
+  def countAllFailureCounters(accumulators: mutable.Map[String, Accumulator[Int]]): Long = {
+    var failureCount = 0
+    for ( (name, accumulator) <- accumulators) {
+      log.info("- Accumulator {} : {}", name, accumulator.value )
+      if (name.endsWith(".failure")) {
+        failureCount += accumulator.value
+      }
+    }
+    failureCount
+  }
+
+  def validateSuccessCounters(accumulators: mutable.Map[String, Accumulator[Int]],
+                              minSuccess: Int): Boolean = {
+    for ( (name, accumulator) <- accumulators) {
+      if (name.endsWith(".success") && accumulator.value < minSuccess) {
+        log.error("Failed counter: {} = {} < {}", name, accumulator.value.toString, minSuccess.toString)
+        return false
+      }
+    }
+    true
+  }
+
+  // TODO(kim): cleanup, write to hdfs directly instead of via SparkContext.
+  def saveCountersAsTextFile(accumulators: mutable.Map[String, Accumulator[Int]],
+                             sc: SparkContext,
+                             hdfsFilePath: String): Unit = {
+    var summary = Array("Summarizing counters:")
+
+    for ( (name, accumulator) <- accumulators) {
+      val logLine = "- %s = %d".format(name, accumulator.value )
+      summary :+= logLine
+      log.info(logLine)
+    }
+
+    saveAndCommitAsTextFile(sc.parallelize(summary), hdfsFilePath, 1, true)
+  }
+
+  def writeStringToFile(str: String, output: String) = {
+    val fs = FileSystem.get(new URI(output), hadoopConfiguration)
+    val path = new Path(output)
+    val stream = fs.create(path, true)
+    val writer = new BufferedWriter(new OutputStreamWriter(stream))
+    writer.write(str)
+    writer.close()
+  }
+
+  def readStringFromFile(inputFile : String): String = {
+    val fs = FileSystem.get(new URI(inputFile), hadoopConfiguration)
+    val path = new Path(inputFile)
+    val stream = fs.open(path)
+    val reader = new BufferedReader(new InputStreamReader(stream))
+    val str = Stream.continually(reader.readLine()).takeWhile(_ != null).mkString("\n")
+    str
+  }
+
+  def averageByKey[U:ClassTag](input: RDD[(U, Double)]) : RDD[(U, Double)] = {
+    input
+      .mapValues(value => (value, 1.0))
+      .reduceByKey((x, y) => (x._1 + y._1, x._2 + y._2))
+      .mapValues(x => x._1 / x._2)
+  }
+
+  def copyFiles(srcPath: String, destPath: String, deleteSource: Boolean = false) = {
+    val src = new Path(srcPath)
+    val dest = new Path(destPath)
+    val fsConfig = new Configuration()
+    val fs = FileSystem.get(new java.net.URI(destPath), fsConfig)
+    log.info("Copying successful from " + src + " to " + dest)
+    try {
+      FileUtil.copy(fs, src, fs, dest, deleteSource, fsConfig)
+    } catch {
+      case e: Exception => {
+        log.info("Copy failed " + dest)
+        System.exit(-1)
+      }
+    }
+    log.info("Copy done.")
+  }
+
+  def getAllDirOrFiles(dirPath: String) : Array[String] = {
+    // get all files under a directory
+    val fsConfig = new Configuration()
+    val fs = FileSystem.get(new java.net.URI(dirPath), fsConfig)
+    val allFiles = fs.listStatus(new Path(dirPath))
+    val out = new ArrayBuffer[String]()
+    allFiles.foreach(f =>
+      out.append(f.getPath.getName)
+    )
+    out.toArray
+  }
+}

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/PipelineUtil.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/PipelineUtil.scala
@@ -2,23 +2,16 @@ package com.airbnb.aerosolve.training.pipeline
 
 import java.io.{BufferedReader, BufferedWriter, InputStreamReader, OutputStreamWriter}
 import java.net.URI
-import java.util.GregorianCalendar
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, FileUtil, Path}
 import org.apache.hadoop.io.compress.GzipCodec
-import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.hive.HiveContext
-import org.apache.spark.{Accumulator, SparkContext}
-import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
-import org.joda.time.{DateTime, Days}
 import org.slf4j.{Logger, LoggerFactory}
 
-import scala.collection.mutable
-import scala.collection.mutable.ArrayBuffer
-import scala.reflect.ClassTag
-
+/*
+ * Miscellaneous utilities
+ */
 object PipelineUtil {
   val log: Logger = LoggerFactory.getLogger("PipelineUtil")
   val hadoopConfiguration = new Configuration()
@@ -31,8 +24,11 @@ object PipelineUtil {
     saveAndCommitAsTextFile(rdd, dest, 0, overwrite)
   }
 
-  def saveAndCommitAsTextFile[U](rdd: RDD[U], dest: String, partition: Int,
-                                 overwrite: Boolean = false): Unit = {
+  def saveAndCommitAsTextFile[U](
+      rdd: RDD[U],
+      dest: String,
+      partition: Int,
+      overwrite: Boolean = false): Unit = {
     log.info("Saving data to %s".format(dest))
 
     val hfs = FileSystem.get(
@@ -75,153 +71,6 @@ object PipelineUtil {
     }
   }
 
-  def getLastPartition(hc: HiveContext, table: String): String = {
-    val query = "SHOW PARTITIONS %s".format(table)
-    val partitions = hc.sql(query).collect.map(_.getString(0)).sorted
-    partitions
-      .last /* e.g. ds=2015-01-01 */
-      .split("=")
-      .apply(1)
-  }
-
-  def ts(year: Int, month: Int, day: Int) : Long = {
-    val date = new GregorianCalendar(year, month - 1, day)
-    (date.getTimeInMillis()/1000)/86400
-  }
-
-  def ts(ds: String): Long  = {
-    ts(ds.substring(0,4).toInt, ds.substring(5,7).toInt, ds.substring(8,10).toInt)
-  }
-
-  // Returns a date iterator from start to end date.
-  def dateRange(from: String, to: String): Seq[DateTime] = {
-    val formatter : DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
-    val startDate = formatter.parseDateTime(from)
-    val endDate = formatter.parseDateTime(to)
-    val numberOfDays = Days.daysBetween(startDate, endDate).getDays()
-
-    for(n <- 0 to numberOfDays) yield startDate.plusDays(n)
-  }
-
-  // Returns a date iterator from today - from to today = to
-  def dateRangeFromToday(from : Int, to : Int): Seq[DateTime] = {
-    val now = new DateTime()
-    val today = now.toLocalDate()
-
-    val startDate = now.plusDays(from)
-    val endDate = now.plusDays(to)
-    val numberOfDays = Days.daysBetween(startDate, endDate).getDays()
-
-    for (n <- 0 to numberOfDays) yield startDate.plusDays(n)
-  }
-
-  def dateDiff(from: String, to: String): Int = {
-    val formatter : DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
-    val startDate = formatter.parseDateTime(from)
-    val endDate = formatter.parseDateTime(to)
-    val numberOfDays = Days.daysBetween(startDate, endDate).getDays()
-    numberOfDays
-  }
-
-  def dateMinus(date: String, days: Int): String = {
-    // return a string for the date which is 'days' earlier than 'date'
-    // e.g. dateMinus("2015-06-01", 1) returns "2015-05-31"
-    val formatter : DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
-    val dateFmt = formatter.parseDateTime(date)
-    formatter.print(dateFmt.minusDays(days))
-  }
-
-  def datePlus(date: String, days: Int): String = {
-    // return a string for the date which is 'days' earlier than 'date'
-    // e.g. datePlus("2015-06-01", 1) returns "2015-06-02"
-    dateMinus(date, -days)
-  }
-
-  // Returns a date range starting numDays before and ending at the desired date
-  def dateRangeUntil(to: String, numDays: Int): Seq[DateTime] = {
-    val formatter : DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
-    val endDate = formatter.parseDateTime(to)
-
-    for(n <- numDays to 0 by -1) yield endDate.minusDays(n)
-  }
-
-  def dayOfYear(date: String): Int = {
-    // return day of year of a date
-    // e.g. dayOfYear("2015-01-01") returns 1
-    val formatter : DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
-    val dateFmt = formatter.parseDateTime(date)
-    dateFmt.dayOfYear().get()
-  }
-
-  def dayOfWeek(date: String): Int = {
-    // return day of week of a date
-    // e.g. if date is Monday, returns 1,
-    // if date is Sunday, returns 0 (this is to be consistent with the pricing training data)
-    val formatter : DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
-    val dateFmt = formatter.parseDateTime(date)
-    dateFmt.dayOfWeek().get() % 7
-  }
-
-  def deleteHDFSFiles(path: String) = {
-    log.info("Deleting files at " + path)
-    val hfs = FileSystem.get(new Configuration())
-    hfs.delete(new Path(path), true)
-    log.info("Deleted.")
-  }
-
-  def rowIsNotNull(row : Row, count : Int) : Boolean = {
-    for (i <- 0 until count) {
-      if (row.isNullAt(i)) return false
-    }
-    return true
-  }
-
-  // Create a pair of spark accumulators that track (success, failure) counts.
-  def addStatusAccumulators(sc: SparkContext,
-                            accName: String,
-                            accumulators: mutable.Map[String, Accumulator[Int]]): Unit = {
-    accumulators.put(accName + ".success", sc.accumulator(0, accName + ".success"))
-    accumulators.put(accName + ".failure", sc.accumulator(0, accName + ".failure"))
-  }
-
-
-  def countAllFailureCounters(accumulators: mutable.Map[String, Accumulator[Int]]): Long = {
-    var failureCount = 0
-    for ( (name, accumulator) <- accumulators) {
-      log.info("- Accumulator {} : {}", name, accumulator.value )
-      if (name.endsWith(".failure")) {
-        failureCount += accumulator.value
-      }
-    }
-    failureCount
-  }
-
-  def validateSuccessCounters(accumulators: mutable.Map[String, Accumulator[Int]],
-                              minSuccess: Int): Boolean = {
-    for ( (name, accumulator) <- accumulators) {
-      if (name.endsWith(".success") && accumulator.value < minSuccess) {
-        log.error("Failed counter: {} = {} < {}", name, accumulator.value.toString, minSuccess.toString)
-        return false
-      }
-    }
-    true
-  }
-
-  // TODO(kim): cleanup, write to hdfs directly instead of via SparkContext.
-  def saveCountersAsTextFile(accumulators: mutable.Map[String, Accumulator[Int]],
-                             sc: SparkContext,
-                             hdfsFilePath: String): Unit = {
-    var summary = Array("Summarizing counters:")
-
-    for ( (name, accumulator) <- accumulators) {
-      val logLine = "- %s = %d".format(name, accumulator.value )
-      summary :+= logLine
-      log.info(logLine)
-    }
-
-    saveAndCommitAsTextFile(sc.parallelize(summary), hdfsFilePath, 1, true)
-  }
-
   def writeStringToFile(str: String, output: String) = {
     val fs = FileSystem.get(new URI(output), hadoopConfiguration)
     val path = new Path(output)
@@ -240,13 +89,6 @@ object PipelineUtil {
     str
   }
 
-  def averageByKey[U:ClassTag](input: RDD[(U, Double)]) : RDD[(U, Double)] = {
-    input
-      .mapValues(value => (value, 1.0))
-      .reduceByKey((x, y) => (x._1 + y._1, x._2 + y._2))
-      .mapValues(x => x._1 / x._2)
-  }
-
   def copyFiles(srcPath: String, destPath: String, deleteSource: Boolean = false) = {
     val src = new Path(srcPath)
     val dest = new Path(destPath)
@@ -262,17 +104,5 @@ object PipelineUtil {
       }
     }
     log.info("Copy done.")
-  }
-
-  def getAllDirOrFiles(dirPath: String) : Array[String] = {
-    // get all files under a directory
-    val fsConfig = new Configuration()
-    val fs = FileSystem.get(new java.net.URI(dirPath), fsConfig)
-    val allFiles = fs.listStatus(new Path(dirPath))
-    val out = new ArrayBuffer[String]()
-    allFiles.foreach(f =>
-      out.append(f.getPath.getName)
-    )
-    out.toArray
   }
 }

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/PipelineUtil.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/PipelineUtil.scala
@@ -10,7 +10,7 @@ import org.apache.spark.rdd.RDD
 import org.slf4j.{Logger, LoggerFactory}
 
 /*
- * Miscellaneous utilities
+ * Miscellaneous utilities for pipeline file system access.
  */
 object PipelineUtil {
   val log: Logger = LoggerFactory.getLogger("PipelineUtil")

--- a/training/src/test/scala/com/airbnb/aerosolve/training/pipeline/EvalUtilTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/pipeline/EvalUtilTest.scala
@@ -1,0 +1,230 @@
+package com.airbnb.aerosolve.training.pipeline
+
+import com.airbnb.aerosolve.core.{FeatureVector, Example, LabelDictionaryEntry}
+import com.airbnb.aerosolve.core.models.{LinearModel, FullRankLinearModel}
+import com.airbnb.aerosolve.core.transforms.Transformer
+import com.airbnb.aerosolve.core.util.FloatVector
+import com.google.common.collect.{ImmutableMap, ImmutableSet}
+import com.typesafe.config.ConfigFactory
+import org.junit.Assert._
+import org.junit.Test
+
+class EvalUtilTest {
+  val transformer = {
+    val config = """
+       |identity_transform {
+       |  transform : list
+       |  transforms : [ ]
+       |}
+       |
+       |model_transforms {
+       |  context_transform : identity_transform
+       |  item_transform : identity_transform
+       |  combined_transform : identity_transform
+       |}
+     """.stripMargin
+
+    new Transformer(ConfigFactory.parseString(config), "model_transforms")
+  }
+
+  // Simple full rank linear model with 2 label classes and 2 features
+  val fullRankLinearModel = {
+    val model = new FullRankLinearModel()
+
+    model.setLabelToIndex(ImmutableMap.of("label1", 0, "label2", 1))
+
+    val labelDictEntry1 = new LabelDictionaryEntry()
+    labelDictEntry1.setLabel("label1")
+    labelDictEntry1.setCount(50)
+
+    val labelDictEntry2 = new LabelDictionaryEntry()
+    labelDictEntry2.setLabel("label2")
+    labelDictEntry2.setCount(100)
+
+    val labelDictionary = new java.util.ArrayList[LabelDictionaryEntry]()
+
+    labelDictionary.add(labelDictEntry1)
+    labelDictionary.add(labelDictEntry2)
+
+    model.setLabelDictionary(labelDictionary)
+
+    val floatVector1 = new FloatVector(Array(1.2f, 2.1f))
+    val floatVector2 = new FloatVector(Array(3.4f, -1.2f))
+
+    model.setWeightVector(
+      ImmutableMap.of(
+        "f", ImmutableMap.of("feature1", floatVector1, "feature2", floatVector2)
+      )
+    )
+
+    model
+  }
+
+  // Simple linear model with 2 features
+  val linearModel = {
+    val model = new LinearModel()
+
+    model.setWeights(ImmutableMap.of("s", ImmutableMap.of("feature1", 1.4f, "feature2", 1.3f)))
+
+    model
+  }
+
+  val multiclassExample1 = {
+    val example = new Example()
+    val fv = new FeatureVector()
+
+    fv.setFloatFeatures(ImmutableMap.of(
+      "f", ImmutableMap.of("feature1", 1.2, "feature2", 5.6),
+      "LABEL", ImmutableMap.of("label1", 10.0, "label2", 9.0)
+    ))
+
+    example.addToExample(fv)
+
+    example
+  }
+
+  val multiclassExample2 = {
+    val example = new Example()
+    val fv = new FeatureVector()
+
+    fv.setFloatFeatures(ImmutableMap.of(
+      "f", ImmutableMap.of("feature1", 1.8, "feature2", -1.6),
+      "LABEL", ImmutableMap.of("label1", 8.0, "label2", 4.0)
+    ))
+
+    example.addToExample(fv)
+
+    example
+  }
+
+  val linearExample1 = {
+    val example = new Example()
+    val fv = new FeatureVector()
+
+    fv.setFloatFeatures(ImmutableMap.of(
+      "LABEL", ImmutableMap.of("", 3.5)
+    ))
+
+    fv.setStringFeatures(ImmutableMap.of(
+      "s", ImmutableSet.of("feature1", "feature2")
+    ))
+
+    example.addToExample(fv)
+
+    example
+  }
+
+  val linearExample2 = {
+    val example = new Example()
+    val fv = new FeatureVector()
+
+    fv.setFloatFeatures(ImmutableMap.of(
+      "LABEL", ImmutableMap.of("", -2.0)
+    ))
+
+    fv.setStringFeatures(ImmutableMap.of(
+      "s", ImmutableSet.of("feature1")
+    ))
+
+    example.addToExample(fv)
+
+    example
+  }
+
+  @Test
+  def testExampleToEvaluationRecordMulticlass() = {
+    val evalResult = EvalUtil.exampleToEvaluationRecord(
+      multiclassExample1,
+      transformer,
+      fullRankLinearModel,
+      false,
+      true,
+      "LABEL",
+      _ => false
+    )
+
+    assertEquals(evalResult.getLabelsSize, 2)
+    assertEquals(evalResult.getScoresSize, 2)
+
+    assertEquals(evalResult.getLabels.get("label1"), 10.0, 0.001)
+    assertEquals(evalResult.getLabels.get("label2"), 9.0, 0.001)
+    assertEquals(evalResult.getScores.get("label1"), 1.2 * 1.2 + 5.6 * 3.4, 0.001)
+    assertEquals(evalResult.getScores.get("label2"), 1.2 * 2.1 + 5.6 * -1.2, 0.001)
+    assertEquals(evalResult.isIs_training, false)
+  }
+
+  @Test
+  def testExampleToEvaluationRecordLinear() = {
+    val evalResult = EvalUtil.exampleToEvaluationRecord(
+      linearExample1,
+      transformer,
+      linearModel,
+      false,
+      false,
+      "LABEL",
+      _ => false
+    )
+
+    assertEquals(evalResult.getLabel, 3.5, 0.001)
+    assertEquals(evalResult.getScore, 1.4 + 1.3, 0.001)
+    assertEquals(evalResult.isIs_training, false)
+  }
+
+  @Test
+  def testExampleToEvaluationRecordLinearProb() = {
+    val evalResult = EvalUtil.exampleToEvaluationRecord(
+      linearExample1,
+      transformer,
+      linearModel,
+      true,
+      false,
+      "LABEL",
+      _ => true
+    )
+
+    assertEquals(evalResult.getLabel, 3.5, 0.001)
+    assertEquals(evalResult.getScore, 1.0 / (1.0 + math.exp(-(1.3 + 1.4))), 0.001)
+    assertEquals(evalResult.isIs_training, true)
+  }
+
+  @Test
+  def testScoreExamples() = {
+    PipelineTestingUtil.withSparkContext(sc => {
+      val examples = sc.parallelize(Seq(linearExample1, linearExample2))
+
+      val trainingPredicate = (example: Example) => {
+        example.getExample.get(0).getStringFeatures.get("s").size() == 1
+      }
+
+      val results = EvalUtil.scoreExamples(
+        sc, transformer, linearModel, examples, trainingPredicate, "LABEL"
+      ).collect()
+
+      assertEquals(results.size, 2)
+      assertEquals(results(0)._1, 1.4 + 1.3, 0.001)
+      assertEquals(results(0)._2, "HOLD_P")
+
+      assertEquals(results(1)._1, 1.4, 0.001)
+      assertEquals(results(1)._2, "TRAIN_N")
+    })
+  }
+
+  @Test
+  def testScoreExamplesForEvaluation() = {
+    PipelineTestingUtil.withSparkContext(sc => {
+      val examples = sc.parallelize(Seq(multiclassExample1, multiclassExample2))
+
+      val results = EvalUtil.scoreExamplesForEvaluation(
+        sc, transformer, fullRankLinearModel, examples, "LABEL", false, true, _ => false
+      ).collect()
+
+      assertEquals(results.size, 2)
+      assertEquals(results(0).getLabels, ImmutableMap.of("label1", 10.0, "label2", 9.0))
+      assertEquals(results(1).getLabels, ImmutableMap.of("label1", 8.0, "label2", 4.0))
+
+      // Test one of the results in more detail
+      assertEquals(results(0).getScores.get("label1"), 1.2 * 1.2 + 5.6 * 3.4, 0.001)
+      assertEquals(results(0).isIs_training, false)
+    })
+  }
+}

--- a/training/src/test/scala/com/airbnb/aerosolve/training/pipeline/GenericPipelineTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/pipeline/GenericPipelineTest.scala
@@ -1,0 +1,92 @@
+package com.airbnb.aerosolve.training.pipeline
+
+import com.google.common.collect.{ImmutableMap, ImmutableSet}
+import org.junit.Assert._
+import org.junit.Test
+
+case class FakeDataRow(
+    i_intFeature1: Int,
+    i_intFeature2: Int,
+    f_floatFeature: Float,
+    d_doubleFeature: Double,
+    b_boolFeature: Boolean,
+    s_stringFeature: String,
+    s2_RAW: String,
+    LABEL: Double)
+
+case class FakeDataRowMulticlass(
+    i_intFeature: Int,
+    LABEL: String)
+
+class GenericPipelineTest {
+  @Test
+  def hiveTrainingToExample() = {
+    val fakeRow = FakeDataRow(
+      10, 7, 4.1f, 11.0, false, "some string", "some other string", 4.5
+    )
+
+    PipelineTestingUtil.withSparkContext(sc => {
+      val (sqlRow, schema) = PipelineTestingUtil.createFakeRowAndSchema(sc, fakeRow)
+
+      val example = GenericPipeline.hiveTrainingToExample(sqlRow, schema.fields.toArray, false)
+      val stringFeatures = example.getExample.get(0).getStringFeatures
+      val floatFeatures = example.getExample.get(0).getFloatFeatures
+
+      assertEquals(
+        stringFeatures.get("s"),
+        ImmutableSet.of("stringFeature:some string")
+      )
+      assertEquals(
+        stringFeatures.get("s2"),
+        ImmutableSet.of("some other string")
+      )
+      assertEquals(
+        floatFeatures.get("i"),
+        ImmutableMap.of("intFeature1", 10.0, "intFeature2", 7.0)
+      )
+      assertEquals(
+        floatFeatures.get("f"),
+        ImmutableMap.of("floatFeature", 4.1f.toDouble)
+      )
+      assertEquals(
+        floatFeatures.get("d"),
+        ImmutableMap.of("doubleFeature", 11.0)
+      )
+      assertEquals(
+        stringFeatures.get("b"),
+        ImmutableSet.of("boolFeature:F")
+      )
+      assertEquals(
+        floatFeatures.get("LABEL"),
+        ImmutableMap.of("", 4.5)
+      )
+    })
+  }
+
+  @Test
+  def hiveTrainingToExampleMulticlass() = {
+    val fakeRow = FakeDataRowMulticlass(
+      10, "CLASS1:2.1,CLASS2:4.5,CLASS3:5.6"
+    )
+
+    PipelineTestingUtil.withSparkContext(sc => {
+      val (sqlRow, schema) = PipelineTestingUtil.createFakeRowAndSchema(sc, fakeRow)
+
+      val example = GenericPipeline.hiveTrainingToExample(sqlRow, schema.fields.toArray, true)
+      val floatFeatures = example.getExample.get(0).getFloatFeatures
+
+      assertEquals(
+        floatFeatures.get("i"),
+        ImmutableMap.of("intFeature", 10.0)
+      )
+      assertEquals(
+        floatFeatures.get("LABEL"),
+        ImmutableMap.of(
+          "CLASS1", 2.1,
+          "CLASS2", 4.5,
+          "CLASS3", 5.6
+        )
+      )
+    })
+  }
+}

--- a/training/src/test/scala/com/airbnb/aerosolve/training/pipeline/PipelineTestingUtil.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/pipeline/PipelineTestingUtil.scala
@@ -1,0 +1,81 @@
+package com.airbnb.aerosolve.training.pipeline
+
+import org.apache.spark.sql.hive.HiveContext
+import org.apache.spark.sql.{Row, SQLContext, StructType}
+import org.apache.spark.{SparkConf, SparkContext}
+import org.mockito.Matchers._
+import org.mockito.Mockito._
+
+import scala.language.implicitConversions
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe.TypeTag
+
+/*
+ * Misc. utilities that may be useful for testing Spark pipelines.
+ */
+object PipelineTestingUtil {
+  def generateSparkContext = {
+    val sparkConf =
+      new SparkConf()
+        .setMaster("local[2]")
+        .setAppName("PipelineTestingUtil")
+        .set("spark.io.compression.codec", "lz4")
+
+    new SparkContext(sparkConf)
+  }
+
+  /*
+   * Wrapper that generates a local SparkContext for a test and then
+   * cleans everything up after test completion.
+   */
+  def withSparkContext[B](f: SparkContext => B): B = {
+    val sc = generateSparkContext
+
+    try {
+      f(sc)
+    } finally {
+      sc.stop
+      System.clearProperty("spark.master.port")
+    }
+  }
+
+  /*
+   * Create a mock HiveContext that responds to sql calls by returning
+   * the argument results in a SchemaRDD.
+   *
+   * Works for any case class.
+   */
+  def createFakeHiveContext[A <: Product: TypeTag : ClassTag](
+      sc: SparkContext, results: List[A]): HiveContext = {
+    val mockHiveContext = mock(classOf[HiveContext])
+
+    val schemaRdd = sc.parallelize(results)
+
+    val sqlContext = new SQLContext(sc)
+    import sqlContext._
+
+    schemaRdd.registerAsTable("rows")
+
+    when(mockHiveContext.sql(anyString())).thenReturn(sql("select * from rows"))
+
+    mockHiveContext
+  }
+
+  /*
+   * Create a fake row and schema for a given case class.
+   */
+  def createFakeRowAndSchema[A <: Product: TypeTag : ClassTag](
+      sc: SparkContext, result: A): Tuple2[Row, StructType] = {
+    // TODO: Investigate whether there is an easier way to do this
+    val schemaRdd = sc.parallelize(Seq(result))
+
+    val sqlContext = new SQLContext(sc)
+    import sqlContext._
+
+    schemaRdd.registerAsTable("rows")
+
+    val sqlResult = sql("select * from rows")
+
+    (sqlResult.collect().toSeq.head, sqlResult.schema)
+  }
+}


### PR DESCRIPTION
to: @deerzq
cc: @askeys @jq 

This change adds a "generic pipeline" that allows one to train, evaluate, and score an Aerosolve model with minimal code. We've been using this inside Airbnb successfully for the last year. 

The code is the same as the internal version, except for some style cleanups.

Documentation will be added in a future change.