### PR TITLE
Support CSV data sources in GenericPipeline

### DIFF
--- a/training/build.gradle
+++ b/training/build.gradle
@@ -35,6 +35,7 @@ dependencies {
   compile 'com.fasterxml.jackson.module:jackson-module-scala_2.10:2.4.2'
   compile 'joda-time:joda-time:2.5'
   compile 'org.apache.hadoop:hadoop-client:2.2.0'
+  compile 'com.databricks:spark-csv_2.10:1.4.0'
 
   provided 'org.apache.spark:spark-core_2.10:1.5.2'
   provided 'org.apache.spark:spark-hive_2.10:1.5.2'

--- a/training/src/main/resources/demo_train.conf
+++ b/training/src/main/resources/demo_train.conf
@@ -57,6 +57,23 @@ generic_hive_query : """
     hours_per_week as i_hours,
     native_country as s_country
 """
+# To use a CSV as a data source instead of Hive, create a temporary table using the
+# databricks spark-csv library and then write a query against that table. Here's an example:
+#
+#  create temporary table tmp_income_training
+#  using com.databricks.spark.csv
+#  options (
+#  path          "file:///home/my_username/my_data_file.csv",
+#  header        "true",
+#  inferSchema   "true"
+#  );
+#  select
+#    if(LENGTH(label)=5, -1, 1) as LABEL,
+#    age as i_age,
+#    workclass as s_workclass, fnlwgt as s_fnlwgt,
+#    education as s_education,
+#    ...
+#  from tmp_income_training;
 
 debug_example {
   hive_query : ${generic_hive_query}" from "${demo_table}
@@ -222,6 +239,7 @@ forest_model_config {
   trainer : "forest"
   model_output : ${model_name}
   rank_key : "LABEL"
+  loss : "gini",
   rank_threshold : 0.5
   # How many trees
   num_trees : 100

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/GenericPipeline.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/GenericPipeline.scala
@@ -16,6 +16,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.hive.HiveContext
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.SQLContext
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.JavaConversions._
@@ -507,8 +508,12 @@ object GenericPipeline {
       sc: SparkContext,
       query: String,
       isMulticlass: Boolean = false): RDD[Example] = {
-    val hc = new HiveContext(sc)
-    val hiveTraining = hc.sql(query)
+    val sqlContext = new SQLContext(sc)
+
+    //val hc = new HiveContext(sc)
+    //val hiveTraining = hc.sql(query)
+    val hiveTraining = sqlContext.sql(query)
+
     val schema: Array[StructField] = hiveTraining.schema.fields.toArray
 
     hiveTraining

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/GenericPipeline.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/GenericPipeline.scala
@@ -341,9 +341,7 @@ object GenericPipeline {
     val isMulticlass = Try(cfg.getBoolean("is_multiclass")).getOrElse(false)
 
     val (model, transformer) = getModelAndTransform(config, modelCfgName, modelName)
-
-    val hc = new HiveContext(sc)
-    val hiveTraining = hc.sql(query)
+    val hiveTraining = runQuery(sc, query)
 
     val schema: Array[StructField] = hiveTraining.schema.fields.toArray
     val lastIdx = schema.size - 1
@@ -387,8 +385,7 @@ object GenericPipeline {
 
     val (model, transformer) = getModelAndTransform(config, modelCfgName, modelName)
 
-    val hc = new HiveContext(sc)
-    val hiveTraining = hc.sql(query)
+    val hiveTraining = runQuery(sc, query)
     val schema: Array[StructField] = hiveTraining.schema.fields.toArray
     val lastIdx = schema.size - 1
 
@@ -508,12 +505,7 @@ object GenericPipeline {
       sc: SparkContext,
       query: String,
       isMulticlass: Boolean = false): RDD[Example] = {
-    val sqlContext = new SQLContext(sc)
-
-    //val hc = new HiveContext(sc)
-    //val hiveTraining = hc.sql(query)
-    val hiveTraining = sqlContext.sql(query)
-
+    val hiveTraining = runQuery(sc, query)
     val schema: Array[StructField] = hiveTraining.schema.fields.toArray
 
     hiveTraining
@@ -535,6 +527,27 @@ object GenericPipeline {
       .textFile(inputPattern)
       .map(Util.decodeExample)
     examples
+  }
+
+  def runQuery(
+      sc: SparkContext,
+      query: String): DataFrame = {
+    val queryRunner = if (query.toLowerCase().contains("com.databricks.spark.csv")) {
+      // This query is operating on a file; use generic SQLContext
+      new SQLContext(sc)
+    } else {
+      // This query should be run in Hive
+      new HiveContext(sc)
+    }
+
+    val queryComponents = query.split(";")
+
+    queryComponents.slice(0, queryComponents.length - 1).foreach(queryComponent => {
+      queryRunner.sql(queryComponent)
+    })
+
+    // Return results of last query component
+    queryRunner.sql(queryComponents.last)
   }
 
   def evalCalibration(


### PR DESCRIPTION
to: @deerzq 

This change allows for CSV data sources in the ```GenericPipeline```. In particular, if the pipeline encounters a query with a reference to ```com.databricks.spark.csv```, it will use a local ```SQLContext``` instead of a ```HiveContext```. Queries run by the former can use the databricks spark-csv library to load a temporary table from a CSV and then execute a query on the loaded data. The table schema is inferred from the header row and values in each column.

Here's an example:

```
generic_hive_query : """
  create temporary table credit_defaults
  using com.databricks.spark.csv
  options (
    path          "file:///home/my_username/my_data_file.csv",
    header        "true",
    inferSchema   "true"
  );
  select
    limit_bal     as i_limitbal,
    sex           as i_sex,
    education     as i_education,
    marraige      as i_marraige,
    label         as LABEL
  from credit_defaults
"""
```