### PR TITLE
Infer version from git tag/describe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,9 @@ out/
 # NetBeans
 .nb-gradle/
 .solano*
+
+gradle/
+metastore_db/
+derby.log
+demo/income_prediction/output
+demo/income_prediction/src/main/resources/adult.*

--- a/build.gradle
+++ b/build.gradle
@@ -13,10 +13,6 @@ buildscript {
   }
 }
 
-import java.text.SimpleDateFormat
-
-def globalVersion = new Version(currentVersion)
-
 allprojects {
   apply plugin: 'java'
   apply plugin: 'idea'
@@ -84,35 +80,5 @@ subprojects {
             published sourceJar
             published javadocJar
         }
-    }
-}
-
-class Version {
-    String originalVersion
-    String thisVersion
-    String status
-    Date buildTime
-
-    Version(String versionValue) {
-        buildTime = new Date()
-        originalVersion = versionValue
-        if (originalVersion.endsWith('-SNAPSHOT')) {
-            status = 'integration'
-            thisVersion = originalVersion.substring(0, originalVersion.length() - 'SNAPSHOT'.length()) + getTimestamp()
-        } else {
-            status = 'release'
-            thisVersion = versionValue
-        }
-    }
-
-    String getTimestamp() {
-        // Convert local file timestamp to UTC
-        def format = new SimpleDateFormat('yyyyMMddHHmmss')
-        format.setCalendar(Calendar.getInstance(TimeZone.getTimeZone('UTC')));
-        return format.format(buildTime)
-    }
-
-    String toString() {
-        thisVersion
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,12 @@ apply plugin: 'wrapper'
 buildscript {
   repositories {
     jcenter()
+    maven { url "https://plugins.gradle.org/m2/" }
   }
   dependencies {
     classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
     classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
+    classpath 'gradle.plugin.com.palantir.gradle.gitversion:gradle-git-version:0.5.2'
   }
 }
 
@@ -20,6 +22,7 @@ allprojects {
   apply plugin: 'idea'
   apply plugin: 'eclipse'
   apply plugin: 'com.github.johnrengelman.shadow'
+  apply plugin: 'com.palantir.git-version'
 
   repositories {
     jcenter()
@@ -32,8 +35,7 @@ allprojects {
   }
 
   group = 'com.airbnb.aerosolve'
-  version = globalVersion
-  status = version.status
+  version gitVersion()
 
   ext.publish = true
   ext.dryRun = false

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -19,7 +19,7 @@ bintray {
     repo = 'aerosolve'
     userOrg = 'airbnb'
     name = 'aerosolve-core'
-    desc = 'Aerosolve machine learning library'
+    desc = 'Aerosolve machine learning library core module'
     websiteUrl = 'https://github.com/airbnb/aerosolve'
     issueTrackerUrl = 'https://github.com/airbnb/aerosolve/issues'
     vcsUrl = 'https://github.com/airbnb/aerosolve.git'
@@ -27,10 +27,6 @@ bintray {
     labels = ['machine learning', 'spark', 'scala']
     attributes= ['plat': ['linux', 'osx']]
     publicDownloadNumbers = true
-    version {
-      name = currentVersion
-      desc = 'Aerosolve core library'
-    }
   }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
-currentVersion=0.1.68
 bintray_user=fake_user
 bintray_key=fake_key

--- a/training/build.gradle
+++ b/training/build.gradle
@@ -27,10 +27,6 @@ bintray {
     labels = ['machine learning', 'spark', 'scala']
     attributes= ['plat': ['linux', 'osx']]
     publicDownloadNumbers = true
-    version {
-      name = currentVersion
-      desc = 'Aerosolve training library'
-    }
   }
 }
 


### PR DESCRIPTION
This changes the published version of Aersolve to be inferred via Git tag. The primary motivation is that it will attached Git commit (and optionally `.dirty` if working copy is dirty) to the end of version string and mark the status as integration. This would allow us to published locally and test the implementation without publishing artifacts to Bintray.

The side effect is that we will need to look directly at Git tag when tagging new version (versus the version is documented in `gradle.properties`. You can also do:
```
$ gradlew :core:printVersion
:core:printVersion
0.1.67-3-g3e1e48e
```
which would indicate last Git tag is `0.1.67`. If this is acceptable, we can merge it and I will update documentation on how to publish and test Aerosolve locally.

@jq @deerzq @spencerde @yolken 