### PR TITLE
Improve NDTree Performance and  obey min leaf count rules

### DIFF
--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/FloatToStringTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/FloatToStringTransform.java
@@ -1,0 +1,75 @@
+package com.airbnb.aerosolve.core.transforms;
+
+import com.airbnb.aerosolve.core.FeatureVector;
+import com.airbnb.aerosolve.core.util.Util;
+import com.typesafe.config.Config;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Similar to MoveFloatToStringAndFloat, however, just move defined float value into String Feature
+ * not using bucket. This is used when there are certain number of incorrect data,
+ * i.e. x = 0 doesn't mean it is worse than x = 0.00001, it just somewhere in the pipeline
+ * make null = 0, so before we fixed the pipeline, convert it to string feature.
+ */
+@Slf4j
+public class FloatToStringTransform implements Transform {
+  private String fieldName;
+  private Collection<String> keys;
+  private Set<Double> values;
+  private String stringOutputName;
+
+  @Override
+  public void configure(Config config, String key) {
+    fieldName = config.getString(key + ".field1");
+    if (config.hasPath(key + ".keys")) {
+      keys = config.getStringList(key + ".keys");
+    }
+    values = new HashSet<>(config.getDoubleList(key + ".values"));
+    stringOutputName = config.getString(key + ".string_output");
+  }
+
+  @Override
+  public void doTransform(FeatureVector featureVector) {
+    Map<String, Map<String, Double>> floatFeatures = featureVector.floatFeatures;
+
+    if (floatFeatures == null || floatFeatures.isEmpty()) {
+      return;
+    }
+
+    Map<String, Double> input = floatFeatures.get(fieldName);
+
+    if (input == null || input.isEmpty()) {
+      return;
+    }
+
+    Util.optionallyCreateStringFeatures(featureVector);
+    Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
+    Set<String> stringOutput = Util.getOrCreateStringFeature(stringOutputName, stringFeatures);
+    Collection<String> localKeys = (keys == null)? input.keySet() : keys;
+    log.debug("k {} {}", localKeys, input);
+    for (String key : localKeys) {
+      moveFloatToStringAndFloat(
+          input, key, values, stringOutput);
+    }
+  }
+
+  private void moveFloatToStringAndFloat(
+      Map<String, Double> input,
+      String key, Set<Double> values,
+      Set<String> stringOutput) {
+    if (input.containsKey(key)) {
+      Double inputFloatValue = input.get(key);
+
+      if (values.contains(inputFloatValue)) {
+        String movedFloat = key + "=" + inputFloatValue;
+        stringOutput.add(movedFloat);
+        input.remove(key);
+      }
+    }
+  }
+}

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/FloatToStringTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/FloatToStringTransform.java
@@ -53,12 +53,12 @@ public class FloatToStringTransform implements Transform {
     Collection<String> localKeys = (keys == null)? input.keySet() : keys;
     log.debug("k {} {}", localKeys, input);
     for (String key : localKeys) {
-      moveFloatToStringAndFloat(
+      moveFloatToString(
           input, key, values, stringOutput);
     }
   }
 
-  private void moveFloatToStringAndFloat(
+  private void moveFloatToString(
       Map<String, Double> input,
       String key, Set<Double> values,
       Set<String> stringOutput) {

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/MoveFloatToStringAndFloatTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/MoveFloatToStringAndFloatTransform.java
@@ -58,12 +58,9 @@ public class MoveFloatToStringAndFloatTransform implements Transform {
     Set<String> stringOutput = Util.getOrCreateStringFeature(stringOutputName, stringFeatures);
 
     Map<String, Double> floatOutput = Util.getOrCreateFloatFeature(floatOutputName, floatFeatures);
+    Collection<String> localKeys = (keys == null)? input.keySet() : keys;
 
-    if (keys == null) {
-      keys = input.keySet();
-    }
-
-    for (String key : keys) {
+    for (String key : localKeys) {
       moveFloatToStringAndFloat(
         input, key, bucket, minBucket, maxBucket, stringOutput, floatOutput);
     }

--- a/core/src/test/java/com/airbnb/aerosolve/core/transforms/FloatToStringTransformTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/transforms/FloatToStringTransformTest.java
@@ -1,0 +1,92 @@
+package com.airbnb.aerosolve.core.transforms;
+
+import com.airbnb.aerosolve.core.FeatureVector;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class FloatToStringTransformTest {
+  public String makeConfig() {
+    return "test_float_to_string_and_float {\n" +
+        " transform : float_to_string\n" +
+        " field1 : floatFeature1\n" +
+        " keys : [a, b, g]\n" +
+        " values : [0.0, 10.0]\n" +
+        " string_output : stringOutput\n" +
+        "}";
+  }
+
+  public FeatureVector makeFeatureVector() {
+    Map<String, Map<String, Double>> floatFeatures = new HashMap<>();
+
+    Map<String, Double> floatFeature1 = new HashMap<>();
+
+    floatFeature1.put("a", 0.0);
+    floatFeature1.put("b", 10.0);
+    floatFeature1.put("c", 21.3);
+    floatFeature1.put("d", 10.1);
+    floatFeature1.put("e", 11.01);
+    floatFeature1.put("f", -1.01);
+    floatFeature1.put("g", 0d);
+
+    floatFeatures.put("floatFeature1", floatFeature1);
+
+    FeatureVector featureVector = new FeatureVector();
+    featureVector.setFloatFeatures(floatFeatures);
+    return featureVector;
+  }
+
+  @Test
+  public void testEmptyFeatureVector() {
+    Config config = ConfigFactory.parseString(makeConfig());
+    Transform transform = TransformFactory.createTransform(
+        config, "test_float_to_string_and_float");
+    FeatureVector featureVector = new FeatureVector();
+    transform.doTransform(featureVector);
+
+    assertTrue(featureVector.getStringFeatures() == null);
+    assertTrue(featureVector.getFloatFeatures() == null);
+  }
+
+  @Test
+  public void testTransform() {
+    Config config = ConfigFactory.parseString(makeConfig());
+    Transform transform = TransformFactory.createTransform(
+        config, "test_float_to_string_and_float");
+    FeatureVector featureVector = makeFeatureVector();
+
+    transform.doTransform(featureVector);
+
+    Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
+    Map<String, Map<String, Double>> floatFeatures = featureVector.getFloatFeatures();
+
+    assertNotNull(stringFeatures);
+    assertEquals(1, stringFeatures.size());
+
+    assertNotNull(floatFeatures);
+    assertEquals(1, floatFeatures.size());
+
+    Set<String> stringOutput = stringFeatures.get("stringOutput");
+    Map<String, Double> floatOutput = floatFeatures.get("floatFeature1");
+
+    assertEquals(3, stringOutput.size());
+    assertEquals(4, floatOutput.size());
+
+    assertTrue(stringOutput.contains("a=0.0"));
+    assertTrue(stringOutput.contains("b=10.0"));
+    assertTrue(stringOutput.contains("g=0.0"));
+
+    assertEquals(21.3, floatOutput.get("c"), 0.0);
+    assertEquals(10.1, floatOutput.get("d"), 0.0);
+    assertEquals(11.01, floatOutput.get("e"), 0.0);
+    assertEquals(-1.01, floatOutput.get("f"), 0.0);
+  }
+}

--- a/training/src/main/scala/com/airbnb/aerosolve/training/NDTree.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/NDTree.scala
@@ -169,27 +169,6 @@ object NDTree {
     }
   }
 
-  /*
-    bounds set min = bottom minLeafWidthPercentage/4 's max
-    max = top minLeafWidthPercentage/4 's min
-    so that we cap possible outliers and not affect model performance.
-   */
-  def getBoundsWithCap(points: Array[Array[Double]], minLeafWidthPercentage: Double): Bounds = {
-    val minima = points.reduceLeft((result: Array[Double], point: Array[Double]) => {
-      result.zip(point).map((axisIndexValues: (Double, Double)) => {
-        math.min(axisIndexValues._1, axisIndexValues._2)
-      })
-    })
-
-    val maxima = points.reduceLeft((result: Array[Double], point: Array[Double]) => {
-      result.zip(point).map((axisIndexValues: (Double, Double)) => {
-        math.max(axisIndexValues._1, axisIndexValues._2)
-      })
-    })
-
-    Bounds(minima, maxima)
-  }
-
   private def getBounds(
       points: Array[Array[Double]],
       indices: Array[Int]): Bounds = {
@@ -245,11 +224,12 @@ object NDTree {
       if (nextSplitValue.nonEmpty) {
         val splitValue = nextSplitValue.get
         val (left, right) = indices.partition(index => points(index)(axisIndex) < splitValue)
-        return Split(axisIndex, splitValue, left, right)
+        Split(axisIndex, splitValue, left, right)
+      } else {
+        // no next greater element, so median happens to equal to both mix and max
+        // this will become a leaf.
+        Split(0, 0.0, Array(), Array())
       }
-      // no next greater element, so median happens to equal to both mix and max
-      // this will become a leaf.
-      Split(0, 0.0, Array(), Array())
     }
   }
 

--- a/training/src/main/scala/com/airbnb/aerosolve/training/NDTree.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/NDTree.scala
@@ -231,7 +231,7 @@ object NDTree {
       points: Array[Array[Double]],
       indices: Array[Int],
       axisIndex: Int): Split = {
-    val splitValue = getMedianFast(points, indices, axisIndex)
+    val splitValue = getMedian(points, indices, axisIndex)
     val (leftIndices, rightIndices) = indices.partition(index => points(index)(axisIndex) < splitValue)
 
     log.debug(s"getSplitUsingMedian ${splitValue} ${leftIndices.length} ${rightIndices.length}")
@@ -253,31 +253,12 @@ object NDTree {
     }
   }
 
-  def getMedianFast(points: Array[Array[Double]],
+  def getMedian(points: Array[Array[Double]],
       indices: Array[Int],
       axisIndex: Int):Double = {
     val axisPoints = indices.map(i => points(i)(axisIndex))
     val length = axisPoints.length
     Sort.quickSelect(axisPoints, length/2)
-  }
-
-  private def getMedian(
-      points: Array[Array[Double]],
-      indices: Array[Int],
-      axisIndex: Int): Double = {
-    // TODO (christhetree): use median of medians algorithm (quick select) for O(n)
-    // performance instead of O(nln(n)) performance
-    // TODO use https://github.com/scalanlp/breeze/blob/master/math/src/test/scala/breeze/util/SelectTest.scala
-    val sortedPoints = indices.map(i => points(i)(axisIndex)).sorted
-    val length = sortedPoints.length
-
-    val median = if ((length % 2) == 0) {
-      (sortedPoints(length / 2) + sortedPoints((length / 2) - 1)) / 2.0
-    } else {
-      sortedPoints(length / 2)
-    }
-
-    median
   }
 
   // Split using the surface area heuristic

--- a/training/src/main/scala/com/airbnb/aerosolve/training/utils/Sort.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/utils/Sort.scala
@@ -1,0 +1,37 @@
+package com.airbnb.aerosolve.training.utils
+
+import scala.annotation.tailrec
+import scala.util.{Random}
+
+object Sort {
+
+  @tailrec
+  def quickSelect[A](
+      seq: Seq[A], n: Int, rand: Random = new Random)(implicit evidence: A => Ordered[A]): A = {
+    assert(n < seq.length, s"n $n cannot be larger than length of sequence ${seq.length}")
+    val pivot = rand.nextInt(seq.length)
+    val (left, right) = seq.partition(seq(pivot).>)
+    if (left.length == n) {
+      seq(pivot)
+    } else if (left.isEmpty) {
+      val (left, right) = seq.partition(seq(pivot).==)
+      if (left.length > n) {
+        seq(pivot)
+      } else {
+        quickSelect(right, n - left.length, rand)
+      }
+    } else if (left.length < n) {
+      quickSelect(right, n - left.length, rand)
+    } else {
+      quickSelect(left, n, rand)
+    }
+  }
+
+  def quickSelectAxis[A](
+      seq: Array[Array[A]], n: Int, axis: Int, rand: Random = new Random)(implicit evidence: A => Ordered[A]): A = {
+    implicit val ordering = Ordering.by[Array[A], A](_(axis))
+    val found = quickSelect(seq, n, rand)
+    // need to be separate line due to implicit
+    found(axis)
+  }
+}

--- a/training/src/test/scala/com/airbnb/aerosolve/training/NDTreeTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/NDTreeTest.scala
@@ -56,10 +56,10 @@ class NDTreeTest {
 
     log.info(s"nodes = ${nodes.mkString("\n")}")
     assertEquals(27, nodes.length)
-    assertEquals(6.5, nodes(0).splitValue, 0)
-    assertEquals(11, nodes(2).splitValue, 0)
+    assertEquals(7.0, nodes(0).splitValue, 0)
+    assertEquals(11.0, nodes(2).splitValue, 0)
     assertEquals(1.0, nodes(1).min.get(0))
-    assertEquals(6.5, nodes(1).max.get(0))
+    assertEquals(7.0, nodes(1).max.get(0))
     assertEquals(-1, nodes(5).axisIndex)
     assertEquals(1.0, nodes(5).min.get(0))
     assertEquals(1.0, nodes(5).max.get(0))
@@ -81,10 +81,10 @@ class NDTreeTest {
 
     log.info(s"nodes = ${nodes.mkString("\n")}")
     assertEquals(27, nodes.length)
-    assertEquals(6.5, nodes(0).splitValue, 0)
+    assertEquals(7.0, nodes(0).splitValue, 0)
     assertEquals(11, nodes(2).splitValue, 0)
     assertEquals(1.0, nodes(1).min.get(0))
-    assertEquals(6.5, nodes(1).max.get(0))
+    assertEquals(7.0, nodes(1).max.get(0))
     assertEquals(3.0, nodes(4).min.get(0))
     assertEquals(6.0, nodes(4).max.get(0))
   }
@@ -111,10 +111,10 @@ class NDTreeTest {
 
     log.info(s"nodes = ${nodes.mkString("\n")}")
     assertEquals(29, nodes.length)
-    assertEquals(14.5, nodes(0).splitValue, 0)
+    assertEquals(15.0, nodes(0).splitValue, 0)
     assertEquals(18, nodes(2).splitValue, 0)
     assertEquals(1.0, nodes(1).min.get(0))
-    assertEquals(14.5, nodes(1).max.get(0))
+    assertEquals(15.0, nodes(1).max.get(0))
     assertEquals(10.0, nodes(4).min.get(0))
     assertEquals(14.0, nodes(4).max.get(0))
   }
@@ -140,7 +140,7 @@ class NDTreeTest {
     log.info(s"nodes = ${nodes.mkString("\n")}")
     assertEquals(5, nodes.length)
     assertEquals(2.0, nodes(0).splitValue, 0)
-    assertEquals(2.5, nodes(2).splitValue, 0)
+    assertEquals(3.0, nodes(2).splitValue, 0)
     assertEquals(1.0, nodes(1).min.get(0))
     assertEquals(1.0, nodes(1).max.get(0))
     assertEquals(3.0, nodes(4).min.get(0))
@@ -290,7 +290,7 @@ class NDTreeTest {
     assertEquals(2.0, nodes(0).splitValue, 0)
     assertEquals(1, nodes(0).leftChild)
     assertEquals(2, nodes(0).rightChild)
-    assertEquals(10.5, nodes(8).splitValue, 0)
+    assertEquals(11.0, nodes(8).splitValue, 0)
   }
 
 }

--- a/training/src/test/scala/com/airbnb/aerosolve/training/NDTreeTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/NDTreeTest.scala
@@ -110,7 +110,7 @@ class NDTreeTest {
     val nodes = tree.nodes
 
     log.info(s"nodes = ${nodes.mkString("\n")}")
-    assertEquals(29, nodes.length)
+    assertEquals(27, nodes.length)
     assertEquals(15.0, nodes(0).splitValue, 0)
     assertEquals(18, nodes(2).splitValue, 0)
     assertEquals(1.0, nodes(1).min.get(0))

--- a/training/src/test/scala/com/airbnb/aerosolve/training/utils/SortTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/utils/SortTest.scala
@@ -1,0 +1,28 @@
+package com.airbnb.aerosolve.training.utils
+
+import org.junit.Assert._
+import org.junit.Test
+import org.slf4j.LoggerFactory
+
+class SortTest {
+  val log = LoggerFactory.getLogger("SortTest")
+  @Test
+  def testQuickSelect : Unit = {
+    val v = Array(9, 8, 7, 6, 5, 0, 1, 2, 3, 4)
+    val r = (0 until v.length).map(Sort.quickSelect(v, _)).toArray
+    assertTrue(Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).deep == r.deep)
+
+    val v2 = Array(Array(9), Array(8), Array(7), Array(6), Array(5), Array(0), Array(1), Array(2), Array(3), Array(4))
+
+    val r2 = (0 until v2.length).map(Sort.quickSelectAxis[Int](v2, _, 0)).toArray
+    assertTrue(Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9).deep == r2.deep)
+
+    assertEquals(1, Sort.quickSelect(Array(1,1,1,1,1), 0))
+    assertEquals(1, Sort.quickSelect(Array(1,1,1,1,1), 1))
+    assertEquals(1, Sort.quickSelect(Array(1,1,1,2,2,2), 2))
+    assertEquals(2, Sort.quickSelect(Array(1,1,1,2,2,2), 3))
+    assertEquals(1, Sort.quickSelect(Array(0,1,2,1), 2))
+    assertEquals(0, Sort.quickSelect(Array(0,0,0,0,1,2,1), 3))
+
+  }
+}


### PR DESCRIPTION
1. FloatToStringTransform so that you can turn specified float feature to string feature
2. use quick select for median
3. make sure NDTree obey the min leaf count for both children

@deerzq @saurfang @christhetree 