### PR TITLE
Be stricter when loading config file and make JobRunner default main class

### DIFF
--- a/training/build.gradle
+++ b/training/build.gradle
@@ -54,6 +54,10 @@ compileScala {
 
 shadowJar {
   zip64 = true
+
+  manifest {
+    attributes 'Main-Class': 'com.airbnb.aerosolve.training.pipeline.JobRunner'
+  }
 }
 
 test {

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/JobRunner.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/JobRunner.scala
@@ -1,26 +1,31 @@
 package com.airbnb.aerosolve.training.pipeline
 
-import org.apache.spark.{SparkContext, SparkConf}
-import org.slf4j.{LoggerFactory, Logger}
-import com.typesafe.config.ConfigFactory
+import java.io.File
+
+import com.typesafe.config.{ConfigFactory, ConfigParseOptions, ConfigResolveOptions}
+import org.apache.spark.{Logging, SparkConf, SparkContext}
 
 import scala.collection.JavaConversions._
 
 /*
  * Entry-point for running the generic pipeline.
  */
-object JobRunner {
+object JobRunner extends Logging {
   def main(args: Array[String]): Unit = {
-    val log: Logger = LoggerFactory.getLogger("Job.Runner")
 
     if (args.length < 1) {
       log.error("Usage: Job.Runner config_name job1,job2...")
       System.exit(-1)
     }
 
-    log.info("Loading config from " + args(0))
-
-    val config = ConfigFactory.load(args(0))
+    val configFile = new File(args(0))
+    val config = if(configFile.exists()) {
+      log.info("Loading config from file: " + args(0))
+      ConfigFactory.load(ConfigFactory.parseFile(configFile))
+    } else {
+      log.info("Loading config using classpath loader: " + args(0))
+      ConfigFactory.load(args(0), ConfigParseOptions.defaults().setAllowMissing(false), ConfigResolveOptions.defaults())
+    }
 
     val jobs : Seq[String] = if (args.length == 1) {
       config.getStringList("jobs")


### PR DESCRIPTION
We have seen cases where config file was not found and config loader fails silently. It will report a specific key not found instead. This confuses users and make them believe wrong keys have been entered in the config file. 
In addition, we have found the way Spark 1.5+ organize driver classpath make config loader no longer search present working directory anymore. While we can work around it with `--driver-classpath .`, if we consider the purpose of generic pipeline being for user not to build the JAR again, making the config loader look on the filesystem by default seems a better solution. 
We have also improved logging so it is explicit about whether the config file is loaded from filesystem or classpath (or not found at all). 


Finally we have made JobRunner the main class of the training JAR, therefore `--class com.airbnb.aerosolve.training.pipeline.JobRunner` is no longer required.

@jq @deerzq @yolken @coleslaw 