### PR TITLE
NLP transform improvements

### DIFF
--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/ConvertStringCaseTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/ConvertStringCaseTransform.java
@@ -4,6 +4,7 @@ import com.airbnb.aerosolve.core.FeatureVector;
 import com.airbnb.aerosolve.core.util.Util;
 import com.typesafe.config.Config;
 
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -11,6 +12,8 @@ import java.util.Set;
  * Converts strings to either all lowercase or all uppercase
  * "field1" specifies the key of the feature
  * "convert_to_uppercase" converts strings to uppercase if true, otherwise converts to lowercase
+ * "output" optionally specifies the key of the output feature, if it is not given the transform
+ * overwrites / replaces the input feature
  */
 public class ConvertStringCaseTransform implements Transform {
   private String fieldName1;
@@ -21,7 +24,11 @@ public class ConvertStringCaseTransform implements Transform {
   public void configure(Config config, String key) {
     fieldName1 = config.getString(key + ".field1");
     convertToUppercase = config.getBoolean(key + ".convert_to_uppercase");
-    outputName = config.getString(key + ".output");
+    if (config.hasPath(key + ".output")) {
+      outputName = config.getString(key + ".output");
+    } else {
+      outputName = fieldName1;
+    }
   }
 
   @Override
@@ -38,15 +45,23 @@ public class ConvertStringCaseTransform implements Transform {
 
     Set<String> output = Util.getOrCreateStringFeature(outputName, stringFeatures);
 
-    for (String rawString : feature1) {
-      if (rawString == null) continue;
-      String convertedString;
-      if (convertToUppercase) {
-        convertedString = rawString.toUpperCase();
-      } else {
-        convertedString = rawString.toLowerCase();
+    for (Iterator<String> iterator = feature1.iterator(); iterator.hasNext();) {
+      String rawString = iterator.next();
+
+      if (rawString != null) {
+        String convertedString;
+        if (convertToUppercase) {
+          convertedString = rawString.toUpperCase();
+        } else {
+          convertedString = rawString.toLowerCase();
+        }
+        output.add(convertedString);
       }
-      output.add(convertedString);
+
+      // Check reference equality to determine whether the output should overwrite the input
+      if (output == feature1) {
+        iterator.remove();
+      }
     }
   }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/ConvertStringCaseTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/ConvertStringCaseTransform.java
@@ -1,12 +1,6 @@
 package com.airbnb.aerosolve.core.transforms;
 
-import com.airbnb.aerosolve.core.FeatureVector;
-import com.airbnb.aerosolve.core.util.Util;
 import com.typesafe.config.Config;
-
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Converts strings to either all lowercase or all uppercase
@@ -15,53 +9,30 @@ import java.util.Set;
  * "output" optionally specifies the key of the output feature, if it is not given the transform
  * overwrites / replaces the input feature
  */
-public class ConvertStringCaseTransform implements Transform {
-  private String fieldName1;
+public class ConvertStringCaseTransform extends StringTransform {
   private boolean convertToUppercase;
-  private String outputName;
 
   @Override
   public void configure(Config config, String key) {
-    fieldName1 = config.getString(key + ".field1");
+    super.configure(config, key);
+
     convertToUppercase = config.getBoolean(key + ".convert_to_uppercase");
-    if (config.hasPath(key + ".output")) {
-      outputName = config.getString(key + ".output");
-    } else {
-      outputName = fieldName1;
-    }
   }
 
   @Override
-  public void doTransform(FeatureVector featureVector) {
-    Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
-    if (stringFeatures == null) {
-      return;
+  public String processString(String rawString) {
+    if (rawString == null) {
+      return null;
     }
 
-    Set<String> feature1 = stringFeatures.get(fieldName1);
-    if (feature1 == null) {
-      return;
+    String convertedString;
+
+    if (convertToUppercase) {
+      convertedString = rawString.toUpperCase();
+    } else {
+      convertedString = rawString.toLowerCase();
     }
 
-    Set<String> output = Util.getOrCreateStringFeature(outputName, stringFeatures);
-
-    for (Iterator<String> iterator = feature1.iterator(); iterator.hasNext();) {
-      String rawString = iterator.next();
-
-      if (rawString != null) {
-        String convertedString;
-        if (convertToUppercase) {
-          convertedString = rawString.toUpperCase();
-        } else {
-          convertedString = rawString.toLowerCase();
-        }
-        output.add(convertedString);
-      }
-
-      // Check reference equality to determine whether the output should overwrite the input
-      if (output == feature1) {
-        iterator.remove();
-      }
-    }
+    return convertedString;
   }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/ConvertStringCaseTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/ConvertStringCaseTransform.java
@@ -1,5 +1,7 @@
 package com.airbnb.aerosolve.core.transforms;
 
+import com.airbnb.aerosolve.core.transforms.types.StringTransform;
+
 import com.typesafe.config.Config;
 
 /**
@@ -13,9 +15,7 @@ public class ConvertStringCaseTransform extends StringTransform {
   private boolean convertToUppercase;
 
   @Override
-  public void configure(Config config, String key) {
-    super.configure(config, key);
-
+  public void init(Config config, String key) {
     convertToUppercase = config.getBoolean(key + ".convert_to_uppercase");
   }
 

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/DefaultStringTokenizerTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/DefaultStringTokenizerTransform.java
@@ -38,7 +38,7 @@ public class DefaultStringTokenizerTransform implements Transform {
   public void doTransform(FeatureVector featureVector) {
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
     if (stringFeatures == null) {
-      return ;
+      return;
     }
 
     Set<String> feature1 = stringFeatures.get(fieldName1);

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/DefaultStringTokenizerTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/DefaultStringTokenizerTransform.java
@@ -28,7 +28,11 @@ public class DefaultStringTokenizerTransform implements Transform {
     fieldName1 = config.getString(key + ".field1");
     regex = config.getString(key + ".regex");
     outputName = config.getString(key + ".output");
-    generateBigrams = config.getBoolean(key + ".generate_bigrams");
+    if (config.hasPath(key + ".generate_bigrams")) {
+      generateBigrams = config.getBoolean(key + ".generate_bigrams");
+    } else {
+      generateBigrams = false;
+    }
     if (generateBigrams) {
       bigramsOutputName = config.getString(key + ".bigrams_output");
     }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/DeleteFloatFeatureFamilyTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/DeleteFloatFeatureFamilyTransform.java
@@ -9,40 +9,28 @@ import java.util.Map;
 import com.typesafe.config.Config;
 
 /**
- * "field1" optionally specifies the float feature family to be deleted
- * "fields" optionally specifies a list of float feature families to be deleted
+ * "fields" specifies a list of float feature families to be deleted
  */
 public class DeleteFloatFeatureFamilyTransform implements Transform {
-  private String fieldName1;
   private List<String> fieldNames;
 
   @Override
   public void configure(Config config, String key) {
-    if (config.hasPath(key + ".field1")) {
-      fieldName1 = config.getString(key + ".field1");
-    }
-    if (config.hasPath(key + ".fields")) {
-      fieldNames = config.getStringList(key + ".fields");
-    }
+    fieldNames = config.getStringList(key + ".fields");
   }
 
   @Override
   public void doTransform(FeatureVector featureVector) {
     Map<String, Map<String, Double>> floatFeatures = featureVector.getFloatFeatures();
     if (floatFeatures == null) {
-      return ;
+      return;
     }
 
-    HashSet<String> fieldNamesSet = new HashSet<>();
-
-    if (fieldName1 != null) {
-      fieldNamesSet.add(fieldName1);
-    }
-    if (fieldNames != null) {
-      fieldNamesSet.addAll(fieldNames);
+    if (fieldNames == null) {
+      return;
     }
 
-    for (String fieldName: fieldNamesSet) {
+    for (String fieldName: fieldNames) {
       Map<String, Double> feature = floatFeatures.get(fieldName);
       if (feature != null) {
         floatFeatures.remove(fieldName);

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/DeleteFloatFeatureFamilyTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/DeleteFloatFeatureFamilyTransform.java
@@ -1,19 +1,29 @@
 package com.airbnb.aerosolve.core.transforms;
 
 import com.airbnb.aerosolve.core.FeatureVector;
+
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+
 import com.typesafe.config.Config;
 
 /**
- * "field1" specifies the float feature family to be deleted
+ * "field1" optionally specifies the float feature family to be deleted
+ * "fields" optionally specifies a list of float feature families to be deleted
  */
-
 public class DeleteFloatFeatureFamilyTransform implements Transform {
   private String fieldName1;
+  private List<String> fieldNames;
 
   @Override
   public void configure(Config config, String key) {
-    fieldName1 = config.getString(key + ".field1");
+    if (config.hasPath(key + ".field1")) {
+      fieldName1 = config.getString(key + ".field1");
+    }
+    if (config.hasPath(key + ".fields")) {
+      fieldNames = config.getStringList(key + ".fields");
+    }
   }
 
   @Override
@@ -23,11 +33,20 @@ public class DeleteFloatFeatureFamilyTransform implements Transform {
       return ;
     }
 
-    Map<String, Double> feature1 = floatFeatures.get(fieldName1);
-    if (feature1 == null) {
-      return;
+    HashSet<String> fieldNamesSet = new HashSet<>();
+
+    if (fieldName1 != null) {
+      fieldNamesSet.add(fieldName1);
+    }
+    if (fieldNames != null) {
+      fieldNamesSet.addAll(fieldNames);
     }
 
-    floatFeatures.remove(fieldName1);
+    for (String fieldName: fieldNamesSet) {
+      Map<String, Double> feature = floatFeatures.get(fieldName);
+      if (feature != null) {
+        floatFeatures.remove(fieldName);
+      }
+    }
   }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/DeleteStringFeatureColumnTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/DeleteStringFeatureColumnTransform.java
@@ -1,0 +1,4 @@
+package com.airbnb.aerosolve.core.transforms;
+
+// TODO: remove this once all configs have migrated over to the new transform names
+public class DeleteStringFeatureColumnTransform extends DeleteStringFeatureFamilyTransform {}

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/DeleteStringFeatureFamilyTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/DeleteStringFeatureFamilyTransform.java
@@ -10,7 +10,7 @@ import com.typesafe.config.Config;
 /**
  * "field1" specifies the string column to be deleted
  */
-public class DeleteStringFeatureColumnTransform implements Transform {
+public class DeleteStringFeatureFamilyTransform extends Transform {
   private String fieldName1;
 
   @Override

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/DeleteStringFeatureFamilyTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/DeleteStringFeatureFamilyTransform.java
@@ -10,40 +10,28 @@ import java.util.Set;
 import com.typesafe.config.Config;
 
 /**
- * "field1" optionally specifies the string feature family to be deleted
- * "fields" optionally specifies a list of string feature families to be deleted
+ * "fields" specifies a list of string feature families to be deleted
  */
 public class DeleteStringFeatureFamilyTransform implements Transform {
-  private String fieldName1;
   private List<String> fieldNames;
 
   @Override
   public void configure(Config config, String key) {
-    if (config.hasPath(key + ".field1")) {
-      fieldName1 = config.getString(key + ".field1");
-    }
-    if (config.hasPath(key + ".fields")) {
-      fieldNames = config.getStringList(key + ".fields");
-    }
+    fieldNames = config.getStringList(key + ".fields");
   }
 
   @Override
   public void doTransform(FeatureVector featureVector) {
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
     if (stringFeatures == null) {
-      return ;
+      return;
     }
 
-    HashSet<String> fieldNamesSet = new HashSet<>();
-
-    if (fieldName1 != null) {
-      fieldNamesSet.add(fieldName1);
-    }
-    if (fieldNames != null) {
-      fieldNamesSet.addAll(fieldNames);
+    if (fieldNames == null) {
+      return;
     }
 
-    for (String fieldName: fieldNamesSet) {
+    for (String fieldName: fieldNames) {
       Set<String> feature = stringFeatures.get(fieldName);
       if (feature != null) {
         stringFeatures.remove(fieldName);

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/DeleteStringFeatureFamilyTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/DeleteStringFeatureFamilyTransform.java
@@ -2,6 +2,8 @@ package com.airbnb.aerosolve.core.transforms;
 
 import com.airbnb.aerosolve.core.FeatureVector;
 
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -12,10 +14,16 @@ import com.typesafe.config.Config;
  */
 public class DeleteStringFeatureFamilyTransform implements Transform {
   private String fieldName1;
+  private List<String> fieldNames;
 
   @Override
   public void configure(Config config, String key) {
-    fieldName1 = config.getString(key + ".field1");
+    if (config.hasPath(key + ".field1")) {
+      fieldName1 = config.getString(key + ".field1");
+    }
+    if (config.hasPath(key + ".fields")) {
+      fieldNames = config.getStringList(key + ".fields");
+    }
   }
 
   @Override
@@ -25,11 +33,20 @@ public class DeleteStringFeatureFamilyTransform implements Transform {
       return ;
     }
 
-    Set<String> feature1 = stringFeatures.get(fieldName1);
-    if (feature1 == null) {
-      return;
+    HashSet<String> fieldNamesSet = new HashSet<>();
+
+    if (fieldName1 != null) {
+      fieldNamesSet.add(fieldName1);
+    }
+    if (fieldNames != null) {
+      fieldNamesSet.addAll(fieldNames);
     }
 
-    stringFeatures.remove(fieldName1);
+    for (String fieldName: fieldNamesSet) {
+      Set<String> feature1 = stringFeatures.get(fieldName1);
+      if (feature1 != null) {
+        stringFeatures.remove(fieldName);
+      }
+    }
   }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/DeleteStringFeatureFamilyTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/DeleteStringFeatureFamilyTransform.java
@@ -10,7 +10,7 @@ import com.typesafe.config.Config;
 /**
  * "field1" specifies the string column to be deleted
  */
-public class DeleteStringFeatureFamilyTransform extends Transform {
+public class DeleteStringFeatureFamilyTransform implements Transform {
   private String fieldName1;
 
   @Override

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/DeleteStringFeatureFamilyTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/DeleteStringFeatureFamilyTransform.java
@@ -10,7 +10,8 @@ import java.util.Set;
 import com.typesafe.config.Config;
 
 /**
- * "field1" specifies the string column to be deleted
+ * "field1" optionally specifies the string feature family to be deleted
+ * "fields" optionally specifies a list of string feature families to be deleted
  */
 public class DeleteStringFeatureFamilyTransform implements Transform {
   private String fieldName1;
@@ -43,8 +44,8 @@ public class DeleteStringFeatureFamilyTransform implements Transform {
     }
 
     for (String fieldName: fieldNamesSet) {
-      Set<String> feature1 = stringFeatures.get(fieldName1);
-      if (feature1 != null) {
+      Set<String> feature = stringFeatures.get(fieldName);
+      if (feature != null) {
         stringFeatures.remove(fieldName);
       }
     }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/MoveFloatToStringTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/MoveFloatToStringTransform.java
@@ -10,7 +10,8 @@ import java.util.Map.Entry;
 import java.util.List;
 
 /**
- * Moves named fields from one family to another.
+ * Moves named fields from one family to another. If keys are not specified, all keys are moved
+ * from the float family.
  */
 public class MoveFloatToStringTransform implements Transform {
   private String fieldName1;
@@ -24,10 +25,12 @@ public class MoveFloatToStringTransform implements Transform {
     fieldName1 = config.getString(key + ".field1");
     bucket = config.getDouble(key + ".bucket");
     outputName = config.getString(key + ".output");
-    keys = config.getStringList(key + ".keys");
-    try {
+    if (config.hasPath(key + ".keys")) {
+      keys = config.getStringList(key + ".keys");
+    }
+    if (config.hasPath(key + ".cap")) {
       cap = config.getDouble(key + ".cap");
-    } catch (Exception e) {
+    } else {
       cap = 1e10;
     }
   }
@@ -48,17 +51,32 @@ public class MoveFloatToStringTransform implements Transform {
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
     Set<String> output = Util.getOrCreateStringFeature(outputName, stringFeatures);
 
-    for (String key : keys) {
-      if (feature1.containsKey(key)) {
-        Double dbl = feature1.get(key);
-        if (dbl > cap) {
-          dbl = cap;
-        }
-
-        Double quantized = LinearLogQuantizeTransform.quantize(dbl, bucket);
-        output.add(key + '=' + quantized);
-        feature1.remove(key);
+    if (keys != null) {
+      for (String key : keys) {
+        moveFloat(feature1, output, key, cap, bucket);
       }
+    } else {
+      for (String key : feature1.keySet()) {
+        moveFloat(feature1, output, key, cap, bucket);
+      }
+    }
+  }
+
+  public static void moveFloat(
+      Map<String, Double> feature1,
+      Set<String> output,
+      String key,
+      double cap,
+      double bucket) {
+    if (feature1.containsKey(key)) {
+      Double dbl = feature1.get(key);
+      if (dbl > cap) {
+        dbl = cap;
+      }
+
+      Double quantized = LinearLogQuantizeTransform.quantize(dbl, bucket);
+      output.add(key + '=' + quantized);
+      feature1.remove(key);
     }
   }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/MoveFloatToStringTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/MoveFloatToStringTransform.java
@@ -3,8 +3,9 @@ package com.airbnb.aerosolve.core.transforms;
 import com.airbnb.aerosolve.core.FeatureVector;
 import com.airbnb.aerosolve.core.util.Util;
 import com.typesafe.config.Config;
+
+import java.util.Iterator;
 import java.util.Set;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.List;
@@ -54,10 +55,16 @@ public class MoveFloatToStringTransform implements Transform {
     if (keys != null) {
       for (String key : keys) {
         moveFloat(feature1, output, key, cap, bucket);
+        feature1.remove(key);
       }
     } else {
-      for (String key : feature1.keySet()) {
+      for (Iterator<Entry<String, Double>> iterator = feature1.entrySet().iterator();
+          iterator.hasNext();) {
+        Entry<String, Double> entry = iterator.next();
+        String key = entry.getKey();
+
         moveFloat(feature1, output, key, cap, bucket);
+        iterator.remove();
       }
     }
   }
@@ -76,7 +83,6 @@ public class MoveFloatToStringTransform implements Transform {
 
       Double quantized = LinearLogQuantizeTransform.quantize(dbl, bucket);
       output.add(key + '=' + quantized);
-      feature1.remove(key);
     }
   }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/NormalizeUtf8Transform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/NormalizeUtf8Transform.java
@@ -1,12 +1,8 @@
 package com.airbnb.aerosolve.core.transforms;
 
-import com.airbnb.aerosolve.core.FeatureVector;
-import com.airbnb.aerosolve.core.util.Util;
+import com.airbnb.aerosolve.core.transforms.types.StringTransform;
 
 import java.text.Normalizer;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
 
 import com.typesafe.config.Config;
 
@@ -23,9 +19,7 @@ public class NormalizeUtf8Transform extends StringTransform {
   private Normalizer.Form normalizationForm;
 
   @Override
-  public void configure(Config config, String key) {
-    super.configure(config, key);
-
+  public void init(Config config, String key) {
     String normalizationFormString = DEFAULT_NORMALIZATION_FORM.name();
     if (config.hasPath(key + ".normalization_form")) {
       normalizationFormString = config.getString(key + ".normalization_form");

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/ReplaceAllStringsTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/ReplaceAllStringsTransform.java
@@ -1,5 +1,7 @@
 package com.airbnb.aerosolve.core.transforms;
 
+import com.airbnb.aerosolve.core.transforms.types.StringTransform;
+
 import java.util.List;
 import java.util.Map;
 
@@ -17,9 +19,7 @@ public class ReplaceAllStringsTransform extends StringTransform {
   private List<? extends ConfigObject> replacements;
 
   @Override
-  public void configure(Config config, String key) {
-    super.configure(config, key);
-
+  public void init(Config config, String key) {
     replacements = config.getObjectList(key + ".replacements");
   }
 

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/StringTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/StringTransform.java
@@ -1,0 +1,65 @@
+package com.airbnb.aerosolve.core.transforms;
+
+import com.airbnb.aerosolve.core.FeatureVector;
+import com.airbnb.aerosolve.core.util.Util;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.typesafe.config.Config;
+
+/**
+ * Abstract representation of a transform that processes all strings in a string feature and
+ * outputs a new string feature or overwrites /replaces the input string feature.
+ * "field1" specifies the key of the feature
+ * "output" optionally specifies the key of the output feature, if it is not given the transform
+ * overwrites / replaces the input feature
+ */
+public abstract class StringTransform implements Transform {
+  protected String fieldName1;
+  protected String outputName;
+
+  @Override
+  public void configure(Config config, String key) {
+    fieldName1 = config.getString(key + ".field1");
+    if (config.hasPath(key + ".output")) {
+      outputName = config.getString(key + ".output");
+    } else {
+      outputName = fieldName1;
+    }
+  }
+
+  @Override
+  public void doTransform(FeatureVector featureVector) {
+    Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
+    if (stringFeatures == null) {
+      return;
+    }
+
+    Set<String> feature1 = stringFeatures.get(fieldName1);
+    if (feature1 == null) {
+      return;
+    }
+
+    HashSet<String> processedStrings = new HashSet<>();
+
+    for (String rawString : feature1) {
+      if (rawString != null) {
+        String processedString = processString(rawString);
+        processedStrings.add(processedString);
+      }
+    }
+
+    Set<String> output = Util.getOrCreateStringFeature(outputName, stringFeatures);
+
+    // Check reference equality to determine whether the output should overwrite the input
+    if (output == feature1) {
+      output.clear();
+    }
+
+    output.addAll(processedStrings);
+  }
+
+  public abstract String processString(String rawString);
+}

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/TransformFactory.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/TransformFactory.java
@@ -15,6 +15,12 @@ public class TransformFactory {
     if (transformName == null) {
       return null;
     }
+
+    // TODO: remove this once all configs have migrated over to the new transform names
+    if (transformName.equals("delete_string_feature_column")) {
+      transformName = "delete_string_feature_family";
+    }
+
     String name = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, transformName);
     Transform result = null;
     try {

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/TransformFactory.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/TransformFactory.java
@@ -16,11 +16,6 @@ public class TransformFactory {
       return null;
     }
 
-    // TODO: remove this once all configs have migrated over to the new transform names
-    if (transformName.equals("delete_string_feature_column")) {
-      transformName = "delete_string_feature_family";
-    }
-
     String name = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, transformName);
     Transform result = null;
     try {

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/types/StringTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/types/StringTransform.java
@@ -1,6 +1,7 @@
-package com.airbnb.aerosolve.core.transforms;
+package com.airbnb.aerosolve.core.transforms.types;
 
 import com.airbnb.aerosolve.core.FeatureVector;
+import com.airbnb.aerosolve.core.transforms.Transform;
 import com.airbnb.aerosolve.core.util.Util;
 
 import java.util.HashSet;
@@ -28,7 +29,10 @@ public abstract class StringTransform implements Transform {
     } else {
       outputName = fieldName1;
     }
+    init(config, key);
   }
+
+  protected abstract void init(Config config, String key);
 
   @Override
   public void doTransform(FeatureVector featureVector) {

--- a/core/src/test/java/com/airbnb/aerosolve/core/transforms/ConvertStringCaseTransformTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/transforms/ConvertStringCaseTransformTest.java
@@ -23,13 +23,22 @@ import static org.junit.Assert.assertTrue;
 public class ConvertStringCaseTransformTest {
   private static final Logger log = LoggerFactory.getLogger(ConvertStringCaseTransformTest.class);
 
-  public String makeConfig(boolean convertToUppercase, String output) {
-    return "test_convert_string_case {\n" +
-        " transform: convert_string_case\n" +
-        " field1: strFeature1\n" +
-        " convert_to_uppercase: " + Boolean.toString(convertToUppercase) + "\n" +
-        " output: " + output + "\n" +
-        "}";
+  public String makeConfig(boolean convertToUppercase, boolean overwriteInput) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("test_convert_string_case {\n");
+    sb.append(" transform: convert_string_case\n");
+    sb.append(" field1: strFeature1\n");
+    sb.append(" convert_to_uppercase: ");
+    sb.append(Boolean.toString(convertToUppercase));
+    sb.append("\n");
+
+    if (!overwriteInput) {
+      sb.append(" output: bar\n");
+    }
+
+    sb.append("}");
+
+    return sb.toString();
   }
 
   public FeatureVector makeFeatureVector() {
@@ -47,7 +56,7 @@ public class ConvertStringCaseTransformTest {
 
   @Test
   public void testEmptyFeatureVector() {
-    Config config = ConfigFactory.parseString(makeConfig(false, "output"));
+    Config config = ConfigFactory.parseString(makeConfig(false, false));
     Transform transform = TransformFactory.createTransform(config, "test_convert_string_case");
     FeatureVector featureVector = new FeatureVector();
     transform.doTransform(featureVector);
@@ -57,7 +66,7 @@ public class ConvertStringCaseTransformTest {
 
   @Test
   public void testTransformConvertToLowercase() {
-    Config config = ConfigFactory.parseString(makeConfig(false, "output"));
+    Config config = ConfigFactory.parseString(makeConfig(false, false));
     Transform transform = TransformFactory.createTransform(config, "test_convert_string_case");
     FeatureVector featureVector = makeFeatureVector();
     transform.doTransform(featureVector);
@@ -66,7 +75,7 @@ public class ConvertStringCaseTransformTest {
     assertNotNull(stringFeatures);
     assertEquals(2, stringFeatures.size());
 
-    Set<String> output = stringFeatures.get("output");
+    Set<String> output = stringFeatures.get("bar");
 
     assertNotNull(output);
     assertEquals(2, output.size());
@@ -76,7 +85,7 @@ public class ConvertStringCaseTransformTest {
 
   @Test
   public void testTransformConvertToUppercase() {
-    Config config = ConfigFactory.parseString(makeConfig(true, "output"));
+    Config config = ConfigFactory.parseString(makeConfig(true, false));
     Transform transform = TransformFactory.createTransform(config, "test_convert_string_case");
     FeatureVector featureVector = makeFeatureVector();
     transform.doTransform(featureVector);
@@ -85,7 +94,7 @@ public class ConvertStringCaseTransformTest {
     assertNotNull(stringFeatures);
     assertEquals(2, stringFeatures.size());
 
-    Set<String> output = stringFeatures.get("output");
+    Set<String> output = stringFeatures.get("bar");
 
     assertNotNull(output);
     assertEquals(2, output.size());
@@ -95,7 +104,7 @@ public class ConvertStringCaseTransformTest {
 
   @Test
   public void testTransformOverwriteInput() {
-    Config config = ConfigFactory.parseString(makeConfig(true, "strFeature1"));
+    Config config = ConfigFactory.parseString(makeConfig(true, true));
     Transform transform = TransformFactory.createTransform(config, "test_convert_string_case");
     FeatureVector featureVector = makeFeatureVector();
     transform.doTransform(featureVector);

--- a/core/src/test/java/com/airbnb/aerosolve/core/transforms/ConvertStringCaseTransformTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/transforms/ConvertStringCaseTransformTest.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -22,19 +23,19 @@ import static org.junit.Assert.assertTrue;
 public class ConvertStringCaseTransformTest {
   private static final Logger log = LoggerFactory.getLogger(ConvertStringCaseTransformTest.class);
 
-  public String makeConfig(boolean convertToUppercase) {
+  public String makeConfig(boolean convertToUppercase, String output) {
     return "test_convert_string_case {\n" +
         " transform: convert_string_case\n" +
         " field1: strFeature1\n" +
         " convert_to_uppercase: " + Boolean.toString(convertToUppercase) + "\n" +
-        " output: bar\n" +
+        " output: " + output + "\n" +
         "}";
   }
 
   public FeatureVector makeFeatureVector() {
     Map<String, Set<String>> stringFeatures = new HashMap<>();
 
-    Set list = new HashSet<String>();
+    Set<String> list = new HashSet<>();
     list.add("I like BLUEBERRY pie, APPLE pie; and I also like BLUE!");
     list.add("I'm so  excited: I   like blue!?!!");
     stringFeatures.put("strFeature1", list);
@@ -46,7 +47,7 @@ public class ConvertStringCaseTransformTest {
 
   @Test
   public void testEmptyFeatureVector() {
-    Config config = ConfigFactory.parseString(makeConfig(false));
+    Config config = ConfigFactory.parseString(makeConfig(false, "output"));
     Transform transform = TransformFactory.createTransform(config, "test_convert_string_case");
     FeatureVector featureVector = new FeatureVector();
     transform.doTransform(featureVector);
@@ -56,32 +57,57 @@ public class ConvertStringCaseTransformTest {
 
   @Test
   public void testTransformConvertToLowercase() {
-    Config config = ConfigFactory.parseString(makeConfig(false));
+    Config config = ConfigFactory.parseString(makeConfig(false, "output"));
     Transform transform = TransformFactory.createTransform(config, "test_convert_string_case");
     FeatureVector featureVector = makeFeatureVector();
     transform.doTransform(featureVector);
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
 
+    assertNotNull(stringFeatures);
     assertEquals(2, stringFeatures.size());
 
-    Set<String> output = stringFeatures.get("bar");
+    Set<String> output = stringFeatures.get("output");
 
+    assertNotNull(output);
+    assertEquals(2, output.size());
     assertTrue(output.contains("i like blueberry pie, apple pie; and i also like blue!"));
     assertTrue(output.contains("i'm so  excited: i   like blue!?!!"));
   }
 
   @Test
   public void testTransformConvertToUppercase() {
-    Config config = ConfigFactory.parseString(makeConfig(true));
+    Config config = ConfigFactory.parseString(makeConfig(true, "output"));
     Transform transform = TransformFactory.createTransform(config, "test_convert_string_case");
     FeatureVector featureVector = makeFeatureVector();
     transform.doTransform(featureVector);
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
 
+    assertNotNull(stringFeatures);
     assertEquals(2, stringFeatures.size());
 
-    Set<String> output = stringFeatures.get("bar");
+    Set<String> output = stringFeatures.get("output");
 
+    assertNotNull(output);
+    assertEquals(2, output.size());
+    assertTrue(output.contains("I LIKE BLUEBERRY PIE, APPLE PIE; AND I ALSO LIKE BLUE!"));
+    assertTrue(output.contains("I'M SO  EXCITED: I   LIKE BLUE!?!!"));
+  }
+
+  @Test
+  public void testTransformOverwriteInput() {
+    Config config = ConfigFactory.parseString(makeConfig(true, "strFeature1"));
+    Transform transform = TransformFactory.createTransform(config, "test_convert_string_case");
+    FeatureVector featureVector = makeFeatureVector();
+    transform.doTransform(featureVector);
+    Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
+
+    assertNotNull(stringFeatures);
+    assertEquals(1, stringFeatures.size());
+
+    Set<String> output = stringFeatures.get("strFeature1");
+
+    assertNotNull(output);
+    assertEquals(2, output.size());
     assertTrue(output.contains("I LIKE BLUEBERRY PIE, APPLE PIE; AND I ALSO LIKE BLUE!"));
     assertTrue(output.contains("I'M SO  EXCITED: I   LIKE BLUE!?!!"));
   }

--- a/core/src/test/java/com/airbnb/aerosolve/core/transforms/DeleteFloatFeatureFamilyTransformTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/transforms/DeleteFloatFeatureFamilyTransformTest.java
@@ -23,8 +23,7 @@ public class DeleteFloatFeatureFamilyTransformTest {
   public String makeConfig() {
     return "test_delete_float_feature_family {\n" +
         " transform: delete_float_feature_family\n" +
-        " field1: F1\n" +
-        " fields: [F2, F3]" +
+        " fields: [F1, F2, F3]" +
         "}";
   }
 

--- a/core/src/test/java/com/airbnb/aerosolve/core/transforms/DeleteFloatFeatureFamilyTransformTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/transforms/DeleteFloatFeatureFamilyTransformTest.java
@@ -11,7 +11,9 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class DeleteFloatFeatureFamilyTransformTest {
@@ -22,6 +24,7 @@ public class DeleteFloatFeatureFamilyTransformTest {
     return "test_delete_float_feature_family {\n" +
         " transform: delete_float_feature_family\n" +
         " field1: F1\n" +
+        " fields: [F2, F3]" +
         "}";
   }
 
@@ -36,8 +39,18 @@ public class DeleteFloatFeatureFamilyTransformTest {
     family2.put("C", 3.0);
     family2.put("D", 4.0);
 
+    Map<String, Double> family3 = new HashMap<>();
+    family3.put("E", 5.0);
+    family3.put("F", 6.0);
+
+    Map<String, Double> family4 = new HashMap<>();
+    family4.put("G", 7.0);
+    family4.put("H", 8.0);
+
     floatFeatures.put("F1", family1);
     floatFeatures.put("F2", family2);
+    floatFeatures.put("F3", family3);
+    floatFeatures.put("F4", family4);
 
     FeatureVector featureVector = new FeatureVector();
     featureVector.setFloatFeatures(floatFeatures);
@@ -61,10 +74,21 @@ public class DeleteFloatFeatureFamilyTransformTest {
     Transform transform = TransformFactory.createTransform(
         config, "test_delete_float_feature_family");
     FeatureVector fv = makeFeatureVector();
+
+    assertNotNull(fv.getFloatFeatures());
+    assertTrue(fv.getFloatFeatures().containsKey("F1"));
+    assertTrue(fv.getFloatFeatures().containsKey("F2"));
+    assertTrue(fv.getFloatFeatures().containsKey("F3"));
+    assertTrue(fv.getFloatFeatures().containsKey("F4"));
+    assertEquals(4, fv.getFloatFeatures().size());
+
     transform.doTransform(fv);
 
-    assertTrue(fv.getFloatFeatures() != null);
+    assertNotNull(fv.getFloatFeatures());
     assertFalse(fv.getFloatFeatures().containsKey("F1"));
-    assertTrue(fv.getFloatFeatures().containsKey("F2"));
+    assertFalse(fv.getFloatFeatures().containsKey("F2"));
+    assertFalse(fv.getFloatFeatures().containsKey("F3"));
+    assertTrue(fv.getFloatFeatures().containsKey("F4"));
+    assertEquals(1, fv.getFloatFeatures().size());
   }
 }

--- a/core/src/test/java/com/airbnb/aerosolve/core/transforms/DeleteStringFeatureFamilyTransformTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/transforms/DeleteStringFeatureFamilyTransformTest.java
@@ -28,8 +28,7 @@ public class DeleteStringFeatureFamilyTransformTest {
   public String makeConfig() {
     return "test_delete_string_feature_family {\n" +
         " transform: delete_string_feature_family\n" +
-        " field1: strFeature1\n" +
-        " fields: [strFeature2, strFeature3]\n" +
+        " fields: [strFeature1, strFeature2, strFeature3]\n" +
         "}";
   }
 

--- a/core/src/test/java/com/airbnb/aerosolve/core/transforms/DeleteStringFeatureFamilyTransformTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/transforms/DeleteStringFeatureFamilyTransformTest.java
@@ -20,13 +20,13 @@ import static org.junit.Assert.assertTrue;
 /**
  * Created by christhetree on 1/29/16.
  */
-public class DeleteStringFeatureColumnTransformTest {
+public class DeleteStringFeatureFamilyTransformTest {
   private static final Logger log = LoggerFactory.getLogger(
-      DeleteStringFeatureColumnTransformTest.class);
+      DeleteStringFeatureFamilyTransformTest.class);
 
   public String makeConfig() {
-    return "test_delete_string_feature_column {\n" +
-        " transform: delete_string_feature_column\n" +
+    return "test_delete_string_feature_family {\n" +
+        " transform: delete_string_feature_family\n" +
         " field1: strFeature1\n" +
         "}";
   }
@@ -47,7 +47,7 @@ public class DeleteStringFeatureColumnTransformTest {
   public void testEmptyFeatureVector() {
     Config config = ConfigFactory.parseString(makeConfig());
     Transform transform = TransformFactory.createTransform(
-        config, "test_delete_string_feature_column");
+        config, "test_delete_string_feature_family");
     FeatureVector featureVector = new FeatureVector();
     transform.doTransform(featureVector);
 
@@ -58,7 +58,7 @@ public class DeleteStringFeatureColumnTransformTest {
   public void testTransform() {
     Config config = ConfigFactory.parseString(makeConfig());
     Transform transform = TransformFactory.createTransform(
-        config, "test_delete_string_feature_column");
+        config, "test_delete_string_feature_family");
     FeatureVector featureVector = makeFeatureVector();
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
 

--- a/core/src/test/java/com/airbnb/aerosolve/core/transforms/DeleteStringFeatureFamilyTransformTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/transforms/DeleteStringFeatureFamilyTransformTest.java
@@ -28,15 +28,28 @@ public class DeleteStringFeatureFamilyTransformTest {
     return "test_delete_string_feature_family {\n" +
         " transform: delete_string_feature_family\n" +
         " field1: strFeature1\n" +
+        " fields: [strFeature2, strFeature3]\n" +
         "}";
   }
 
   public FeatureVector makeFeatureVector() {
     Map<String, Set<String>> stringFeatures = new HashMap<>();
 
-    Set list = new HashSet<String>();
-    list.add("I am a string in a string feature");
-    stringFeatures.put("strFeature1", list);
+    Set<String> list1 = new HashSet<>();
+    list1.add("I am a string in string feature 1");
+    stringFeatures.put("strFeature1", list1);
+
+    Set<String> list2 = new HashSet<>();
+    list2.add("I am a string in string feature 2");
+    stringFeatures.put("strFeature2", list2);
+
+    Set<String> list3 = new HashSet<>();
+    list3.add("I am a string in string feature 3");
+    stringFeatures.put("strFeature3", list3);
+
+    Set<String> list4 = new HashSet<>();
+    list4.add("I am a string in string feature 4");
+    stringFeatures.put("strFeature4", list4);
 
     FeatureVector featureVector = new FeatureVector();
     featureVector.setStringFeatures(stringFeatures);
@@ -63,11 +76,17 @@ public class DeleteStringFeatureFamilyTransformTest {
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
 
     assertTrue(stringFeatures.containsKey("strFeature1"));
-    assertEquals(1, stringFeatures.size());
+    assertTrue(stringFeatures.containsKey("strFeature2"));
+    assertTrue(stringFeatures.containsKey("strFeature3"));
+    assertTrue(stringFeatures.containsKey("strFeature4"));
+    assertEquals(4, stringFeatures.size());
 
     transform.doTransform(featureVector);
 
     assertFalse(stringFeatures.containsKey("strFeature1"));
-    assertEquals(0, stringFeatures.size());
+    assertFalse(stringFeatures.containsKey("strFeature2"));
+    assertFalse(stringFeatures.containsKey("strFeature3"));
+    assertTrue(stringFeatures.containsKey("strFeature4"));
+    assertEquals(1, stringFeatures.size());
   }
 }

--- a/core/src/test/java/com/airbnb/aerosolve/core/transforms/DeleteStringFeatureFamilyTransformTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/transforms/DeleteStringFeatureFamilyTransformTest.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -75,6 +76,7 @@ public class DeleteStringFeatureFamilyTransformTest {
     FeatureVector featureVector = makeFeatureVector();
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
 
+    assertNotNull(stringFeatures);
     assertTrue(stringFeatures.containsKey("strFeature1"));
     assertTrue(stringFeatures.containsKey("strFeature2"));
     assertTrue(stringFeatures.containsKey("strFeature3"));
@@ -83,6 +85,7 @@ public class DeleteStringFeatureFamilyTransformTest {
 
     transform.doTransform(featureVector);
 
+    assertNotNull(stringFeatures);
     assertFalse(stringFeatures.containsKey("strFeature1"));
     assertFalse(stringFeatures.containsKey("strFeature2"));
     assertFalse(stringFeatures.containsKey("strFeature3"));

--- a/core/src/test/java/com/airbnb/aerosolve/core/transforms/MoveFloatToStringTransformTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/transforms/MoveFloatToStringTransformTest.java
@@ -17,20 +17,26 @@ import static org.junit.Assert.assertTrue;
 public class MoveFloatToStringTransformTest {
   private static final Logger log = LoggerFactory.getLogger(MoveFloatToStringTransformTest.class);
 
-  public String makeConfig() {
-    return "test_quantize {\n" +
-           " transform : move_float_to_string\n" +
-           " field1 : loc\n" +
-           " bucket : 1\n" +
-           " keys : [lat]\n" +
-           " output : loc_quantized\n" +
-           "}";
+  public String makeConfig(boolean moveAllKeys) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("test_move_float_to_string {\n");
+    sb.append(" transform : move_float_to_string\n");
+    sb.append(" field1 : loc\n");
+    sb.append(" bucket : 1\n");
+
+    if (!moveAllKeys) {
+      sb.append(" keys : [lat]\n");
+    }
+
+    sb.append(" output : loc_quantized\n");
+    sb.append("}");
+    return sb.toString();
   }
   
   @Test
   public void testEmptyFeatureVector() {
-    Config config = ConfigFactory.parseString(makeConfig());
-    Transform transform = TransformFactory.createTransform(config, "test_quantize");
+    Config config = ConfigFactory.parseString(makeConfig(false));
+    Transform transform = TransformFactory.createTransform(config, "test_move_float_to_string");
     FeatureVector featureVector = new FeatureVector();
     transform.doTransform(featureVector);
     assertTrue(featureVector.getStringFeatures() == null);
@@ -38,8 +44,8 @@ public class MoveFloatToStringTransformTest {
 
   @Test
   public void testTransform() {
-    Config config = ConfigFactory.parseString(makeConfig());
-    Transform transform = TransformFactory.createTransform(config, "test_quantize");
+    Config config = ConfigFactory.parseString(makeConfig(false));
+    Transform transform = TransformFactory.createTransform(config, "test_move_float_to_string");
     FeatureVector featureVector = TransformTestingHelper.makeFeatureVector();
     transform.doTransform(featureVector);
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
@@ -51,5 +57,24 @@ public class MoveFloatToStringTransformTest {
       log.info(string);
     }
     assertTrue(out.contains("lat=37.0"));
+  }
+
+  @Test
+  public void testTransformMoveAllKeys() {
+    Config config = ConfigFactory.parseString(makeConfig(true));
+    Transform transform = TransformFactory.createTransform(config, "test_move_float_to_string");
+    FeatureVector featureVector = TransformTestingHelper.makeFeatureVector();
+    transform.doTransform(featureVector);
+    Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
+    assertTrue(stringFeatures.size() == 2);
+    Set<String> out = stringFeatures.get("loc_quantized");
+    assertTrue(out.size() == 3);
+    log.info("quantize output");
+    for (String string : out) {
+      log.info(string);
+    }
+    assertTrue(out.contains("lat=37.0"));
+    assertTrue(out.contains("long=40.0"));
+    assertTrue(out.contains("z=-20.0"));
   }
 }

--- a/core/src/test/java/com/airbnb/aerosolve/core/transforms/NormalizeUtf8TransformTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/transforms/NormalizeUtf8TransformTest.java
@@ -2,7 +2,6 @@ package com.airbnb.aerosolve.core.transforms;
 
 import com.airbnb.aerosolve.core.FeatureVector;
 
-import java.io.UnsupportedEncodingException;
 import java.text.Normalizer;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -16,6 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -24,11 +24,10 @@ import static org.junit.Assert.assertTrue;
 public class NormalizeUtf8TransformTest {
   private static final Logger log = LoggerFactory.getLogger(NormalizeUtf8TransformTest.class);
 
-  public String makeConfigWithoutNormalizationForm() {
+  public String makeConfigWithoutNormalizationFormAndOutput() {
     return "test_normalize_utf_8 {\n" +
         " transform: normalize_utf_8\n" +
         " field1: strFeature1\n" +
-        " output: bar\n" +
         "}";
   }
 
@@ -44,7 +43,7 @@ public class NormalizeUtf8TransformTest {
   public FeatureVector makeFeatureVector() {
     Map<String, Set<String>> stringFeatures = new HashMap<>();
 
-    Set list = new HashSet<String>();
+    Set<String> list = new HashSet<>();
     list.add("Funky string: \u03D3\u03D4\u1E9B");
     stringFeatures.put("strFeature1", list);
 
@@ -55,7 +54,7 @@ public class NormalizeUtf8TransformTest {
 
   @Test
   public void testEmptyFeatureVector() {
-    Config config = ConfigFactory.parseString(makeConfigWithoutNormalizationForm());
+    Config config = ConfigFactory.parseString(makeConfigWithoutNormalizationFormAndOutput());
     Transform transform = TransformFactory.createTransform(config, "test_normalize_utf_8");
     FeatureVector featureVector = new FeatureVector();
     transform.doTransform(featureVector);
@@ -64,17 +63,20 @@ public class NormalizeUtf8TransformTest {
   }
 
   @Test
-  public void testTransformDefaultNormalizationForm() {
-    Config config = ConfigFactory.parseString(makeConfigWithoutNormalizationForm());
+  public void testTransformDefaultNormalizationFormAndOverwriteInput() {
+    Config config = ConfigFactory.parseString(makeConfigWithoutNormalizationFormAndOutput());
     Transform transform = TransformFactory.createTransform(config, "test_normalize_utf_8");
     FeatureVector featureVector = makeFeatureVector();
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
     transform.doTransform(featureVector);
 
-    assertEquals(2, stringFeatures.size());
+    assertNotNull(stringFeatures);
+    assertEquals(1, stringFeatures.size());
 
-    Set<String> output = stringFeatures.get("bar");
+    Set<String> output = stringFeatures.get("strFeature1");
 
+    assertNotNull(output);
+    assertEquals(1, output.size());
     assertTrue(output.contains(Normalizer.normalize(
         "Funky string: \u03D3\u03D4\u1E9B", NormalizeUtf8Transform.DEFAULT_NORMALIZATION_FORM)));
   }
@@ -87,10 +89,13 @@ public class NormalizeUtf8TransformTest {
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
     transform.doTransform(featureVector);
 
+    assertNotNull(stringFeatures);
     assertEquals(2, stringFeatures.size());
 
     Set<String> output = stringFeatures.get("bar");
 
+    assertNotNull(output);
+    assertEquals(1, output.size());
     assertTrue(output.contains("Funky string: \u03D3\u03D4\u1E9B"));
     assertTrue(Normalizer.isNormalized("Funky string: \u03D3\u03D4\u1E9B", Normalizer.Form.NFC));
   }
@@ -103,10 +108,13 @@ public class NormalizeUtf8TransformTest {
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
     transform.doTransform(featureVector);
 
+    assertNotNull(stringFeatures);
     assertEquals(2, stringFeatures.size());
 
     Set<String> output = stringFeatures.get("bar");
 
+    assertNotNull(output);
+    assertEquals(1, output.size());
     assertTrue(output.contains("Funky string: \u03D2\u0301\u03D2\u0308\u017F\u0307"));
     assertTrue(Normalizer.isNormalized(
         "Funky string: \u03D2\u0301\u03D2\u0308\u017F\u0307", Normalizer.Form.NFD));
@@ -120,10 +128,13 @@ public class NormalizeUtf8TransformTest {
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
     transform.doTransform(featureVector);
 
+    assertNotNull(stringFeatures);
     assertEquals(2, stringFeatures.size());
 
     Set<String> output = stringFeatures.get("bar");
 
+    assertNotNull(output);
+    assertEquals(1, output.size());
     assertTrue(output.contains("Funky string: \u038e\u03ab\u1e61"));
     assertTrue(Normalizer.isNormalized("Funky string: \u038e\u03ab\u1e61", Normalizer.Form.NFKC));
   }
@@ -136,10 +147,13 @@ public class NormalizeUtf8TransformTest {
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
     transform.doTransform(featureVector);
 
+    assertNotNull(stringFeatures);
     assertEquals(2, stringFeatures.size());
 
     Set<String> output = stringFeatures.get("bar");
 
+    assertNotNull(output);
+    assertEquals(1, output.size());
     assertTrue(output.contains("Funky string: \u03a5\u0301\u03a5\u0308\u0073\u0307"));
     assertTrue(Normalizer.isNormalized(
         "Funky string: \u03a5\u0301\u03a5\u0308\u0073\u0307", Normalizer.Form.NFKD));

--- a/core/src/test/java/com/airbnb/aerosolve/core/transforms/ReplaceAllStringsTransformTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/transforms/ReplaceAllStringsTransformTest.java
@@ -53,7 +53,7 @@ public class ReplaceAllStringsTransformTest {
   public FeatureVector makeFeatureVector() {
     Map<String, Set<String>> stringFeatures = new HashMap<>();
 
-    Set list = new HashSet<String>();
+    Set<String> list = new HashSet<>();
     list.add("I like blueberry pie, apple pie; and I also like blue!");
     list.add("I'm so  excited: I   like blue!?!!");
     stringFeatures.put("strFeature1", list);

--- a/core/src/test/java/com/airbnb/aerosolve/core/transforms/ReplaceAllStringsTransformTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/transforms/ReplaceAllStringsTransformTest.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -24,7 +25,7 @@ import static org.junit.Assert.assertTrue;
 public class ReplaceAllStringsTransformTest {
   private static final Logger log = LoggerFactory.getLogger(ReplaceAllStringsTransformTest.class);
 
-  public String makeConfig(List<Map<String, String>> replacements) {
+  public String makeConfig(List<Map<String, String>> replacements, boolean overwriteInput) {
     StringBuilder sb = new StringBuilder();
     sb.append("test_replace_all_strings {\n");
     sb.append(" transform: replace_all_strings\n");
@@ -40,7 +41,11 @@ public class ReplaceAllStringsTransformTest {
       }
     }
     sb.append(" ]\n");
-    sb.append(" output: bar\n");
+
+    if (!overwriteInput) {
+      sb.append(" output: bar\n");
+    }
+
     sb.append("}");
     return sb.toString();
   }
@@ -74,7 +79,7 @@ public class ReplaceAllStringsTransformTest {
 
   @Test
   public void testEmptyFeatureVector() {
-    Config config = ConfigFactory.parseString(makeConfig(makeReplacements()));
+    Config config = ConfigFactory.parseString(makeConfig(makeReplacements(), false));
     Transform transform = TransformFactory.createTransform(config, "test_replace_all_strings");
     FeatureVector featureVector = new FeatureVector();
     transform.doTransform(featureVector);
@@ -84,16 +89,38 @@ public class ReplaceAllStringsTransformTest {
 
   @Test
   public void testTransform() {
-    Config config = ConfigFactory.parseString(makeConfig(makeReplacements()));
+    Config config = ConfigFactory.parseString(makeConfig(makeReplacements(), false));
     Transform transform = TransformFactory.createTransform(config, "test_replace_all_strings");
     FeatureVector featureVector = makeFeatureVector();
     transform.doTransform(featureVector);
     Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
 
+    assertNotNull(stringFeatures);
     assertEquals(2, stringFeatures.size());
 
     Set<String> output = stringFeatures.get("bar");
 
+    assertNotNull(output);
+    assertEquals(2, output.size());
+    assertTrue(output.contains("you like blackberry pie, apple pie; and you also like black!"));
+    assertTrue(output.contains("I'm so  excited: you   like black!?!!"));
+  }
+
+  @Test
+  public void testTransformOverwriteInput() {
+    Config config = ConfigFactory.parseString(makeConfig(makeReplacements(), true));
+    Transform transform = TransformFactory.createTransform(config, "test_replace_all_strings");
+    FeatureVector featureVector = makeFeatureVector();
+    transform.doTransform(featureVector);
+    Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
+
+    assertNotNull(stringFeatures);
+    assertEquals(1, stringFeatures.size());
+
+    Set<String> output = stringFeatures.get("strFeature1");
+
+    assertNotNull(output);
+    assertEquals(2, output.size());
     assertTrue(output.contains("you like blackberry pie, apple pie; and you also like black!"));
     assertTrue(output.contains("I'm so  excited: you   like black!?!!"));
   }


### PR DESCRIPTION
to: @asaluja @jq @deerzq 
cc: @hectorgon @yolken 

This PR contains the following improvements and implemented feature requests for several string / NLP related transforms:
- Create abstract StringTransform class for transforms that simply process all strings in a string feature and output a new string transform or overwrite the input string transform (NormalizeUtf8Transform, ConvertStringCaseTransform, ReplaceAllStringsTransform). This reduces unnecessary duplicate code and logic.
- Rename DeleteStringFeatureColumnTransform to DeleteStringFeatureFamilyTransform for consistency and clarity.
- Make specifying keys for the MoveFloatToStringTransform optional in which case all keys are moved. This is necessary for transforms that output float features with an arbitrary amount of different keys (DefaultStringTokenizerTransform does this).
- Make the bigram flag optional in DefaultStringTokenizer in preparation for the ngram transform that will be added soon, at which point the bigram ability of the default string tokenizer transform will become obsolete.
- Add the ability to delete multiple string and float families with the DeleteStringFeatureFamilyTransform and DeleteFloatFeatureFamilyTransform in order to help cut down on the length of NLP related config files.
- Preserving backwards compatibility for all of these changes.
- Updating all related tests for these changes.