### PR TITLE
Make forest model more like Randomforest

### DIFF
--- a/training/src/main/resources/demo_train.conf
+++ b/training/src/main/resources/demo_train.conf
@@ -257,6 +257,8 @@ forest_model_config {
   min_leaf_items : 3000
   # How many times per split to search for an optimal split
   num_tries : 100
+  # The max number of features used in each split
+  max_features : "sqrt"
   context_transform : identity_transform
   item_transform : identity_transform
   combined_transform : identity_transform

--- a/training/src/main/scala/com/airbnb/aerosolve/training/BoostedForestTrainer.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/BoostedForestTrainer.scala
@@ -219,6 +219,7 @@ object BoostedForestTrainer {
         params.maxDepth,
         params.rankKey,
         params.rankThreshold,
+        Int.MaxValue,
         params.numTries,
         params.minLeafCount,
         SplitCriteria.splitCriteriaFromName(params.splitCriteria))

--- a/training/src/main/scala/com/airbnb/aerosolve/training/DecisionTreeTrainer.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/DecisionTreeTrainer.scala
@@ -74,11 +74,11 @@ object DecisionTreeTrainer {
 
     val ex = examples(0)
     val numFeatures = LinearRankerUtils.getNumFeatures(ex, rankKey)
-    val maxFeatures : Int = config.getString(key + ".max_features") match {
-      case "all" => numFeatures
+    val maxFeatures : Int =  Try(config.getString(key + ".max_features")).getOrElse("all") match {
+      case "all" => Int.MaxValue
       case "sqrt" => math.sqrt(numFeatures).ceil.toInt
       case "log2" => math.max(1, (math.log(numFeatures) / math.log(2)).ceil.toInt)
-      case _ => numFeatures
+      case _ => Int.MaxValue
     }
 
     val stumps = new util.ArrayList[ModelRecord]()

--- a/training/src/main/scala/com/airbnb/aerosolve/training/ForestTrainer.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/ForestTrainer.scala
@@ -43,6 +43,15 @@ object ForestTrainer {
         .map(x => Util.flattenFeature(x.example(0)))
         .filter(x => x.contains(rankKey))
         .coalesce(numTrees, true)
+
+    val ex = examples.take(1)(0)
+    val numFeatures = LinearRankerUtils.getNumFeatures(ex, rankKey)
+    val maxFeatures : Int = config.getString(key + ".max_features") match {
+      case "all" => numFeatures
+      case "sqrt" => math.sqrt(numFeatures).ceil.toInt
+      case "log2" => math.max(1, (math.log(numFeatures) / math.log(2)).ceil.toInt)
+      case _ => numFeatures
+    }
         
     val trees = examples.mapPartitions(part => {
       val ex = part
@@ -58,6 +67,7 @@ object ForestTrainer {
           maxDepth,
           rankKey,
           rankThreshold,
+          maxFeatures,
           numTries,
           minLeafCount,
           SplitCriteria.splitCriteriaFromName(splitCriteriaName))

--- a/training/src/main/scala/com/airbnb/aerosolve/training/ForestTrainer.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/ForestTrainer.scala
@@ -46,7 +46,7 @@ object ForestTrainer {
 
     val ex = examples.take(1)(0)
     val numFeatures = LinearRankerUtils.getNumFeatures(ex, rankKey)
-    val maxFeatures : Int = Try(config.getString(key + ".max_features")).getOrElse("all") match {
+    val maxFeatures : Int = Try(config.getString(key + ".max_features")).getOrElse("sqrt") match {
       case "all" => Int.MaxValue
       case "sqrt" => math.sqrt(numFeatures).ceil.toInt
       case "log2" => math.max(1, (math.log(numFeatures) / math.log(2)).ceil.toInt)

--- a/training/src/main/scala/com/airbnb/aerosolve/training/ForestTrainer.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/ForestTrainer.scala
@@ -46,11 +46,11 @@ object ForestTrainer {
 
     val ex = examples.take(1)(0)
     val numFeatures = LinearRankerUtils.getNumFeatures(ex, rankKey)
-    val maxFeatures : Int = config.getString(key + ".max_features") match {
-      case "all" => numFeatures
+    val maxFeatures : Int = Try(config.getString(key + ".max_features")).getOrElse("all") match {
+      case "all" => Int.MaxValue
       case "sqrt" => math.sqrt(numFeatures).ceil.toInt
       case "log2" => math.max(1, (math.log(numFeatures) / math.log(2)).ceil.toInt)
-      case _ => numFeatures
+      case _ => Int.MaxValue
     }
         
     val trees = examples.mapPartitions(part => {

--- a/training/src/main/scala/com/airbnb/aerosolve/training/LinearRankerUtils.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/LinearRankerUtils.scala
@@ -9,6 +9,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
 
+import java.util
 import scala.collection.mutable.HashMap
 import scala.collection.mutable.HashSet
 import scala.collection.mutable.ArrayBuffer
@@ -32,6 +33,19 @@ object LinearRankerUtils {
       })
     })
     features.toArray
+  }
+
+  def getNumFeatures(ex : util.Map[java.lang.String, util.Map[java.lang.String, java.lang.Double]],
+                     rankKey : String) : Int = {
+    // Get the number of features in the example excluding the label
+    var numFeature = 0
+
+    for (family <- ex) {
+      if (!family._1.equals(rankKey)) {
+        numFeature += family._2.size
+      }
+    }
+    numFeature
   }
 
   // Does feature expansion on an example and buckets them by rank.

--- a/training/src/test/scala/com/airbnb/aerosolve/training/DecisionTreeTrainerTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/DecisionTreeTrainerTest.scala
@@ -31,6 +31,7 @@ class DecisionTreeTrainerTest {
       |  max_depth : 4
       |  min_leaf_items : 5
       |  num_tries : 10
+      |  max_features : "sqrt"
       |  context_transform : identity_transform
       |  item_transform : identity_transform
       |  combined_transform : identity_transform

--- a/training/src/test/scala/com/airbnb/aerosolve/training/ForestTrainerTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/ForestTrainerTest.scala
@@ -31,6 +31,7 @@ class ForestTrainerTest {
       |  min_leaf_items : 5
       |  num_tries : 100
       |  num_trees : 5
+      |  max_features : "sqrt"
       |  context_transform : identity_transform
       |  item_transform : identity_transform
       |  combined_transform : identity_transform


### PR DESCRIPTION
adding a max_features parameter so that when evaluating a split in a decision tree, it will only consider a random subset of the features. It is a key feature to make Randomforest different from a tree bagging model currently available in Aerosolve. 

@deerzq @jq 
