### PR TITLE
add MAP metric

### DIFF
--- a/training/src/main/scala/com/airbnb/aerosolve/training/Evaluation.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/Evaluation.scala
@@ -117,12 +117,19 @@ object Evaluation {
         }
         metrics.append((prefix + "ALL_PAIRS_HINGE_LOSS", (hingeLoss, 1.0)))
         var inTopK = false
+        var nAccurateLabel = 0.0
+        var sumPrecision = 0.0
         for (i <- 0 until sorted.size) {
           if (rec.labels.containsKey(sorted(i)._1)) {
             inTopK = true
+            nAccurateLabel += 1
+            sumPrecision += nAccurateLabel / (i + 1)
             metrics.append((prefix + "MEAN_RECIPROCAL_RANK", (1.0 / (i + 1), 1.0)))
           }
-          metrics.append((prefix + "PRECISION@" + (i + 1), (if (inTopK) 1.0 else 0.0, 1.0)))
+          metrics.append((prefix + "PRECISION@" + (i + 1), (nAccurateLabel / (i + 1), 1.0)))
+          metrics.append((prefix + "ACCURACY@" + (i + 1), (if (inTopK) 1.0 else 0.0, 1.0)))
+          val denoMAP = math.min(rec.labels.size, i + 1)
+          metrics.append((prefix + "MEAN_AVERAGE_PRECISION@" + (i + 1), (sumPrecision / denoMAP, 1.0)))
         }
       }
       metrics

--- a/training/src/test/scala/com/airbnb/aerosolve/training/EvaluationTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/EvaluationTest.scala
@@ -297,15 +297,47 @@ class EvaluationTest {
       try {
         val results = Evaluation.evaluateMulticlassClassification(sc.parallelize(recs)).toMap
         results.foreach(res => log.info("%s = %f".format(res._1, res._2)))
+        val expectedA1 = if (posOfLabel == 0) 1.0 else 0.0
+        val expectedA2 = if (posOfLabel <= 1) 1.0 else 0.0
+        val expectedA3 = 1.0
+
         val expectedP1 = if (posOfLabel == 0) 1.0 else 0.0
-        val expectedP2 = if (posOfLabel <= 1) 1.0 else 0.0
+        val expectedP2 = if (posOfLabel <= 1) 0.5 else 0.0
+        val expectedP3 = 1.0/3
+
+        val expectedMAP1 = if (posOfLabel == 0) 1.0 else 0.0
+        val expectedMAP2 = posOfLabel match {
+          case 0 => 1.0
+          case 1 => 0.5
+          case 2 => 0.0
+        }
+        val expectedMAP3 = posOfLabel match {
+          case 0 => 1.0
+          case 1 => 0.5
+          case 2 => 1.0/3
+        }
+
+        assertEquals(expectedA1, results.getOrElse("TRAIN_ACCURACY@1", 0.0), 0.1)
+        assertEquals(expectedA2, results.getOrElse("TRAIN_ACCURACY@2", 0.0), 0.1)
+        assertEquals(expectedA3, results.getOrElse("TRAIN_ACCURACY@3", 0.0), 0.1)
+        assertEquals(expectedA1, results.getOrElse("HOLD_ACCURACY@1", 0.0), 0.1)
+        assertEquals(expectedA2, results.getOrElse("HOLD_ACCURACY@2", 0.0), 0.1)
+        assertEquals(expectedA3, results.getOrElse("HOLD_ACCURACY@3", 0.0), 0.1)
 
         assertEquals(expectedP1, results.getOrElse("TRAIN_PRECISION@1", 0.0), 0.1)
         assertEquals(expectedP2, results.getOrElse("TRAIN_PRECISION@2", 0.0), 0.1)
-        assertEquals(1.0, results.getOrElse("TRAIN_PRECISION@3", 0.0), 0.1)
+        assertEquals(expectedP3, results.getOrElse("TRAIN_PRECISION@3", 0.0), 0.1)
         assertEquals(expectedP1, results.getOrElse("HOLD_PRECISION@1", 0.0), 0.1)
         assertEquals(expectedP2, results.getOrElse("HOLD_PRECISION@2", 0.0), 0.1)
-        assertEquals(1.0, results.getOrElse("HOLD_PRECISION@3", 0.0), 0.1)
+        assertEquals(expectedP3, results.getOrElse("HOLD_PRECISION@3", 0.0), 0.1)
+
+        assertEquals(expectedMAP1, results.getOrElse("TRAIN_MEAN_AVERAGE_PRECISION@1", 0.0), 0.1)
+        assertEquals(expectedMAP2, results.getOrElse("TRAIN_MEAN_AVERAGE_PRECISION@2", 0.0), 0.1)
+        assertEquals(expectedMAP3, results.getOrElse("TRAIN_MEAN_AVERAGE_PRECISION@3", 0.0), 0.1)
+        assertEquals(expectedMAP1, results.getOrElse("HOLD_MEAN_AVERAGE_PRECISION@1", 0.0), 0.1)
+        assertEquals(expectedMAP2, results.getOrElse("HOLD_MEAN_AVERAGE_PRECISION@2", 0.0), 0.1)
+        assertEquals(expectedMAP3, results.getOrElse("HOLD_MEAN_AVERAGE_PRECISION@3", 0.0), 0.1)
+
         assertEquals(1.0 / (posOfLabel + 1.0), results.getOrElse("TRAIN_MEAN_RECIPROCAL_RANK", 0.0), 0.1)
         assertEquals(1.0 / (posOfLabel + 1.0), results.getOrElse("HOLD_MEAN_RECIPROCAL_RANK", 0.0), 0.1)
         assertTrue(results.getOrElse("TRAIN_ALL_PAIRS_HINGE_LOSS", 0.0) > posOfLabel)


### PR DESCRIPTION
This PR corrects the precision @k metrics for multiclass
It should be defined as the proportion of relevant/correct results in top k. The Mean Average Precision(MAP) metrics is also added.

The current definition of precision @k is still useful but needs to be renamed to something else. Here I rename it to accuracy@k

Test passed

@deerzq @jq @hectorgon 