### PR TITLE
Make Function and AdditiveModel cloneable

### DIFF
--- a/core/src/main/java/com/airbnb/aerosolve/core/function/AbstractFunction.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/function/AbstractFunction.java
@@ -55,4 +55,9 @@ public abstract class AbstractFunction implements Function {
     }
     throw new RuntimeException("no such function " + funcForm.name());
   }
+
+  @Override
+  public AbstractFunction clone() throws CloneNotSupportedException {
+    return (AbstractFunction) super.clone();
+  }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/function/Function.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/function/Function.java
@@ -5,7 +5,7 @@ import com.airbnb.aerosolve.core.ModelRecord;
 import java.io.Serializable;
 import java.util.List;
 
-public interface Function extends Serializable {
+public interface Function extends Serializable, Cloneable {
   // TODO rename numBins to something else, since it's a Spline specific thing
   Function aggregate(Iterable<Function> functions, float scale, int numBins);
 
@@ -27,4 +27,6 @@ public interface Function extends Serializable {
   void resample(int newBins);
 
   void smooth(double tolerance);
+
+  Function clone() throws CloneNotSupportedException;
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/function/Linear.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/function/Linear.java
@@ -120,4 +120,11 @@ public class Linear extends AbstractFunction {
   @Override
   public void smooth(double tolerance) {
   }
+
+  @Override
+  public Linear clone() throws CloneNotSupportedException {
+    Linear copy = (Linear) super.clone();
+    copy.weights = weights.clone();
+    return copy;
+  }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/function/MultiDimensionSpline.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/function/MultiDimensionSpline.java
@@ -234,6 +234,12 @@ public class MultiDimensionSpline implements Function {
     }
   }
 
+  // TODO: this is a shallow copy. implement deep copy if need immutability
+  @Override
+  public MultiDimensionSpline clone() throws CloneNotSupportedException {
+    return (MultiDimensionSpline) super.clone();
+  }
+
   private boolean canDoSmooth() {
     return ndTreeModel.getDimension() == 1;
   }

--- a/core/src/main/java/com/airbnb/aerosolve/core/function/Spline.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/function/Spline.java
@@ -196,4 +196,11 @@ public class Spline extends AbstractFunction {
   public void smooth(double tolerance) {
     FunctionUtil.smooth(tolerance, weights);
   }
+
+  @Override
+  public Spline clone() throws CloneNotSupportedException {
+    Spline copy = (Spline) super.clone();
+    copy.weights = weights.clone();
+    return copy;
+  }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/models/AdditiveModel.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/models/AdditiveModel.java
@@ -23,7 +23,7 @@ import static com.airbnb.aerosolve.core.function.FunctionUtil.toFloat;
 // A generalized additive model with a parametric function per feature.
 // See http://en.wikipedia.org/wiki/Generalized_additive_model
 @Slf4j
-public class AdditiveModel extends AbstractModel {
+public class AdditiveModel extends AbstractModel implements Cloneable {
   public static final String DENSE_FAMILY = "dense";
   @Getter @Setter
   private Map<String, Map<String, Function>> weights = new HashMap<>();
@@ -293,5 +293,34 @@ public class AdditiveModel extends AbstractModel {
         func.LInfinityCap(cap);
       }
     }
+  }
+
+  @Override
+  public AdditiveModel clone() throws CloneNotSupportedException {
+    AdditiveModel copy = (AdditiveModel) super.clone();
+
+    // deep copy weights
+    Map<String, Map<String, Function>> newWeights = new HashMap<>();
+    weights.forEach((k, v) -> newWeights.put(k, copyFeatures(v)));
+    copy.weights = newWeights;
+
+    copy.denseWeights = copyFeatures(denseWeights);
+
+    return copy;
+  }
+
+  private Map<String, Function> copyFeatures(Map<String, Function> featureMap) {
+    if(featureMap == null) return null;
+
+    Map<String, Function> newFeatureMap = new HashMap<>();
+    featureMap.forEach((feature, function) -> {
+      try {
+        newFeatureMap.put(feature, function.clone());
+      } catch (CloneNotSupportedException e) {
+        // Java8 stream does not handle checked exception properly and requires explicit handling
+        e.printStackTrace();
+      }
+    });
+    return newFeatureMap;
   }
 }

--- a/core/src/test/java/com/airbnb/aerosolve/core/function/LinearTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/function/LinearTest.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -14,14 +15,13 @@ import static org.junit.Assert.assertEquals;
  */
 
 public class LinearTest {
-  float func(float x) {
+  private float func(float x) {
     return 0.2f + 1.5f * (x + 6.0f) / 11.0f;
   }
 
-  Linear createLinearTestExample() {
+  private Linear createLinearTestExample() {
     float [] weights = {0.2f, 1.5f};
-    Linear linearFunc = new Linear(-6.0f, 5.0f, weights);
-    return linearFunc;
+    return new Linear(-6.0f, 5.0f, weights);
   }
 
   @Test
@@ -35,7 +35,7 @@ public class LinearTest {
     ModelRecord record = new ModelRecord();
     record.setFeatureFamily("TEST");
     record.setFeatureName("a");
-    List<Double> weightVec = new ArrayList<Double>();
+    List<Double> weightVec = new ArrayList<>();
     weightVec.add(0.2);
     weightVec.add(1.5);
     record.setWeightVector(weightVec);
@@ -72,7 +72,17 @@ public class LinearTest {
     testLinear(linearFunc);
   }
 
-  void testLinear(Linear linearFunc) {
+  @Test
+  public void testLinearClone() throws CloneNotSupportedException {
+    Linear linearFunc = new Linear(-6.0f, 5.0f, new float[2]);
+    Linear linearCopy = linearFunc.clone();
+    linearCopy.setWeights(new float[]{1.0f, 2.0f, 3.0f});
+    assertArrayEquals(linearFunc.weights, new float[2], 0);
+    linearCopy.minVal = 0f;
+    assertEquals(linearFunc.minVal, -6f, 0);
+  }
+
+  private void testLinear(Linear linearFunc) {
     assertEquals(0.2f + 1.5f * 6.0f / 11.0f, linearFunc.evaluate(0.0f), 0.01f);
     assertEquals(0.2f + 1.5f * 7.0f / 11.0f, linearFunc.evaluate(1.0f), 0.01f);
     assertEquals(0.2f + 1.5f * 5.0f / 11.0f, linearFunc.evaluate(-1.0f), 0.01f);

--- a/core/src/test/java/com/airbnb/aerosolve/core/function/SplineTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/function/SplineTest.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -193,5 +194,16 @@ public class SplineTest {
     assertEquals(5.0f * scale, spline2.getWeights()[0], 0.01f);
     assertEquals(10.0f * scale, spline2.getWeights()[1], 0.01f);
     assertEquals(-20.0f * scale, spline2.getWeights()[2], 0.01f);
+  }
+
+  @Test
+  public void testSplineClone() throws CloneNotSupportedException {
+    float[] weights = {5.0f, 10.0f, -20.0f};
+    Spline spline = new Spline(1.0f, 3.0f, weights);
+    Spline splineCopy = spline.clone();
+    splineCopy.resample(2);
+    assertArrayEquals(spline.weights, weights, 0);
+    splineCopy.minVal = 0f;
+    assertEquals(spline.minVal, 1f, 0);
   }
 }

--- a/core/src/test/java/com/airbnb/aerosolve/core/models/AdditiveModelTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/models/AdditiveModelTest.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 /**
@@ -235,5 +236,17 @@ public class AdditiveModelTest {
         }
       }
     }
+  }
+
+  @Test
+  public void testModelClone() throws CloneNotSupportedException {
+    float[] weights = {5.0f, 10.0f, -20.0f};
+    AdditiveModel model = makeAdditiveModel();
+    model.addFunction("spline_float", "aaa", new Spline(2.0f, 10.0f, weights), false);
+
+    AdditiveModel modelClone = model.clone();
+    modelClone.getWeights().get("spline_float").get("aaa").resample(2);
+
+    assertArrayEquals(((Spline)model.getWeights().get("spline_float").get("aaa")).getWeights(), weights, 0);
   }
 }

--- a/training/src/main/scala/com/airbnb/aerosolve/training/AdditiveModelTrainer.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/AdditiveModelTrainer.scala
@@ -137,7 +137,7 @@ object AdditiveModelTrainer {
                    partition: Iterator[Example],
                    modelBC: Broadcast[AdditiveModel],
                    paramsBC: Broadcast[AdditiveTrainerParams]): Iterator[((String, String), Function)] = {
-    val workingModel = modelBC.value
+    val workingModel = modelBC.value.clone()
     val params = paramsBC.value
     val multiscale = params.multiscale
 

--- a/training/src/test/scala/com/airbnb/aerosolve/training/AdditiveModelTrainerTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/AdditiveModelTrainerTest.scala
@@ -56,7 +56,7 @@ class AdditiveModelTrainerTest {
       |  rank_threshold : 0.0
       |  learning_rate : 0.1
       |  num_bins : 16
-      |  iterations : 10
+      |  iterations : 20
       |  smoothing_tolerance : 0.1
       |  linfinity_threshold : 0.01
       |  linfinity_cap : 10.0


### PR DESCRIPTION
Currently AdditiveModel support multiscale sampling and does so by assigning each partition one scale to train model on. Each partition receives the (mutable) model spec/weights via broadcasted variable, which each JVM has one and only one copy. This becomes a problem when each executor has multi-cores and tasks on the same executor work on different partitions/scales. This create a race-condition between executors and leads to ArrayIndexOutOfBound exception.

Even when multiscaling is off, task runner on the same executor will still overwrite each other's weight update and race condition simply gets masked.

We work around this issue by making Function and AdditiveModel cloneable such that a deep copy is made for each partition. In the long run, we should revisit the liberal use of mutable data structure in Aerosolve and possibly adopt a different weights updating scheme.

@jq @deerzq @yolken @timyitong

p.s. Never done Java cloneable before. Please let me know if you have a better idea. (I considered copy constructor and builder pattern but couldn't come up a way to make inheritance work.)