### PR TITLE
Update travis setting to fix flaky java installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,20 @@
 language: java
-os : osx
+jdk:
+  - oraclejdk8
+
+# this doesn't work yet: https://github.com/travis-ci/travis-ci/issues/4706
+#sudo: false
+#addons:
+#  apt:
+#    sources:
+#    - debian-sid
+#    packages:
+#    - thrift-compiler
+
+sudo: required
 before_install:
-  - brew update
-  - brew install thrift
-  - brew install gradle
-  - brew tap caskroom/cask
-  - brew install brew-cask
-  - brew cask install java
+  - sudo apt-get update -qq
+  - sudo apt-get install libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev
+  - wget https://archive.apache.org/dist/thrift/0.9.1/thrift-0.9.1.tar.gz
+  - tar xfz thrift-0.9.1.tar.gz
+  - cd thrift-0.9.1 && ./configure --without-cpp --without-c_glib --without-python --without-ruby --without-go --without-erlang --without-java && sudo make install && cd ..


### PR DESCRIPTION
This updates the travis setting to use pre-installed jdk8 directly and switch to Linux based build environment. This fixes flaky build issue due to brew install java being flaky. 

It also saves about 5 minutes build time (~30%) per build. 

This also prepares us to move to container based build once the thrift installation issue mentioned below be fixed. (which allows thrift installation and Java packages be cached and faster build startup time)

@jq  @deerzq 