### PR TITLE
Add eval_test option

### DIFF
--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/JobRunner.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/JobRunner.scala
@@ -3,6 +3,7 @@ package com.airbnb.aerosolve.training.pipeline
 import java.io.File
 
 import com.typesafe.config.{ConfigFactory, ConfigParseOptions, ConfigResolveOptions}
+import com.airbnb.aerosolve.core.Example
 import org.apache.spark.{Logging, SparkConf, SparkContext}
 
 import scala.collection.JavaConversions._
@@ -47,7 +48,9 @@ object JobRunner extends Logging {
       try {
         job match {
           case "GenericMakeExamples" => GenericPipeline
-            .makeTrainingRun(sc, config)
+            .makeExampleRun(sc, config.getConfig("make_training"))
+          case "GenericMakeTesting" => GenericPipeline
+            .makeExampleRun(sc, config.getConfig("make_testing"))
           case "GenericDebugExamples" => GenericPipeline
             .debugExampleRun(sc, config)
           case "GenericDebugTransforms" => GenericPipeline
@@ -58,6 +61,8 @@ object JobRunner extends Logging {
             .trainingRun(sc, config)
           case "GenericEvalModel" => GenericPipeline
             .evalRun(sc, config, "eval_model")
+          case "GenericEvalTest" => GenericPipeline
+            .evalRun(sc, config, "eval_test", Option((example : Example) => false))
           case "GenericCalibrateModel" => GenericPipeline
             .calibrateRun(sc, config)
           case "GenericEvalModelCalibrated" => GenericPipeline


### PR DESCRIPTION
`eval_test` was an option in income pipeline but not part of Genericpipeline. The goal is to be able to evaluate the performance of model on a separate test data other than `hold_out` data as specified in `eval_test`.

Example usage:

```
make_testing {
  hive_query : ${generic_hive_query}" from "${training_table}${testing_filter}
  num_shards : 20
  output : ${testing_data}
}

eval_test {
  input : ${testing_data}
  subsample : ${eval_subsample}
  bins : 100
  model_config : ${model_config}
  is_probability : false
  is_regression : false
  metric_to_maximize : "!HOLD_F1"
  model_name : ${model_name}
}
```
