### PR TITLE
Revert "convert family and feature names to lower case"

### DIFF
--- a/core/src/main/java/com/airbnb/aerosolve/core/features/Features.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/features/Features.java
@@ -14,6 +14,7 @@ import java.util.*;
 
 @Builder @Slf4j
 public class Features {
+  // lower case label field will be inserted into Upper case LABEL family name.
   public final static String LABEL = "LABEL";
   public final static String LABEL_FEATURE_NAME = "";
   public final static String MISS = "MISS";
@@ -176,7 +177,7 @@ public class Features {
   static Pair<String, String> getFamily(String name) {
     int pos = name.indexOf(FAMILY_SEPARATOR);
     if (pos == -1) {
-      if (name.compareTo(LABEL) == 0) {
+      if (name.compareToIgnoreCase(LABEL) == 0) {
         return new ImmutablePair<>(LABEL, LABEL_FEATURE_NAME) ;
       } else if (!name.isEmpty()){
         return new ImmutablePair<>("", name) ;


### PR DESCRIPTION
This reverts commit 866f14539fb27267351a5cbfbb391366e33ea3e4.

still need this so that lower case label can be accepted as label, and it wont' break existing model or scoring since it is label, and it accept compareToIgnoreCase of LABEL

@deerzq 