### PR TITLE
publish artifacts to bintray from travis upon successful tag builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,17 @@ before_install:
   - wget https://archive.apache.org/dist/thrift/0.9.1/thrift-0.9.1.tar.gz
   - tar xfz thrift-0.9.1.tar.gz
   - cd thrift-0.9.1 && ./configure --without-cpp --without-c_glib --without-python --without-ruby --without-go --without-erlang --without-java && sudo make install && cd ..
+
+# publish artifacts to bintray on tag builds
+after_success:
+  - >
+      test ! "${TRAVIS_TAG}" &&
+      test "${TRAVIS_JDK_VERSION}" = 'oraclejdk8' &&
+      gradle --info bintrayUpload
+
+# environment variables for bintray credentials
+# https://docs.travis-ci.com/user/encryption-keys/
+env:
+  global:
+    - secure: "OVRD2esfT7qMaMpqddaROFSdWZD4HzE9mXxkOH0Kf/8oeyt1m4xEudaF1jB9G0tHIR+WeM/jaBLZv0BMr0Q6V+Goo73070kLy0MgQWGkqoDxjxXLHAqT853AZj5QhNM96+EG5Z5Dty+mYv4W5XRJob9QaWpKVPl3TC3g3ea+ehi2kzyzx98zcfPGfifB5G9yeFHn/mgIl55Y2RNOGVbtu4DInkb2tCn0J1uvJAykG8ANAYYajqA4rpGEq45xUwXBCYnmsn1M1ciqNHP6F/1HvBYSNcGHwVTT4bPChmQ1sqlNlHduPEAiQSCKxndU254Ppp88noIFUdDZA+A5zIaoTVjQ7/ufafxx21JgN3TSe47CCdz21Pl++TNlUP/N5K4rKfr53maN3TJdEc35ox4DqyhjXN4C20W2XCU+SIKnm2ODnFyfZrECnGfVY47f89L4YmapZ7TXmyjk+DHL5ZaaWeVIPgSlQFhb8870ZJ6ksfhAZbGmjk/BpvalAtzS6AjG/dUKQJWeB7KvSnuMkSUsZR3oznm6Bhr5bKf/CdgCuDSeYemYiQ5XsQidI2RuAZ4ljhOuvV6xIHr4zNFSl51O8AViWpm26PkG1x14e4GiHWFmv1uv5ztPUwajCB+UshN4ZPKEKe0IrW3sE7m236UEnVaXf8CnTuB8m9ifebY86+E="
+    - secure: "LAUAtJeLIQ72hmRx+uWEBQ8vRzDL9V3PgY7YF+ofNA0mCkEjlKkvaQjSS5iu1recGvcbqmW/C5BYhZIGRiyOC16au/0uzhIGmBicDnv2TWHzB1cZkYOEpLDAQUInTOv8qykaQtOg+9lDvfCoqMDYW1t9iPvL1sX4r2K67jJCtrOQexguKH67JPJCBX4cigXZpbvdlWZXmvmx3roaEDiuX3ir/nc9rFbvUjE0IqayNiaHsJNA40GMpntZGEuH3KKP4kGXIx7SzZXvCCgH+xYbAMjx2OFgKv/H1nNErE1c/+rUSyBDU6pkqOfvC1nvHdqNzc/B8E4FcP1OfE+IG3AbpG8714/bYrusFQ0t93EenbEuJPO2a0QrC4R10Em7GY5WAl8mo4Dpv8I06YcBKFEHaekXRDRXf99MPLkfTpl17bpuEYHVXJoEgxKqSPkNaCXh0CB9nU3T5HnDgy6jfB/8WNq8dyclc9i9+YRVgTS/SLKAVK4K+lKe8sGzthsFAbA8xIIaiNAYuKFvrUyI2pXLw38x23i8HR9HV7R22clJQLq5gzmqyaDs6omOyi6mJyfCSNYmrbFVq7els3AQKTVcgh/2tj4AXt+fA7S5cy9p/+FIRpRqJh9bJoEL94jMkroosuu0lY0QCadkLWRTdOcNgaYQOexvdYYt3AgjzG5ahXE="

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,10 @@ before_install:
 # publish artifacts to bintray on tag builds
 after_success:
   - >
-      test ! "${TRAVIS_TAG}" &&
+      test "${TRAVIS_TAG}" &&
       test "${TRAVIS_JDK_VERSION}" = 'oraclejdk8' &&
-      gradle --info bintrayUpload
+      gradle --info bintrayUpload &&
+      curl -X POST -H 'Content-type: application/json' --data '{"text":"Aerosolve version ${TRAVIS_TAG} has been <https://travis-ci.org/airbnb/aerosolve/builds/${TRAVIS_BUILD_ID}|built> and published!"}' ${AEROSOLVE_CHANNEL}
 
 # environment variables for bintray credentials
 # https://docs.travis-ci.com/user/encryption-keys/
@@ -32,3 +33,4 @@ env:
   global:
     - secure: "OVRD2esfT7qMaMpqddaROFSdWZD4HzE9mXxkOH0Kf/8oeyt1m4xEudaF1jB9G0tHIR+WeM/jaBLZv0BMr0Q6V+Goo73070kLy0MgQWGkqoDxjxXLHAqT853AZj5QhNM96+EG5Z5Dty+mYv4W5XRJob9QaWpKVPl3TC3g3ea+ehi2kzyzx98zcfPGfifB5G9yeFHn/mgIl55Y2RNOGVbtu4DInkb2tCn0J1uvJAykG8ANAYYajqA4rpGEq45xUwXBCYnmsn1M1ciqNHP6F/1HvBYSNcGHwVTT4bPChmQ1sqlNlHduPEAiQSCKxndU254Ppp88noIFUdDZA+A5zIaoTVjQ7/ufafxx21JgN3TSe47CCdz21Pl++TNlUP/N5K4rKfr53maN3TJdEc35ox4DqyhjXN4C20W2XCU+SIKnm2ODnFyfZrECnGfVY47f89L4YmapZ7TXmyjk+DHL5ZaaWeVIPgSlQFhb8870ZJ6ksfhAZbGmjk/BpvalAtzS6AjG/dUKQJWeB7KvSnuMkSUsZR3oznm6Bhr5bKf/CdgCuDSeYemYiQ5XsQidI2RuAZ4ljhOuvV6xIHr4zNFSl51O8AViWpm26PkG1x14e4GiHWFmv1uv5ztPUwajCB+UshN4ZPKEKe0IrW3sE7m236UEnVaXf8CnTuB8m9ifebY86+E="
     - secure: "LAUAtJeLIQ72hmRx+uWEBQ8vRzDL9V3PgY7YF+ofNA0mCkEjlKkvaQjSS5iu1recGvcbqmW/C5BYhZIGRiyOC16au/0uzhIGmBicDnv2TWHzB1cZkYOEpLDAQUInTOv8qykaQtOg+9lDvfCoqMDYW1t9iPvL1sX4r2K67jJCtrOQexguKH67JPJCBX4cigXZpbvdlWZXmvmx3roaEDiuX3ir/nc9rFbvUjE0IqayNiaHsJNA40GMpntZGEuH3KKP4kGXIx7SzZXvCCgH+xYbAMjx2OFgKv/H1nNErE1c/+rUSyBDU6pkqOfvC1nvHdqNzc/B8E4FcP1OfE+IG3AbpG8714/bYrusFQ0t93EenbEuJPO2a0QrC4R10Em7GY5WAl8mo4Dpv8I06YcBKFEHaekXRDRXf99MPLkfTpl17bpuEYHVXJoEgxKqSPkNaCXh0CB9nU3T5HnDgy6jfB/8WNq8dyclc9i9+YRVgTS/SLKAVK4K+lKe8sGzthsFAbA8xIIaiNAYuKFvrUyI2pXLw38x23i8HR9HV7R22clJQLq5gzmqyaDs6omOyi6mJyfCSNYmrbFVq7els3AQKTVcgh/2tj4AXt+fA7S5cy9p/+FIRpRqJh9bJoEL94jMkroosuu0lY0QCadkLWRTdOcNgaYQOexvdYYt3AgjzG5ahXE="
+    - secure: "hL1dBrlWs9GX/px6cFji1rf7XXRrioiY+ZY4kQ3WP3V0FaWLxaV9l8boPUBP2NbHDm2eMhFO+DYqPWqo9T12PZuPUr6HyRQmHD9U4tpxobdImMx0Q3SkfGbCEHkYrcbLcm+YLfDaS1MfXgkf59WCY0IyIGo0fs5ZwPvTtGnkgniP8wa6NZ/fpaAjQX9TYzbwa+8Yl3cGFcv+Sw47edHQl/TaCLLtox/x8IywvpPMAqZWoved0KyyqxKU7HmK4ZzBAY2kNe8zHBT2gKEEXqQT4yscH51QezkWtDPbTStpXSOi9lIgkV22D0Ms3FwO9xKUe/Kp3MPP+fKijTwT1WFG7pxCIHCeIadvbxooCLN3Vmh0HN+VJr3wcsBL+sENwzIJWO3ugCBZ/RT0Dx22qUOm1nhdpThisIT4CUb/aPCIQiNCxpqhOZIgLFH19WS8o7VFpM2Tn5fCktZcfrmwbF2q0+EO4gDrC0NzNHfKIaLZdD5XmsrPGbPxhPfXhDOhXSJC4ELsq8L17d4PuBugPou3J9JSnuIuRVNcfzDcMmHk+K47519KlsCblOY83XSoWesbbE9YGZAihr9io6gibQIhJScb+dXN+VMARDDrc0shbRmCg8GUlM9tZxnyjkqqi1V+u0dB/P/yMWO4HscYdsKY23xDYFjOhryhDeV2dRbDTvI="

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ after_success:
       test "${TRAVIS_TAG}" &&
       test "${TRAVIS_JDK_VERSION}" = 'oraclejdk8' &&
       gradle --info bintrayUpload &&
-      curl -X POST -H 'Content-type: application/json' --data '{"text":"Aerosolve version ${TRAVIS_TAG} has been <https://travis-ci.org/airbnb/aerosolve/builds/${TRAVIS_BUILD_ID}|built> and published!"}' ${AEROSOLVE_CHANNEL}
+      ./publish-notify.sh
 
 # environment variables for bintray credentials
 # https://docs.travis-ci.com/user/encryption-keys/

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ before_install:
   - tar xfz thrift-0.9.1.tar.gz
   - cd thrift-0.9.1 && ./configure --without-cpp --without-c_glib --without-python --without-ruby --without-go --without-erlang --without-java && sudo make install && cd ..
 
+script:
+  - gradle assemble
+  - test ! "${TRAVIS_TAG}" && gradle check # only run check on non-tag build because of flaky tests
+
 # publish artifacts to bintray on tag builds
 after_success:
   - >

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   }
   dependencies {
     classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
-    classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.2'
+    classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
   }
 }
 
@@ -20,7 +20,6 @@ allprojects {
   apply plugin: 'idea'
   apply plugin: 'eclipse'
   apply plugin: 'com.github.johnrengelman.shadow'
-  apply plugin: 'com.jfrog.bintray'
 
   repositories {
     jcenter()
@@ -36,7 +35,8 @@ allprojects {
   version = globalVersion
   status = version.status
 
-  ext.publish = false
+  ext.publish = true
+  ext.dryRun = false
 
   sourceSets {
       main {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -3,8 +3,8 @@ apply plugin: "java"
 apply plugin: 'com.jfrog.bintray'
 
 bintray {
-  user = bintray_user
-  key = bintray_key
+  user = System.env.BINTRAY_USER ?: bintray_user
+  key = System.env.BINTRAY_KEY ?: bintray_key
   configurations = ['published', 'archives']
   //publications = ['published']
   //filesSpec {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -13,6 +13,8 @@ bintray {
   // rename '(.+)\\.(.+)', '$1-suffix.$2'
   //}
   publish = project.publish
+  dryRun = project.dryRun
+
   pkg {
     repo = 'aerosolve'
     userOrg = 'airbnb'

--- a/publish-notify.sh
+++ b/publish-notify.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+author=`git --no-pager show -s --format='%an' ${TRAVIS_COMMIT}`
+text="{\"text\":\"Aerosolve version ${TRAVIS_TAG} has been <https://travis-ci.org/airbnb/aerosolve/builds/${TRAVIS_BUILD_ID}|built> and published by ${author}!\"}"
+
+curl -s -X POST -H 'Content-type: application/json' --data '$text' ${AEROSOLVE_CHANNEL}

--- a/training/build.gradle
+++ b/training/build.gradle
@@ -3,8 +3,8 @@ apply plugin: "scala"
 
 ext.publish = false
 bintray {
-  user = bintray_user
-  key = bintray_key
+  user = System.env.BINTRAY_USER ?: bintray_user
+  key = System.env.BINTRAY_KEY ?: bintray_key
   configurations = ['published', 'archives']
   //publications = ['published']
   //filesSpec {

--- a/training/build.gradle
+++ b/training/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: "java"
 apply plugin: "scala"
+apply plugin: 'com.jfrog.bintray'
 
 ext.publish = false
 bintray {
@@ -13,6 +14,8 @@ bintray {
   // rename '(.+)\\.(.+)', '$1-suffix.$2'
   //}
   publish = project.publish
+  dryRun = project.dryRun
+
   pkg {
     repo = 'aerosolve'
     userOrg = 'airbnb'


### PR DESCRIPTION
This should remove one (or more) extra manual step when we upgrade Aerosolve version. With this change, once you receive travis build notification on a tag push, you can go straight to bintray and publish the artifacts.
