### PR TITLE
Fix NDTreePipeline

### DIFF
--- a/core/src/main/java/com/airbnb/aerosolve/core/models/AdditiveModel.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/models/AdditiveModel.java
@@ -34,6 +34,9 @@ public class AdditiveModel extends AbstractModel implements Cloneable {
   private Map<String, Function> getOrCreateDenseWeights() {
     if (denseWeights == null) {
       denseWeights = weights.get(DENSE_FAMILY);
+      if (denseWeights == null) {
+        denseWeights = weights.put(DENSE_FAMILY, new HashMap<>());
+      }
     }
     return denseWeights;
   }
@@ -48,7 +51,6 @@ public class AdditiveModel extends AbstractModel implements Cloneable {
     float sum = 0;
     if (denseFeatures != null && !denseFeatures.isEmpty()) {
       Map<String, Function> denseWeights = getOrCreateDenseWeights();
-      if (denseWeights == null) return 0;
       for (Map.Entry<String, List<Double>> feature : denseFeatures.entrySet()) {
         String featureName = feature.getKey();
         Function fun = denseWeights.get(featureName);
@@ -276,15 +278,13 @@ public class AdditiveModel extends AbstractModel implements Cloneable {
     // update with lInfinite cap
     if (denseFeatures != null && !denseFeatures.isEmpty()) {
       Map<String, Function> denseWeights = getOrCreateDenseWeights();
-      if (denseWeights != null) {
-        for (Map.Entry<String, List<Double>> feature : denseFeatures.entrySet()) {
-          String featureName = feature.getKey();
-          Function func = denseWeights.get(featureName);
-          if (func == null) continue;
-          float[] val = FunctionUtil.toFloat(feature.getValue());
-          func.update(-gradWithLearningRate, val);
-          func.LInfinityCap(cap);
-        }
+      for (Map.Entry<String, List<Double>> feature : denseFeatures.entrySet()) {
+        String featureName = feature.getKey();
+        Function func = denseWeights.get(featureName);
+        if (func == null) continue;
+        float[] val = FunctionUtil.toFloat(feature.getValue());
+        func.update(-gradWithLearningRate, val);
+        func.LInfinityCap(cap);
       }
     }
   }

--- a/core/src/main/java/com/airbnb/aerosolve/core/models/AdditiveModel.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/models/AdditiveModel.java
@@ -48,9 +48,11 @@ public class AdditiveModel extends AbstractModel implements Cloneable {
     float sum = 0;
     if (denseFeatures != null && !denseFeatures.isEmpty()) {
       Map<String, Function> denseWeights = getOrCreateDenseWeights();
+      if (denseWeights == null) return 0;
       for (Map.Entry<String, List<Double>> feature : denseFeatures.entrySet()) {
         String featureName = feature.getKey();
         Function fun = denseWeights.get(featureName);
+        if (fun == null) continue;
         sum += fun.evaluate(toFloat(feature.getValue()));
       }
     }

--- a/core/src/main/java/com/airbnb/aerosolve/core/models/NDTreeModel.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/models/NDTreeModel.java
@@ -7,8 +7,6 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -24,7 +22,6 @@ import java.util.Stack;
 @Slf4j
 public class NDTreeModel implements Serializable {
   private static final long serialVersionUID = -2884260218927875615L;
-  private static final Logger log = LoggerFactory.getLogger(NDTreeModel.class);
   public static final int LEAF = -1;
   private static final double NOVALUE = Double.MIN_VALUE;
   private static final int LEFT = 0;

--- a/core/src/main/java/com/airbnb/aerosolve/core/models/NDTreeModel.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/models/NDTreeModel.java
@@ -23,9 +23,6 @@ import java.util.Stack;
 public class NDTreeModel implements Serializable {
   private static final long serialVersionUID = -2884260218927875615L;
   public static final int LEAF = -1;
-  private static final double NOVALUE = Double.MIN_VALUE;
-  private static final int LEFT = 0;
-  private static final int RIGHT = 1;
 
   @Getter
   private final NDTreeNode[] nodes;

--- a/core/src/main/java/com/airbnb/aerosolve/core/models/NDTreeModel.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/models/NDTreeModel.java
@@ -42,6 +42,10 @@ public class NDTreeModel implements Serializable {
     dimension = max + 1;
   }
 
+  public static NDTreeModel getModelWithSplitValueInChildrenNodes(NDTreeNode[] nodes) {
+    updateWithSplitValue(nodes);
+    return new NDTreeModel(nodes);
+  }
   /*
     if min != max, use parent's split value as left child's max
     and right child's min so that left and right share same nodes

--- a/core/src/test/java/com/airbnb/aerosolve/core/models/NDTreeModelTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/models/NDTreeModelTest.java
@@ -13,12 +13,82 @@ import static org.junit.Assert.assertTrue;
 
 public class NDTreeModelTest {
   private static final Logger log = LoggerFactory.getLogger(NDTreeModelTest.class);
+
+  private static NDTreeNode[] getNDTreeNodes2DWithMinMax() {
+    NDTreeNode parent = new NDTreeNode();
+    parent.setAxisIndex(0);
+    parent.setSplitValue(2.0);
+    parent.setLeftChild(1);
+    parent.setRightChild(2);
+    parent.setMin(Arrays.asList(0.0, 0.0));
+    parent.setMax(Arrays.asList(6.0, 6.0));
+
+    NDTreeNode one = new NDTreeNode();
+    one.setAxisIndex(LEAF);
+    one.setMin(Arrays.asList(0.0,0.0));
+    one.setMax(Arrays.asList(1.0,6.0));
+
+    NDTreeNode two = new NDTreeNode();
+    two.setAxisIndex(1);
+    two.setSplitValue(2.0);
+    two.setLeftChild(3);
+    two.setRightChild(4);
+    two.setMin(Arrays.asList(2.5, 0.0));
+    two.setMax(Arrays.asList(6.0, 6.0));
+
+    NDTreeNode three = new NDTreeNode();
+    three.setAxisIndex(LEAF);
+    three.setMin(Arrays.asList(2.5,1.0));
+    three.setMax(Arrays.asList(6.0,1.0));
+
+    NDTreeNode four = new NDTreeNode();
+    four.setAxisIndex(0);
+    four.setSplitValue(4.0);
+    four.setLeftChild(5);
+    four.setRightChild(6);
+    four.setMin(Arrays.asList(2.5,3.0));
+    four.setMax(Arrays.asList(6.0,6.0));
+
+    NDTreeNode five = new NDTreeNode();
+    five.setAxisIndex(LEAF);
+    five.setMin(Arrays.asList(3.0,3.0));
+    five.setMax(Arrays.asList(3.5,3.5));
+
+    NDTreeNode six = new NDTreeNode();
+    six.setAxisIndex(LEAF);
+    six.setMin(Arrays.asList(4.5,4.0));
+    six.setMax(Arrays.asList(6.0,6.0));
+
+    return new NDTreeNode[]{parent, one, two, three, four, five, six};
+  }
+
+  @Test
+  public void updateWithSplitValue() {
+    NDTreeNode[] nodes = getNDTreeNodes2DWithMinMax();
+
+    NDTreeModel.updateWithSplitValue(nodes);
+
+    NDTreeNode[] oldNodes = getNDTreeNodes2DWithMinMax();
+
+    assertEquals(oldNodes[0].max, nodes[0].max);
+    assertEquals(nodes[0].splitValue, nodes[1].getMax().get(0), 0);
+    assertEquals(nodes[0].splitValue, nodes[2].getMin().get(0), 0);
+    assertEquals(2.5, nodes[3].getMin().get(0), 0);
+    assertEquals(1, nodes[3].getMax().get(1), 0);
+    assertEquals(1, nodes[3].getMin().get(1), 0);
+    assertEquals(nodes[2].splitValue, nodes[4].getMin().get(1), 0);
+
+    assertEquals(nodes[4].splitValue, nodes[5].getMax().get(0), 0);
+    assertEquals(nodes[4].splitValue, nodes[6].getMin().get(0), 0);
+    assertEquals(3.0, nodes[5].getMin().get(0), 0);
+  }
+
   //                    4
   //         |--------------- y = 2
   //  1      | 2       3
   //     x = 1
   // total space is from (0,0) to (4,4)
-  public static NDTreeModel getNDTreeModel() {
+  private static NDTreeNode[] getNDTreeNodes2D() {
     NDTreeNode parent = new NDTreeNode();
     parent.setAxisIndex(0);
     parent.setSplitValue(1.0);
@@ -46,8 +116,11 @@ public class NDTreeModelTest {
     four.setMin(Arrays.asList(1.0,2.0));
     four.setMax(Arrays.asList(4.0,4.0));
 
-    NDTreeNode[] arr = {parent, one, two, three, four};
-    return new NDTreeModel(arr);
+    return new NDTreeNode[]{parent, one, two, three, four};
+  }
+
+  public static NDTreeModel getNDTreeModel() {
+    return new NDTreeModel(getNDTreeNodes2D());
   }
 
   public static NDTreeModel getNDTreeModel2DWithSameMinMax() {

--- a/training/src/main/scala/com/airbnb/aerosolve/training/NDTree.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/NDTree.scala
@@ -73,11 +73,11 @@ object NDTree {
 
   def getNextAxis(lastAxis: Int,
                   deltas: Array[Double],
-                  node: NDTreeNode,
+                  root: NDTreeNode,
                   minLeafWidthPercentage: Double):Int = {
     for(i <- 1 to deltas.length) {
       val axis = (lastAxis + i) % deltas.length
-      val rootWidth = node.getMax.get(axis) - node.getMin.get(axis)
+      val rootWidth = root.getMax.get(axis) - root.getMin.get(axis)
       val width = deltas(axis)
       if (rootWidth > 0 && width > 0 &&
           minLeafWidthPercentage * rootWidth <= width) {
@@ -121,6 +121,7 @@ object NDTree {
       val deltas = getDeltas(bounds)
 
       // TODO Choose axisIndex with largest corresponding delta as option: deltas.zipWithIndex.maxBy(_._1)._2
+      // there is no pop in buildTreeRecursive, so nodes(0) is always the root
       val axisIndex:Int = getNextAxis(lastAxis, deltas, nodes(0), options.minLeafWidthPercentage)
       if (axisIndex == NOAXIS) {
         makeLeaf = true

--- a/training/src/main/scala/com/airbnb/aerosolve/training/NDTree.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/NDTree.scala
@@ -171,7 +171,7 @@ object NDTree {
 
   private def areBoundsOverlapping(bounds: Bounds): Boolean = {
     // for multi-dimension all bounds overlapping means overlapping.
-    bounds.minima.zip(bounds.maxima).exists((bound: (Double, Double)) => {
+    bounds.minima.zip(bounds.maxima).forall((bound: (Double, Double)) => {
       bound._1 >= bound._2
     })
   }

--- a/training/src/main/scala/com/airbnb/aerosolve/training/NDTree.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/NDTree.scala
@@ -20,7 +20,7 @@ object SplitType extends Enumeration {
 object NDTree {
   val log = LoggerFactory.getLogger("NDTree")
   val splitUsingSurfaceAreaMaxCount = 10
-  val NOAXIS = -1
+  val NO_AXIS = -1
 
   val defaultOneDimensionalSplitType = SplitType.Median
   val defaultMultiDimensionalSplitType = SplitType.SurfaceArea
@@ -66,9 +66,7 @@ object NDTree {
       nodes.append(node)
       buildTreeRecursive(options, points, -1, indices, nodes, node, 1, splitType)
     }
-    val ndtreeNodes = nodes.toArray
-    NDTreeModel.updateWithSplitValue(ndtreeNodes)
-    val tree = new NDTree(ndtreeNodes)
+    val tree = new NDTree(nodes.toArray)
     tree
   }
 
@@ -85,7 +83,7 @@ object NDTree {
         return axis
       }
     }
-    NOAXIS
+    NO_AXIS
   }
 
   private def buildTreeRecursive(
@@ -103,8 +101,8 @@ object NDTree {
 
     // Determine the min and max dimensions of the active set
     val bounds = getBounds(points, indices)
-    node.setMin(bounds.minima.map(java.lang.Double.valueOf).toList.asJava)
-    node.setMax(bounds.maxima.map(java.lang.Double.valueOf).toList.asJava)
+    node.setMin(bounds.minima.map(java.lang.Double.valueOf).toBuffer.asJava)
+    node.setMax(bounds.maxima.map(java.lang.Double.valueOf).toBuffer.asJava)
 
     var makeLeaf = false
 
@@ -124,7 +122,7 @@ object NDTree {
       // TODO Choose axisIndex with largest corresponding delta as option: deltas.zipWithIndex.maxBy(_._1)._2
       // there is no pop in buildTreeRecursive, so nodes(0) is always the root
       val axisIndex:Int = getNextAxis(lastAxis, deltas, nodes(0), options.minLeafWidthPercentage)
-      if (axisIndex == NOAXIS) {
+      if (axisIndex == NO_AXIS) {
         makeLeaf = true
       } else {
         val split = splitType match {
@@ -323,7 +321,7 @@ object NDTree {
 }
 
 class NDTree(val nodes: Array[NDTreeNode]) extends Serializable {
-  val model = new NDTreeModel(nodes)
+  val model = NDTreeModel.getModelWithSplitValueInChildrenNodes(nodes)
 
   // Returns the indices of nodes traversed to get to the leaf containing the point.
   def query(point: Array[Double]): Array[Int] = {

--- a/training/src/main/scala/com/airbnb/aerosolve/training/NDTree.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/NDTree.scala
@@ -27,6 +27,8 @@ object NDTree {
   case class NDTreeBuildOptions(
       maxTreeDepth: Int,
       minLeafCount: Int,
+      // (leaf's max - min)/(root's max - min)
+      minLeafWidthPercentage: Double,
       splitType: SplitType.Value = SplitType.Unspecified)
 
   private case class Bounds(minima: Array[Double], maxima: Array[Double])

--- a/training/src/main/scala/com/airbnb/aerosolve/training/NDTree.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/NDTree.scala
@@ -66,8 +66,9 @@ object NDTree {
       nodes.append(node)
       buildTreeRecursive(options, points, -1, indices, nodes, node, 1, splitType)
     }
-
-    val tree = new NDTree(nodes.toArray)
+    val ndtreeNodes = nodes.toArray
+    NDTreeModel.updateWithSplitValue(ndtreeNodes)
+    val tree = new NDTree(ndtreeNodes)
     tree
   }
 

--- a/training/src/main/scala/com/airbnb/aerosolve/training/NDTree.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/NDTree.scala
@@ -321,6 +321,7 @@ object NDTree {
 }
 
 class NDTree(val nodes: Array[NDTreeNode]) extends Serializable {
+  // TODO add option to control when to use split value
   val model = NDTreeModel.getModelWithSplitValueInChildrenNodes(nodes)
 
   // Returns the indices of nodes traversed to get to the leaf containing the point.

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/NDTreePipeline.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/NDTreePipeline.scala
@@ -148,11 +148,13 @@ object NDTreePipeline {
         val result: ((String, String), Either[NDTreeModel, FeatureStats]) = a match {
           case Left(y) => {
             // build tree
+            // FloatToDense transform make sure all array in y are same size.
+            // so we just pick first one to get the dimension
             val dimension = y(0).length
             val minLeafWidthPercentage: Double = if (dimension == 1) {
-              1/(2 ^ paramsBC.value.maxTreeDepth1Dimension)
+              1.0/(2 ^ paramsBC.value.maxTreeDepth1Dimension)
             } else {
-              1/(2 ^ paramsBC.value.maxTreeDepth1Dimension)
+              1.0/(2 ^ paramsBC.value.maxTreeDepth1Dimension)
             }
             val options = NDTreeBuildOptions(
               math.max(paramsBC.value.maxTreeDepth1Dimension,

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/NDTreePipeline.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/NDTreePipeline.scala
@@ -25,7 +25,9 @@ object NDTreePipeline {
                                   minCount: Int,
                                   linearFeatureFamilies: util.List[String],
                                   checkPointDir: String,
-                                  options: NDTreeBuildOptions,
+                                  maxTreeDepth1Dimension: Int,
+                                  maxTreeDepthPerDimension: Int,
+                                  minLeafCount: Int,
                                   maxMinLeafNodesDivByStd: Double)
 
   case class FeatureStats(count: Double, min: Double, max: Double,
@@ -39,7 +41,9 @@ object NDTreePipeline {
       output:  ${feature_map}
       sample: 0.01
       min_count: 200
-      max_tree_depth: 7  ( max nodes could be 2^(max_tree_depth-1) )
+      // max_tree_depth = max(max_tree_depth_1_dimension, max_tree_depth_per_dimension * dimension)
+      max_tree_depth_1_dimension: 7  ( max nodes could be 2^(max_tree_depth) )
+      max_tree_depth_per_dimension: 4
       min_leaf_count: 200
       // feature families in linear_feature should use linear
       linear_feature: ["L", "T", "L_x_T"]
@@ -70,9 +74,10 @@ object NDTreePipeline {
     val linearFeatureFamilies: java.util.List[String] = Try(cfg.getStringList("linear_feature"))
       .getOrElse[java.util.List[String]](List.empty.asJava)
     val checkPointDir = Try(cfg.getString("check_point_dir")).getOrElse("")
-    val options = NDTreeBuildOptions(
-      maxTreeDepth = cfg.getInt("max_tree_depth"),
-      minLeafCount = cfg.getInt("min_leaf_count"))
+    val maxTreeDepth1Dimension = cfg.getInt("max_tree_depth_1_dimension")
+    val maxTreeDepthPerDimension = cfg.getInt("max_tree_depth_per_dimension")
+    val minLeafCount = cfg.getInt("min_leaf_count")
+
     val maxMinLeafNodesDivByStd:Double =
       Try(cfg.getDouble("max_min_leaf_nodes_count_div_by_std")).
       getOrElse(0)
@@ -81,7 +86,9 @@ object NDTreePipeline {
       cfg.getInt("min_count"),
       linearFeatureFamilies,
       checkPointDir,
-      options,
+      maxTreeDepth1Dimension,
+      maxTreeDepthPerDimension,
+      minLeafCount,
       maxMinLeafNodesDivByStd)
   }
 
@@ -141,7 +148,12 @@ object NDTreePipeline {
         val result: ((String, String), Either[NDTreeModel, FeatureStats]) = a match {
           case Left(y) => {
             // build tree
-            val model = NDTree(paramsBC.value.options, y.toArray).model
+            val options = NDTreeBuildOptions(
+              math.max(paramsBC.value.maxTreeDepth1Dimension,
+                paramsBC.value.maxTreeDepthPerDimension * y(0).length),
+                paramsBC.value.minLeafCount)
+
+            val model = NDTree(options, y.toArray).model
             val maxValue = paramsBC.value.maxMinLeafNodesDivByStd
             if (maxValue > 0) {
               if (model.canReplaceBySpline(maxValue)) {

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/NDTreePipeline.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/NDTreePipeline.scala
@@ -42,7 +42,7 @@ object NDTreePipeline {
       sample: 0.01
       min_count: 200
       // max_tree_depth = max(max_tree_depth_1_dimension, max_tree_depth_per_dimension * dimension)
-      max_tree_depth_1_dimension: 6  ( max nodes could be 2^(max_tree_depth) )
+      max_tree_depth_1_dimension: 6  ( max nodes could be 2^(max_tree_depth) - 1 )
       max_tree_depth_per_dimension: 4
       min_leaf_count: 200
       // feature families in linear_feature should use linear

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/NDTreePipeline.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/NDTreePipeline.scala
@@ -42,7 +42,7 @@ object NDTreePipeline {
       sample: 0.01
       min_count: 200
       // max_tree_depth = max(max_tree_depth_1_dimension, max_tree_depth_per_dimension * dimension)
-      max_tree_depth_1_dimension: 7  ( max nodes could be 2^(max_tree_depth) )
+      max_tree_depth_1_dimension: 6  ( max nodes could be 2^(max_tree_depth) )
       max_tree_depth_per_dimension: 4
       min_leaf_count: 200
       // feature families in linear_feature should use linear
@@ -148,10 +148,17 @@ object NDTreePipeline {
         val result: ((String, String), Either[NDTreeModel, FeatureStats]) = a match {
           case Left(y) => {
             // build tree
+            val dimension = y(0).length
+            val minLeafWidthPercentage: Double = if (dimension == 1) {
+              1/(2 ^ paramsBC.value.maxTreeDepth1Dimension)
+            } else {
+              1/(2 ^ paramsBC.value.maxTreeDepth1Dimension)
+            }
             val options = NDTreeBuildOptions(
               math.max(paramsBC.value.maxTreeDepth1Dimension,
-                paramsBC.value.maxTreeDepthPerDimension * y(0).length),
-                paramsBC.value.minLeafCount)
+                paramsBC.value.maxTreeDepthPerDimension * dimension),
+                paramsBC.value.minLeafCount,
+                minLeafWidthPercentage)
 
             val model = NDTree(options, y.toArray).model
             val maxValue = paramsBC.value.maxMinLeafNodesDivByStd

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/NDTreePipeline.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/NDTreePipeline.scala
@@ -41,7 +41,7 @@ object NDTreePipeline {
       output:  ${feature_map}
       sample: 0.01
       min_count: 200
-      // max_tree_depth = max(max_tree_depth_1_dimension, max_tree_depth_per_dimension * dimension)
+      // max_tree_depth = max(max_tree_depth_1_dimension, max_tree_depth_per_dimension * dimension + 1)
       max_tree_depth_1_dimension: 6  ( max nodes could be 2^(max_tree_depth) - 1 )
       max_tree_depth_per_dimension: 4
       min_leaf_count: 200
@@ -158,7 +158,7 @@ object NDTreePipeline {
             }
             val options = NDTreeBuildOptions(
               math.max(paramsBC.value.maxTreeDepth1Dimension,
-                paramsBC.value.maxTreeDepthPerDimension * dimension),
+                paramsBC.value.maxTreeDepthPerDimension * dimension + 1),
                 paramsBC.value.minLeafCount,
                 minLeafWidthPercentage)
 

--- a/training/src/test/scala/com/airbnb/aerosolve/training/NDTreeTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/NDTreeTest.scala
@@ -1,5 +1,6 @@
 package com.airbnb.aerosolve.training
 
+import com.airbnb.aerosolve.core.NDTreeNode
 import com.airbnb.aerosolve.core.models.NDTreeModel
 import com.airbnb.aerosolve.training.NDTree.NDTreeBuildOptions
 import org.junit.Assert.assertEquals
@@ -20,6 +21,22 @@ class NDTreeTest {
       }
     }
     points
+  }
+
+  @Test
+  def getNextAxis: Unit = {
+    val node = new NDTreeNode()
+    node.setMax(java.util.Arrays.asList(5.0, 8.0, 10.0))
+    node.setMin(java.util.Arrays.asList(5.0, 6.0, 1.0))
+
+    val deltas: Array[Double] = Array(0, 1, 5)
+
+    assertEquals(1, NDTree.getNextAxis(-1, deltas, node, 0))
+    assertEquals(NDTree.NOAXIS, NDTree.getNextAxis(-1, deltas, node, 0.6))
+    assertEquals(1, NDTree.getNextAxis(0, deltas, node, 0))
+    assertEquals(2, NDTree.getNextAxis(1, deltas, node, 0))
+    assertEquals(1, NDTree.getNextAxis(2, deltas, node, 0))
+    assertEquals(NDTree.NOAXIS, NDTree.getNextAxis(2, Array(0), node, 0))
   }
 
   @Test
@@ -155,10 +172,10 @@ class NDTreeTest {
     val nodes = tree.nodes
 
     log.info("Number of nodes = %d".format(nodes.length))
+    log.debug(s"nodes = ${nodes.mkString("\n")}")
 
-    // Since the y dimension is largest, we expect the first node to be a split along the y axis
-    assertEquals(1, nodes(0).axisIndex)
-    assertEquals(21.0, nodes(0).splitValue, 0)
+    assertEquals(0, nodes(0).axisIndex)
+    assertEquals(2.0, nodes(0).splitValue, 0)
     assertEquals(1, nodes(0).leftChild)
     assertEquals(2, nodes(0).rightChild)
 
@@ -214,7 +231,6 @@ class NDTreeTest {
 
     log.info("Number of nodes = %d".format(nodes.length))
 
-    // Since the x dimension is largest, we expect the first node to be a split along the x axis
     assertEquals(0, nodes(0).axisIndex)
     assertEquals(-1.81, nodes(0).splitValue, 0.1)
     assertEquals(1, nodes(0).leftChild)

--- a/training/src/test/scala/com/airbnb/aerosolve/training/NDTreeTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/NDTreeTest.scala
@@ -32,11 +32,11 @@ class NDTreeTest {
     val deltas: Array[Double] = Array(0, 1, 5)
 
     assertEquals(1, NDTree.getNextAxis(-1, deltas, node, 0))
-    assertEquals(NDTree.NOAXIS, NDTree.getNextAxis(-1, deltas, node, 0.6))
+    assertEquals(NDTree.NO_AXIS, NDTree.getNextAxis(-1, deltas, node, 0.6))
     assertEquals(1, NDTree.getNextAxis(0, deltas, node, 0))
     assertEquals(2, NDTree.getNextAxis(1, deltas, node, 0))
     assertEquals(1, NDTree.getNextAxis(2, deltas, node, 0))
-    assertEquals(NDTree.NOAXIS, NDTree.getNextAxis(2, Array(0), node, 0))
+    assertEquals(NDTree.NO_AXIS, NDTree.getNextAxis(2, Array(0), node, 0))
   }
 
   @Test

--- a/training/src/test/scala/com/airbnb/aerosolve/training/NDTreeTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/NDTreeTest.scala
@@ -59,7 +59,7 @@ class NDTreeTest {
     assertEquals(6.5, nodes(0).splitValue, 0)
     assertEquals(11, nodes(2).splitValue, 0)
     assertEquals(1.0, nodes(1).min.get(0))
-    assertEquals(6.0, nodes(1).max.get(0))
+    assertEquals(6.5, nodes(1).max.get(0))
     assertEquals(-1, nodes(4).axisIndex)
     assertEquals(3.0, nodes(4).min.get(0))
     assertEquals(6.0, nodes(4).max.get(0))
@@ -84,7 +84,7 @@ class NDTreeTest {
     assertEquals(6.5, nodes(0).splitValue, 0)
     assertEquals(11, nodes(2).splitValue, 0)
     assertEquals(1.0, nodes(1).min.get(0))
-    assertEquals(6.0, nodes(1).max.get(0))
+    assertEquals(6.5, nodes(1).max.get(0))
     assertEquals(3.0, nodes(4).min.get(0))
     assertEquals(6.0, nodes(4).max.get(0))
   }
@@ -114,7 +114,7 @@ class NDTreeTest {
     assertEquals(14.5, nodes(0).splitValue, 0)
     assertEquals(18, nodes(2).splitValue, 0)
     assertEquals(1.0, nodes(1).min.get(0))
-    assertEquals(14.0, nodes(1).max.get(0))
+    assertEquals(14.5, nodes(1).max.get(0))
     assertEquals(10.0, nodes(4).min.get(0))
     assertEquals(14.0, nodes(4).max.get(0))
   }
@@ -128,8 +128,6 @@ class NDTreeTest {
           points.append(Array[Double](y.toDouble))
         }
     }
-
-    val dimensions = points.head.length
 
     val options = NDTreeBuildOptions(
       maxTreeDepth = 16,

--- a/training/src/test/scala/com/airbnb/aerosolve/training/NDTreeTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/NDTreeTest.scala
@@ -3,8 +3,8 @@ package com.airbnb.aerosolve.training
 import com.airbnb.aerosolve.core.NDTreeNode
 import com.airbnb.aerosolve.core.models.NDTreeModel
 import com.airbnb.aerosolve.training.NDTree.NDTreeBuildOptions
-import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.junit.Assert._
 import org.slf4j.LoggerFactory
 
 import scala.collection.mutable.ArrayBuffer
@@ -31,12 +31,12 @@ class NDTreeTest {
 
     val deltas: Array[Double] = Array(0, 1, 5)
 
-    assertEquals(1, NDTree.getNextAxis(-1, deltas, node, 0))
-    assertEquals(NDTree.NO_AXIS, NDTree.getNextAxis(-1, deltas, node, 0.6))
-    assertEquals(1, NDTree.getNextAxis(0, deltas, node, 0))
-    assertEquals(2, NDTree.getNextAxis(1, deltas, node, 0))
-    assertEquals(1, NDTree.getNextAxis(2, deltas, node, 0))
-    assertEquals(NDTree.NO_AXIS, NDTree.getNextAxis(2, Array(0), node, 0))
+    assertEquals(1, NDTree.getNextAxis(-1, deltas, node, 0).get)
+    assertTrue(NDTree.getNextAxis(-1, deltas, node, 0.6).isEmpty)
+    assertEquals(1, NDTree.getNextAxis(0, deltas, node, 0).get)
+    assertEquals(2, NDTree.getNextAxis(1, deltas, node, 0).get)
+    assertEquals(1, NDTree.getNextAxis(2, deltas, node, 0).get)
+    assertTrue(NDTree.getNextAxis(2, Array(0), node, 0).isEmpty)
   }
 
   @Test

--- a/training/src/test/scala/com/airbnb/aerosolve/training/NDTreeTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/NDTreeTest.scala
@@ -261,4 +261,38 @@ class NDTreeTest {
       }
     }
   }
+
+  @Test
+  def buildTreeUsingMedianTestFullSettings: Unit = {
+    val points = ArrayBuffer[Array[Double]]()
+
+    for (x <- -2 to 6) {
+      for (y <- 1 to 41) {
+        for (z <- 3 to 18) {
+          points.append(Array[Double](x.toDouble, y.toDouble, z.toDouble))
+        }
+      }
+    }
+
+    val dimensions = points.head.length
+
+    val options = NDTreeBuildOptions(
+      maxTreeDepth = 6,
+      minLeafCount = 30,
+      minLeafWidthPercentage = 0.05,
+      splitType = SplitType.Median)
+
+    val tree = NDTree(options, points.toArray)
+    val nodes = tree.nodes
+
+    log.info("Number of nodes = %d".format(nodes.length))
+    log.info(s"nodes = ${nodes.mkString("\n")}")
+
+    assertEquals(0, nodes(0).axisIndex)
+    assertEquals(2.0, nodes(0).splitValue, 0)
+    assertEquals(1, nodes(0).leftChild)
+    assertEquals(2, nodes(0).rightChild)
+    assertEquals(10.5, nodes(8).splitValue, 0)
+  }
+
 }


### PR DESCRIPTION
1. make sure no dense function won't crash
2. use order of element in the point array as the axis order, oder by largest corresponding delta is copy from KDTree, only make sense if features are same, if features are different, it could result only cut in feature with bigger width. 
3. able to set different size for different dimension
4. add minLeafWidthPercentage, if leaf width is < this number, make it a leaf. this is to reduce number of leaves for highly uneven data.
5. update children's min/max according to parent's split value, this is to share more nodes in Multi-dimension spline.

@deerzq @christhetree @saurfang 