### PR TITLE
fix NDTreeTraining Build Tree.

### DIFF
--- a/core/src/main/java/com/airbnb/aerosolve/core/function/MultiDimensionSpline.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/function/MultiDimensionSpline.java
@@ -8,6 +8,7 @@ import com.airbnb.aerosolve.core.models.NDTreeModel;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 public class MultiDimensionSpline implements Function {
@@ -173,10 +174,8 @@ public class MultiDimensionSpline implements Function {
 
   private List<Double> getWeightsFromList() {
     List<Double> weights = new ArrayList<>(points.size());
-    for (MultiDimensionPoint p: points) {
-
-      weights.add(p.getWeight());
-    }
+    weights.addAll(points.stream().map(
+        MultiDimensionPoint::getWeight).collect(Collectors.toList()));
     return weights;
   }
 

--- a/training/src/main/scala/com/airbnb/aerosolve/training/NDTree.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/NDTree.scala
@@ -200,13 +200,14 @@ object NDTree {
       Split(axisIndex, splitValue, leftIndices, rightIndices)
     } else {
       // if leftIndices empty, find next
+      // median happens to be the min element
       val nextSplitValue = nextGreaterElement(points, rightIndices, axisIndex, splitValue)
       if (nextSplitValue.nonEmpty) {
         val splitValue = nextSplitValue.get
         val (left, right) = filterBySplit(points, indices, axisIndex, splitValue)
         Split(axisIndex, splitValue, left, right)
       } else {
-        // no next greater element, so all points into one leaf node.
+        // no next greater element, so median happens to equal to both mix and max
         Split(0, 0.0, Array(), Array())
       }
     }

--- a/training/src/main/scala/com/airbnb/aerosolve/training/NDTree.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/NDTree.scala
@@ -206,6 +206,7 @@ object NDTree {
       axisIndex: Int): Double = {
     // TODO (christhetree): use median of medians algorithm (quick select) for O(n)
     // performance instead of O(nln(n)) performance
+    // TODO use https://github.com/scalanlp/breeze/blob/master/math/src/test/scala/breeze/util/SelectTest.scala
     val sortedPoints = indices.map(i => points(i)(axisIndex)).sorted
     val length = sortedPoints.length
 

--- a/training/src/test/scala/com/airbnb/aerosolve/training/NDTreeTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/NDTreeTest.scala
@@ -12,6 +12,66 @@ class NDTreeTest {
   val log = LoggerFactory.getLogger("NDTreeTest")
 
   @Test
+  def buildTree1DNotEvenlyDistributed: Unit = {
+    val points = ArrayBuffer[Array[Double]]()
+
+    for (x <- 1 to 20) {
+      for (y <- 1 to x) {
+        points.append(Array[Double](y.toDouble))
+      }
+    }
+
+    val dimensions = points.head.length
+
+    val options = NDTreeBuildOptions(
+      maxTreeDepth = 16,
+      minLeafCount = 10,
+      splitType = SplitType.Median)
+
+    val tree = NDTree(options, points.toArray)
+    val nodes = tree.nodes
+
+    log.info(s"nodes = ${nodes.mkString("\n")}")
+    assertEquals(27, nodes.length)
+    assertEquals(6.5, nodes(0).splitValue, 0)
+    assertEquals(11, nodes(2).splitValue, 0)
+    assertEquals(1.0, nodes(1).min.get(0))
+    assertEquals(6.0, nodes(1).max.get(0))
+    assertEquals(3.0, nodes(4).min.get(0))
+    assertEquals(6.0, nodes(4).max.get(0))
+  }
+
+  @Test
+  def buildTree1DNoNextGreaterElement: Unit = {
+    val points = ArrayBuffer[Array[Double]]()
+
+    for (x <- 1 to 20) {
+      for (y <- (21- x) to 20) {
+        points.append(Array[Double](y.toDouble))
+      }
+    }
+
+    val dimensions = points.head.length
+
+    val options = NDTreeBuildOptions(
+      maxTreeDepth = 16,
+      minLeafCount = 10,
+      splitType = SplitType.Median)
+
+    val tree = NDTree(options, points.toArray)
+    val nodes = tree.nodes
+
+    log.info(s"nodes = ${nodes.mkString("\n")}")
+    assertEquals(29, nodes.length)
+    assertEquals(14.5, nodes(0).splitValue, 0)
+    assertEquals(18, nodes(2).splitValue, 0)
+    assertEquals(1.0, nodes(1).min.get(0))
+    assertEquals(14.0, nodes(1).max.get(0))
+    assertEquals(10.0, nodes(4).min.get(0))
+    assertEquals(14.0, nodes(4).max.get(0))
+  }
+
+  @Test
   def buildTreeUsingMedianTestWithLimitedValues: Unit = {
     val points = ArrayBuffer[Array[Double]]()
 
@@ -76,7 +136,9 @@ class NDTreeTest {
       val res = tree.query(point)
       for (index <- res) {
         for (i <- 0 until dimensions) {
-          assert(point(i) >= nodes(index).min.get(i))
+          log.info(s"i $i p ${point(i)} min ${nodes(index).min.get(i)} ${nodes(index).max.get(i)} index $index")
+          assert(point(i) >= nodes(index).min.get(i),
+            s"i $i p ${point(i)} min ${nodes(index).min.get(i)} index $index ${res.mkString(",")}")
           assert(point(i) <= nodes(index).max.get(i))
         }
       }


### PR DESCRIPTION
NDTreeTraining build wrong tree 
1. not obey min count option, as long as left or right < min count, it stop
2. it may not create bucket evenly if median happens to be the min element.

@deerzq @christhetree @saurfang 