### PR TITLE
Optimize AdditiveModelTrainer using sparse representation

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -39,5 +39,5 @@ dependencies {
   compile 'org.projectlombok:lombok:1.14.8'
   compile 'org.apache.commons:commons-lang3:3.4'
   compile 'org.apache.commons:commons-math3:3.6.1'
-  testCompile 'org.slf4j:slf4j-simple:1.7.7'
+  testCompile 'org.slf4j:slf4j-log4j12:1.7.21'
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/features/SparseLabeledPoint.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/features/SparseLabeledPoint.java
@@ -1,0 +1,19 @@
+package com.airbnb.aerosolve.core.features;
+
+import lombok.Data;
+
+import java.io.Serializable;
+
+/**
+ * This is a compressed representation of a feature vector indexed via a feature index map. It captures values in
+ * flat representation for space and runtime efficiency during model training.
+ */
+@Data
+public class SparseLabeledPoint implements Serializable {
+    public final boolean isTraining;
+    public final double label;
+    public final int[] indices;
+    public final float[] values;
+    public final int[] denseIndices;
+    public final float[][] denseValues;
+}

--- a/core/src/main/java/com/airbnb/aerosolve/core/features/SparseLabeledPoint.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/features/SparseLabeledPoint.java
@@ -5,15 +5,15 @@ import lombok.Data;
 import java.io.Serializable;
 
 /**
- * This is a compressed representation of a feature vector indexed via a feature index map. It captures values in
- * flat representation for space and runtime efficiency during model training.
+ * This is a compressed representation of a feature vector indexed via a feature index map. It
+ * captures values in flat representation for space and runtime efficiency during model training.
  */
 @Data
 public class SparseLabeledPoint implements Serializable {
-    public final boolean isTraining;
-    public final double label;
-    public final int[] indices;
-    public final float[] values;
-    public final int[] denseIndices;
-    public final float[][] denseValues;
+  public final boolean isTraining;
+  public final double label;
+  public final int[] indices;
+  public final float[] values;
+  public final int[] denseIndices;
+  public final float[][] denseValues;
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/function/Zero.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/function/Zero.java
@@ -1,73 +1,74 @@
 package com.airbnb.aerosolve.core.function;
 
 import com.airbnb.aerosolve.core.ModelRecord;
+
 import java.util.List;
 
 /**
- * This is a special case of a point where no contribution whatsoever is provided by this feature. This is
- * intended to mark feature as deleted for future deletion. This is needed so we avoid re-indexing of the feature
- * space for both model and data points.
- * The behavior is simply no-op for most operations and always outputs 0 for scoring.
- * Those features with such function should be deleted before final model persistence onto the disk.
+ * This is a special case of a point where no contribution whatsoever is provided by this feature.
+ * This is intended to mark feature as deleted for future deletion. This is needed so we avoid
+ * re-indexing of the feature space for both model and data points. The behavior is simply no-op for
+ * most operations and always outputs 0 for scoring. Those features with such function should be
+ * deleted before final model persistence onto the disk.
  */
 public class Zero implements Function {
-    @Override
-    public Function aggregate(Iterable<Function> functions, float scale, int numBins) {
-        return this;
-    }
+  @Override
+  public Function aggregate(Iterable<Function> functions, float scale, int numBins) {
+    return this;
+  }
 
-    @Override
-    public float evaluate(float... x) {
-        return 0;
-    }
+  @Override
+  public float evaluate(float... x) {
+    return 0;
+  }
 
-    @Override
-    public float evaluate(List<Double> values) {
-        return 0;
-    }
+  @Override
+  public float evaluate(List<Double> values) {
+    return 0;
+  }
 
-    @Override
-    public void update(float delta, float... values) {
+  @Override
+  public void update(float delta, float... values) {
 
-    }
+  }
 
-    @Override
-    public void update(float delta, List<Double> values) {
+  @Override
+  public void update(float delta, List<Double> values) {
 
-    }
+  }
 
-    @Override
-    public ModelRecord toModelRecord(String featureFamily, String featureName) {
-        throw new IllegalAccessError("Zero point should never be persisted. Please delete or skip this feature instead.");
-    }
+  @Override
+  public ModelRecord toModelRecord(String featureFamily, String featureName) {
+    throw new IllegalAccessError("Zero point should never be persisted. Please delete or skip this feature instead.");
+  }
 
-    @Override
-    public void setPriors(float[] params) {
+  @Override
+  public void setPriors(float[] params) {
 
-    }
+  }
 
-    @Override
-    public void LInfinityCap(float cap) {
+  @Override
+  public void LInfinityCap(float cap) {
 
-    }
+  }
 
-    @Override
-    public float LInfinityNorm() {
-        return 0;
-    }
+  @Override
+  public float LInfinityNorm() {
+    return 0;
+  }
 
-    @Override
-    public void resample(int newBins) {
+  @Override
+  public void resample(int newBins) {
 
-    }
+  }
 
-    @Override
-    public double smooth(double tolerance, boolean toleranceIsPercentage) {
-        return 0;
-    }
+  @Override
+  public double smooth(double tolerance, boolean toleranceIsPercentage) {
+    return 0;
+  }
 
-    @Override
-    public Function clone() throws CloneNotSupportedException {
-        return this;
-    }
+  @Override
+  public Function clone() throws CloneNotSupportedException {
+    return this;
+  }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/function/Zero.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/function/Zero.java
@@ -1,0 +1,73 @@
+package com.airbnb.aerosolve.core.function;
+
+import com.airbnb.aerosolve.core.ModelRecord;
+import java.util.List;
+
+/**
+ * This is a special case of a point where no contribution whatsoever is provided by this feature. This is
+ * intended to mark feature as deleted for future deletion. This is needed so we avoid re-indexing of the feature
+ * space for both model and data points.
+ * The behavior is simply no-op for most operations and always outputs 0 for scoring.
+ * Those features with such function should be deleted before final model persistence onto the disk.
+ */
+public class Zero implements Function {
+    @Override
+    public Function aggregate(Iterable<Function> functions, float scale, int numBins) {
+        return this;
+    }
+
+    @Override
+    public float evaluate(float... x) {
+        return 0;
+    }
+
+    @Override
+    public float evaluate(List<Double> values) {
+        return 0;
+    }
+
+    @Override
+    public void update(float delta, float... values) {
+
+    }
+
+    @Override
+    public void update(float delta, List<Double> values) {
+
+    }
+
+    @Override
+    public ModelRecord toModelRecord(String featureFamily, String featureName) {
+        throw new IllegalAccessError("Zero point should never be persisted. Please delete or skip this feature instead.");
+    }
+
+    @Override
+    public void setPriors(float[] params) {
+
+    }
+
+    @Override
+    public void LInfinityCap(float cap) {
+
+    }
+
+    @Override
+    public float LInfinityNorm() {
+        return 0;
+    }
+
+    @Override
+    public void resample(int newBins) {
+
+    }
+
+    @Override
+    public double smooth(double tolerance, boolean toleranceIsPercentage) {
+        return 0;
+    }
+
+    @Override
+    public Function clone() throws CloneNotSupportedException {
+        return this;
+    }
+}

--- a/core/src/main/java/com/airbnb/aerosolve/core/models/AdditiveModel.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/models/AdditiveModel.java
@@ -7,8 +7,8 @@ import com.airbnb.aerosolve.core.ModelRecord;
 import com.airbnb.aerosolve.core.features.SparseLabeledPoint;
 import com.airbnb.aerosolve.core.function.AbstractFunction;
 import com.airbnb.aerosolve.core.function.Function;
-import com.airbnb.aerosolve.core.function.FunctionUtil;
 import com.airbnb.aerosolve.core.util.Util;
+
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -16,377 +16,383 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.util.*;
-import java.util.stream.Stream;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Random;
 
 import static com.airbnb.aerosolve.core.function.FunctionUtil.toFloat;
 
 /**
- * A generalized additive model with a parametric function per feature.
- * See http://en.wikipedia.org/wiki/Generalized_additive_model
+ * A generalized additive model with a parametric function per feature. See
+ * http://en.wikipedia.org/wiki/Generalized_additive_model
  *
- * Aside from common functionality AdditiveModel has special optimization that uses an indexer for features.
- * This allows efficient storage of sparse feature vector such that they could be persist into memory or disk
- * if desired.
- * This is achieved by calling `generateFeatureIndexer` function after model has been initialized with all
- * feature weights, which arranges all known features into an array. All feature vector can now be flatten
- * into a sparse vector according to index of feature in corresponding feature indexer.
- * Subsequent model update can then be made via array lookup instead of nested map lookup. This is done via
- * calling `generateWeightVector` to populate the array of function corresponding to the feature.
+ * Aside from common functionality AdditiveModel has special optimization that uses an indexer for
+ * features. This allows efficient storage of sparse feature vector such that they could be persist
+ * into memory or disk if desired. This is achieved by calling `generateFeatureIndexer` function
+ * after model has been initialized with all feature weights, which arranges all known features into
+ * an array. All feature vector can now be flatten into a sparse vector according to index of
+ * feature in corresponding feature indexer. Subsequent model update can then be made via array
+ * lookup instead of nested map lookup. This is done via calling `generateWeightVector` to populate
+ * the array of function corresponding to the feature.
  */
 @Slf4j
 public class AdditiveModel extends AbstractModel implements Cloneable {
-    public static final String DENSE_FAMILY = "dense";
-    @Getter
-    @Setter
-    private Map<String, Map<String, Function>> weights = new HashMap<>();
+  public static final String DENSE_FAMILY = "dense";
+  @Getter
+  @Setter
+  private Map<String, Map<String, Function>> weights = new HashMap<>();
 
-    // only MultiDimensionSpline using denseWeights
-    // whole dense features belongs to feature family DENSE_FAMILY
-    private Map<String, Function> denseWeights;
+  // only MultiDimensionSpline using denseWeights
+  // whole dense features belongs to feature family DENSE_FAMILY
+  private Map<String, Function> denseWeights;
 
-    private Map<String, Function> getOrCreateDenseWeights() {
-        if (denseWeights == null) {
-            denseWeights = weights.get(DENSE_FAMILY);
-            if (denseWeights == null) {
-                denseWeights = weights.put(DENSE_FAMILY, new HashMap<>());
-            }
-        }
-        return denseWeights;
+  private Map<String, Function> getOrCreateDenseWeights() {
+    if (denseWeights == null) {
+      denseWeights = weights.get(DENSE_FAMILY);
+      if (denseWeights == null) {
+        denseWeights = weights.put(DENSE_FAMILY, new HashMap<>());
+      }
+    }
+    return denseWeights;
+  }
+
+  // featureIndexer maps features to a unique consecutive ascending index
+  // mapping training data via this index before shuffling can save a lot of time
+  @Getter
+  private Map<String, Map<String, Integer>> featureIndexer = new HashMap<>();
+  // weightVector takes the index generated above and construct an indexed weight function vector
+  @Getter
+  private Function[] weightVector = new Function[0];
+
+  /**
+   * Generate the feature indexer which maps each feature to a unique integer index
+   *
+   * @apiNote Subsequent `generateWeightVector` calls will use this index. This index does not
+   * automatically update when features are added or removed.
+   */
+  public AdditiveModel generateFeatureIndexer() {
+    featureIndexer.clear();
+
+    int count = 0;
+    for (Map.Entry<String, Map<String, Function>> family : weights.entrySet()) {
+      String familyName = family.getKey();
+      Map<String, Integer> featureIndex = new HashMap<>();
+      featureIndexer.put(familyName, featureIndex);
+      for (Map.Entry<String, Function> feature : family.getValue().entrySet()) {
+        featureIndex.put(feature.getKey(), count++);
+      }
+    }
+    // (re)initialize the weight vector to be populated
+    weightVector = new Function[count];
+    return this;
+  }
+
+  /**
+   * Populate the weight vector with index weight function according to feature indexer
+   *
+   * @apiNote `generateFeatureIndexer` must be called before this function if there is any feature
+   * set modification No error/boundary checking is performed in this function. This function is
+   * automatically called during `clone`.
+   */
+  public AdditiveModel generateWeightVector() {
+    for (Map.Entry<String, Map<String, Integer>> family : featureIndexer.entrySet()) {
+      String familyName = family.getKey();
+      for (Map.Entry<String, Integer> feature : family.getValue().entrySet()) {
+        weightVector[feature.getValue()] = weights.get(familyName).get(feature.getKey());
+      }
+    }
+    return this;
+  }
+
+  @Override
+  public float scoreItem(FeatureVector combinedItem) {
+    Map<String, Map<String, Double>> flatFeatures = Util.flattenFeature(combinedItem);
+    return scoreFlatFeatures(flatFeatures) + scoreDenseFeatures(combinedItem.getDenseFeatures());
+  }
+
+  public float scoreDenseFeatures(Map<String, List<Double>> denseFeatures) {
+    float sum = 0;
+    if (denseFeatures != null && !denseFeatures.isEmpty()) {
+      Map<String, Function> denseWeights = getOrCreateDenseWeights();
+      for (Map.Entry<String, List<Double>> feature : denseFeatures.entrySet()) {
+        String featureName = feature.getKey();
+        Function fun = denseWeights.get(featureName);
+        if (fun == null) continue;
+        sum += fun.evaluate(toFloat(feature.getValue()));
+      }
+    }
+    return sum;
+  }
+
+  @Override
+  public float debugScoreItem(FeatureVector combinedItem,
+                              StringBuilder builder) {
+    Map<String, Map<String, Double>> flatFeatures = Util.flattenFeature(combinedItem);
+
+    float sum = 0.0f;
+    // order by the absolute value
+    PriorityQueue<Map.Entry<String, Float>> scores =
+        new PriorityQueue<>(100, new LinearModel.EntryComparator());
+
+    for (Map.Entry<String, Map<String, Double>> featureFamily : flatFeatures.entrySet()) {
+      Map<String, Function> familyWeightMap = weights.get(featureFamily.getKey());
+      if (familyWeightMap == null)
+        continue;
+      for (Map.Entry<String, Double> feature : featureFamily.getValue().entrySet()) {
+        Function func = familyWeightMap.get(feature.getKey());
+        if (func == null)
+          continue;
+        float val = feature.getValue().floatValue();
+        float subScore = func.evaluate(val);
+        sum += subScore;
+        String str = featureFamily.getKey() + ":" + feature.getKey() + "=" + val
+            + " = " + subScore + "<br>\n";
+        scores.add(new AbstractMap.SimpleEntry<>(str, subScore));
+      }
     }
 
-    // featureIndexer maps features to a unique consecutive ascending index
-    // mapping training data via this index before shuffling can save a lot of time
-    @Getter
-    private Map<String, Map<String, Integer>> featureIndexer = new HashMap<>();
-    // weightVector takes the index generated above and construct an indexed weight function vector
-    @Getter
-    private Function[] weightVector = new Function[0];
-
-    /**
-     * Generate the feature indexer which maps each feature to a unique integer index
-     *
-     * @apiNote Subsequent `generateWeightVector` calls will use this index. This index does not automatically update
-     * when features are added or removed.
-     */
-    public AdditiveModel generateFeatureIndexer() {
-        featureIndexer.clear();
-
-        int count = 0;
-        for (Map.Entry<String, Map<String, Function>> family : weights.entrySet()) {
-            String familyName = family.getKey();
-            Map<String, Integer> featureIndex = new HashMap<>();
-            featureIndexer.put(familyName, featureIndex);
-            for (Map.Entry<String, Function> feature : family.getValue().entrySet()) {
-                featureIndex.put(feature.getKey(), count++);
-            }
-        }
-        // (re)initialize the weight vector to be populated
-        weightVector = new Function[count];
-        return this;
+    Map<String, List<Double>> denseFeatures = combinedItem.getDenseFeatures();
+    if (denseFeatures != null) {
+      assert (denseWeights != null);
+      for (Map.Entry<String, List<Double>> feature : denseFeatures.entrySet()) {
+        String featureName = feature.getKey();
+        Function fun = denseWeights.get(featureName);
+        float[] val = toFloat(feature.getValue());
+        float subScore = fun.evaluate(val);
+        sum += subScore;
+        String str = DENSE_FAMILY + ":" + featureName + "=" + val
+            + " = " + subScore + "<br>\n";
+        scores.add(new AbstractMap.SimpleEntry<>(str, subScore));
+      }
     }
 
-    /**
-     * Populate the weight vector with index weight function according to feature indexer
-     *
-     * @apiNote `generateFeatureIndexer` must be called before this function if there is any feature set modification
-     * No error/boundary checking is performed in this function. This function is automatically called during `clone`.
-     */
-    public AdditiveModel generateWeightVector() {
-        for (Map.Entry<String, Map<String, Integer>> family : featureIndexer.entrySet()) {
-            String familyName = family.getKey();
-            for (Map.Entry<String, Integer> feature : family.getValue().entrySet()) {
-                weightVector[feature.getValue()] = weights.get(familyName).get(feature.getKey());
-            }
+    final int MAX_COUNT = 100;
+    builder.append("Top scores ===>\n");
+    if (!scores.isEmpty()) {
+      int count = 0;
+      float subsum = 0.0f;
+      while (!scores.isEmpty()) {
+        Map.Entry<String, Float> entry = scores.poll();
+        builder.append(entry.getKey());
+        float val = entry.getValue();
+        subsum += val;
+        count = count + 1;
+        if (count >= MAX_COUNT) {
+          builder.append("Leftover = " + (sum - subsum) + '\n');
+          break;
         }
-        return this;
+      }
+    }
+    builder.append("Total = " + sum + '\n');
+
+    return sum;
+  }
+
+  @Override
+  public List<DebugScoreRecord> debugScoreComponents(FeatureVector combinedItem) {
+    Map<String, Map<String, Double>> flatFeatures = Util.flattenFeature(combinedItem);
+    List<DebugScoreRecord> scoreRecordsList = new ArrayList<>();
+
+    for (Map.Entry<String, Map<String, Double>> featureFamily : flatFeatures.entrySet()) {
+      Map<String, Function> familyWeightMap = weights.get(featureFamily.getKey());
+      if (familyWeightMap == null) continue;
+      for (Map.Entry<String, Double> feature : featureFamily.getValue().entrySet()) {
+        Function func = familyWeightMap.get(feature.getKey());
+        if (func == null) continue;
+        float val = feature.getValue().floatValue();
+        float weight = func.evaluate(val);
+        DebugScoreRecord record = new DebugScoreRecord();
+        record.setFeatureFamily(featureFamily.getKey());
+        record.setFeatureName(feature.getKey());
+        record.setFeatureValue(val);
+        record.setFeatureWeight(weight);
+        scoreRecordsList.add(record);
+      }
     }
 
-    @Override
-    public float scoreItem(FeatureVector combinedItem) {
-        Map<String, Map<String, Double>> flatFeatures = Util.flattenFeature(combinedItem);
-        return scoreFlatFeatures(flatFeatures) + scoreDenseFeatures(combinedItem.getDenseFeatures());
+    Map<String, List<Double>> denseFeatures = combinedItem.getDenseFeatures();
+    if (denseFeatures != null) {
+      Map<String, Function> denseWeights = getOrCreateDenseWeights();
+      for (Map.Entry<String, List<Double>> feature : denseFeatures.entrySet()) {
+        String featureName = feature.getKey();
+        Function fun = denseWeights.get(featureName);
+        float[] val = toFloat(feature.getValue());
+        float weight = fun.evaluate(val);
+        DebugScoreRecord record = new DebugScoreRecord();
+        record.setFeatureFamily(DENSE_FAMILY);
+        record.setFeatureName(feature.getKey());
+        record.setDenseFeatureValue(feature.getValue());
+        record.setFeatureWeight(weight);
+        scoreRecordsList.add(record);
+      }
     }
 
-    public float scoreDenseFeatures(Map<String, List<Double>> denseFeatures) {
-        float sum = 0;
-        if (denseFeatures != null && !denseFeatures.isEmpty()) {
-            Map<String, Function> denseWeights = getOrCreateDenseWeights();
-            for (Map.Entry<String, List<Double>> feature : denseFeatures.entrySet()) {
-                String featureName = feature.getKey();
-                Function fun = denseWeights.get(featureName);
-                if (fun == null) continue;
-                sum += fun.evaluate(toFloat(feature.getValue()));
-            }
-        }
-        return sum;
+    return scoreRecordsList;
+  }
+
+  @Override
+  protected void loadInternal(ModelHeader header, BufferedReader reader) throws IOException {
+    long rows = header.getNumRecords();
+    slope = header.getSlope();
+    offset = header.getOffset();
+    weights = new HashMap<>();
+    for (long i = 0; i < rows; i++) {
+      String line = reader.readLine();
+      ModelRecord record = Util.decodeModel(line);
+      String family = record.getFeatureFamily();
+      String name = record.getFeatureName();
+      Map<String, Function> inner = weights.get(family);
+      if (inner == null) {
+        inner = new HashMap<>();
+        weights.put(family, inner);
+      }
+      inner.put(name, AbstractFunction.buildFunction(record));
     }
+  }
 
-    @Override
-    public float debugScoreItem(FeatureVector combinedItem,
-                                StringBuilder builder) {
-        Map<String, Map<String, Double>> flatFeatures = Util.flattenFeature(combinedItem);
-
-        float sum = 0.0f;
-        // order by the absolute value
-        PriorityQueue<Map.Entry<String, Float>> scores =
-                new PriorityQueue<>(100, new LinearModel.EntryComparator());
-
-        for (Map.Entry<String, Map<String, Double>> featureFamily : flatFeatures.entrySet()) {
-            Map<String, Function> familyWeightMap = weights.get(featureFamily.getKey());
-            if (familyWeightMap == null)
-                continue;
-            for (Map.Entry<String, Double> feature : featureFamily.getValue().entrySet()) {
-                Function func = familyWeightMap.get(feature.getKey());
-                if (func == null)
-                    continue;
-                float val = feature.getValue().floatValue();
-                float subScore = func.evaluate(val);
-                sum += subScore;
-                String str = featureFamily.getKey() + ":" + feature.getKey() + "=" + val
-                        + " = " + subScore + "<br>\n";
-                scores.add(new AbstractMap.SimpleEntry<String, Float>(str, subScore));
-            }
-        }
-
-        Map<String, List<Double>> denseFeatures = combinedItem.getDenseFeatures();
-        if (denseFeatures != null) {
-            assert (denseWeights != null);
-            for (Map.Entry<String, List<Double>> feature : denseFeatures.entrySet()) {
-                String featureName = feature.getKey();
-                Function fun = denseWeights.get(featureName);
-                float[] val = toFloat(feature.getValue());
-                float subScore = fun.evaluate(val);
-                sum += subScore;
-                String str = DENSE_FAMILY + ":" + featureName + "=" + val
-                        + " = " + subScore + "<br>\n";
-                scores.add(new AbstractMap.SimpleEntry<String, Float>(str, subScore));
-            }
-        }
-
-        final int MAX_COUNT = 100;
-        builder.append("Top scores ===>\n");
-        if (!scores.isEmpty()) {
-            int count = 0;
-            float subsum = 0.0f;
-            while (!scores.isEmpty()) {
-                Map.Entry<String, Float> entry = scores.poll();
-                builder.append(entry.getKey());
-                float val = entry.getValue();
-                subsum += val;
-                count = count + 1;
-                if (count >= MAX_COUNT) {
-                    builder.append("Leftover = " + (sum - subsum) + '\n');
-                    break;
-                }
-            }
-        }
-        builder.append("Total = " + sum + '\n');
-
-        return sum;
+  @Override
+  public void save(BufferedWriter writer) throws IOException {
+    ModelHeader header = new ModelHeader();
+    header.setModelType("additive");
+    header.setSlope(slope);
+    header.setOffset(offset);
+    long count = 0;
+    for (Map.Entry<String, Map<String, Function>> familyMap : weights.entrySet()) {
+      count += familyMap.getValue().size();
     }
-
-    @Override
-    public List<DebugScoreRecord> debugScoreComponents(FeatureVector combinedItem) {
-        Map<String, Map<String, Double>> flatFeatures = Util.flattenFeature(combinedItem);
-        List<DebugScoreRecord> scoreRecordsList = new ArrayList<>();
-
-        for (Map.Entry<String, Map<String, Double>> featureFamily : flatFeatures.entrySet()) {
-            Map<String, Function> familyWeightMap = weights.get(featureFamily.getKey());
-            if (familyWeightMap == null) continue;
-            for (Map.Entry<String, Double> feature : featureFamily.getValue().entrySet()) {
-                Function func = familyWeightMap.get(feature.getKey());
-                if (func == null) continue;
-                float val = feature.getValue().floatValue();
-                float weight = func.evaluate(val);
-                DebugScoreRecord record = new DebugScoreRecord();
-                record.setFeatureFamily(featureFamily.getKey());
-                record.setFeatureName(feature.getKey());
-                record.setFeatureValue(val);
-                record.setFeatureWeight(weight);
-                scoreRecordsList.add(record);
-            }
-        }
-
-        Map<String, List<Double>> denseFeatures = combinedItem.getDenseFeatures();
-        if (denseFeatures != null) {
-            Map<String, Function> denseWeights = getOrCreateDenseWeights();
-            for (Map.Entry<String, List<Double>> feature : denseFeatures.entrySet()) {
-                String featureName = feature.getKey();
-                Function fun = denseWeights.get(featureName);
-                float[] val = toFloat(feature.getValue());
-                float weight = fun.evaluate(val);
-                DebugScoreRecord record = new DebugScoreRecord();
-                record.setFeatureFamily(DENSE_FAMILY);
-                record.setFeatureName(feature.getKey());
-                record.setDenseFeatureValue(feature.getValue());
-                record.setFeatureWeight(weight);
-                scoreRecordsList.add(record);
-            }
-        }
-
-        return scoreRecordsList;
-    }
-
-    @Override
-    protected void loadInternal(ModelHeader header, BufferedReader reader) throws IOException {
-        long rows = header.getNumRecords();
-        slope = header.getSlope();
-        offset = header.getOffset();
-        weights = new HashMap<>();
-        for (long i = 0; i < rows; i++) {
-            String line = reader.readLine();
-            ModelRecord record = Util.decodeModel(line);
-            String family = record.getFeatureFamily();
-            String name = record.getFeatureName();
-            Map<String, Function> inner = weights.get(family);
-            if (inner == null) {
-                inner = new HashMap<>();
-                weights.put(family, inner);
-            }
-            inner.put(name, AbstractFunction.buildFunction(record));
-        }
-    }
-
-    @Override
-    public void save(BufferedWriter writer) throws IOException {
-        ModelHeader header = new ModelHeader();
-        header.setModelType("additive");
-        header.setSlope(slope);
-        header.setOffset(offset);
-        long count = 0;
-        for (Map.Entry<String, Map<String, Function>> familyMap : weights.entrySet()) {
-            count += familyMap.getValue().size();
-        }
-        header.setNumRecords(count);
-        ModelRecord headerRec = new ModelRecord();
-        headerRec.setModelHeader(header);
-        writer.write(Util.encode(headerRec));
+    header.setNumRecords(count);
+    ModelRecord headerRec = new ModelRecord();
+    headerRec.setModelHeader(header);
+    writer.write(Util.encode(headerRec));
+    writer.newLine();
+    for (Map.Entry<String, Map<String, Function>> familyMap : weights.entrySet()) {
+      String featureFamily = familyMap.getKey();
+      for (Map.Entry<String, Function> feature : familyMap.getValue().entrySet()) {
+        Function func = feature.getValue();
+        String featureName = feature.getKey();
+        writer.write(Util.encode(func.toModelRecord(featureFamily, featureName)));
         writer.newLine();
-        for (Map.Entry<String, Map<String, Function>> familyMap : weights.entrySet()) {
-            String featureFamily = familyMap.getKey();
-            for (Map.Entry<String, Function> feature : familyMap.getValue().entrySet()) {
-                Function func = feature.getValue();
-                String featureName = feature.getKey();
-                writer.write(Util.encode(func.toModelRecord(featureFamily, featureName)));
-                writer.newLine();
-            }
-        }
-        writer.flush();
+      }
+    }
+    writer.flush();
+  }
+
+  public float scoreFlatFeatures(Map<String, Map<String, Double>> flatFeatures) {
+    float sum = 0.0f;
+    for (Map.Entry<String, Map<String, Double>> featureFamily : flatFeatures.entrySet()) {
+      Map<String, Function> familyWeightMap = weights.get(featureFamily.getKey());
+      if (familyWeightMap == null) {
+        // not important families/features are removed from model
+        log.debug("miss featureFamily {}", featureFamily.getKey());
+        continue;
+      }
+      for (Map.Entry<String, Double> feature : featureFamily.getValue().entrySet()) {
+        Function func = familyWeightMap.get(feature.getKey());
+        if (func == null)
+          continue;
+        float val = feature.getValue().floatValue();
+        sum += func.evaluate(val);
+      }
+    }
+    return sum;
+  }
+
+  public float scoreFeatures(SparseLabeledPoint point, double dropout, Random rand) {
+    float prediction = 0;
+
+    for (int i = 0; i < point.indices.length; i++) {
+      if (dropout <= 0 || rand.nextDouble() > dropout) {
+        int index = point.indices[i];
+        Function function = weightVector[index];
+        float value = point.values[i];
+        prediction += function.evaluate(value);
+      }
     }
 
-    public float scoreFlatFeatures(Map<String, Map<String, Double>> flatFeatures) {
-        float sum = 0.0f;
-        for (Map.Entry<String, Map<String, Double>> featureFamily : flatFeatures.entrySet()) {
-            Map<String, Function> familyWeightMap = weights.get(featureFamily.getKey());
-            if (familyWeightMap == null) {
-                // not important families/features are removed from model
-                log.debug("miss featureFamily {}", featureFamily.getKey());
-                continue;
-            }
-            for (Map.Entry<String, Double> feature : featureFamily.getValue().entrySet()) {
-                Function func = familyWeightMap.get(feature.getKey());
-                if (func == null)
-                    continue;
-                float val = feature.getValue().floatValue();
-                sum += func.evaluate(val);
-            }
-        }
-        return sum;
+    for (int i = 0; i < point.denseIndices.length; i++) {
+      if (dropout <= 0 || rand.nextDouble() > dropout) {
+        int index = point.denseIndices[i];
+        Function function = weightVector[index];
+        float[] value = point.denseValues[i];
+        prediction += function.evaluate(value);
+      }
     }
 
-    public float scoreFeatures(SparseLabeledPoint point, double dropout, Random rand) {
-        float prediction = 0;
+    return prediction;
+  }
 
-        for (int i = 0; i < point.indices.length; i++) {
-            if (dropout <= 0 || rand.nextDouble() > dropout) {
-                int index = point.indices[i];
-                Function function = weightVector[index];
-                float value = point.values[i];
-                prediction += function.evaluate(value);
-            }
-        }
+  public Map<String, Function> getOrCreateFeatureFamily(String featureFamily) {
+    Map<String, Function> featFamily = weights.get(featureFamily);
+    if (featFamily == null) {
+      featFamily = new HashMap<>();
+      weights.put(featureFamily, featFamily);
+    }
+    return featFamily;
+  }
 
-        for (int i = 0; i < point.denseIndices.length; i++) {
-            if (dropout <= 0 || rand.nextDouble() > dropout) {
-                int index = point.denseIndices[i];
-                Function function = weightVector[index];
-                float[] value = point.denseValues[i];
-                prediction += function.evaluate(value);
-            }
-        }
+  public void addFunction(String featureFamily, String featureName,
+                          Function function, boolean overwrite) {
+    if (function == null) {
+      throw new RuntimeException(featureFamily + " " + featureName + " function null");
+    }
+    Map<String, Function> featFamily = getOrCreateFeatureFamily(featureFamily);
+    if (overwrite || !featFamily.containsKey(featureName)) {
+      featFamily.put(featureName, function);
+    }
+  }
 
-        return prediction;
+  public void update(float gradWithLearningRate, SparseLabeledPoint point, double dropout, Random rand) {
+    for (int i = 0; i < point.indices.length; i++) {
+      if (dropout <= 0 || rand.nextDouble() > dropout) {
+        int index = point.indices[i];
+        Function function = weightVector[index];
+        float value = point.values[i];
+        function.update(-gradWithLearningRate, value);
+      }
     }
 
-    public Map<String, Function> getOrCreateFeatureFamily(String featureFamily) {
-        Map<String, Function> featFamily = weights.get(featureFamily);
-        if (featFamily == null) {
-            featFamily = new HashMap<>();
-            weights.put(featureFamily, featFamily);
-        }
-        return featFamily;
+    for (int i = 0; i < point.denseIndices.length; i++) {
+      if (dropout <= 0 || rand.nextDouble() > dropout) {
+        int index = point.denseIndices[i];
+        Function function = weightVector[index];
+        float[] value = point.denseValues[i];
+        function.update(-gradWithLearningRate, value);
+      }
     }
+  }
 
-    public void addFunction(String featureFamily, String featureName,
-                            Function function, boolean overwrite) {
-        if (function == null) {
-            throw new RuntimeException(featureFamily + " " + featureName + " function null");
-        }
-        Map<String, Function> featFamily = getOrCreateFeatureFamily(featureFamily);
-        if (overwrite || !featFamily.containsKey(featureName)) {
-            featFamily.put(featureName, function);
-        }
-    }
+  @Override
+  public AdditiveModel clone() throws CloneNotSupportedException {
+    AdditiveModel copy = (AdditiveModel) super.clone();
 
-    public void update(float gradWithLearningRate, SparseLabeledPoint point, double dropout, Random rand) {
-        for (int i = 0; i < point.indices.length; i++) {
-            if (dropout <= 0 || rand.nextDouble() > dropout) {
-                int index = point.indices[i];
-                Function function = weightVector[index];
-                float value = point.values[i];
-                function.update(-gradWithLearningRate, value);
-            }
-        }
+    // deep copy weights
+    Map<String, Map<String, Function>> newWeights = new HashMap<>();
+    weights.forEach((k, v) -> newWeights.put(k, copyFeatures(v)));
+    copy.weights = newWeights;
 
-        for (int i = 0; i < point.denseIndices.length; i++) {
-            if (dropout <= 0 || rand.nextDouble() > dropout) {
-                int index = point.denseIndices[i];
-                Function function = weightVector[index];
-                float[] value = point.denseValues[i];
-                function.update(-gradWithLearningRate, value);
-            }
-        }
-    }
+    copy.denseWeights = copyFeatures(denseWeights);
 
-    @Override
-    public AdditiveModel clone() throws CloneNotSupportedException {
-        AdditiveModel copy = (AdditiveModel) super.clone();
+    // regenerate weight vector
+    copy.weightVector = new Function[copy.weightVector.length];
+    return copy.generateWeightVector();
+  }
 
-        // deep copy weights
-        Map<String, Map<String, Function>> newWeights = new HashMap<>();
-        weights.forEach((k, v) -> newWeights.put(k, copyFeatures(v)));
-        copy.weights = newWeights;
+  private Map<String, Function> copyFeatures(Map<String, Function> featureMap) {
+    if (featureMap == null) return null;
 
-        copy.denseWeights = copyFeatures(denseWeights);
-
-        // regenerate weight vector
-        copy.weightVector = new Function[copy.weightVector.length];
-        return copy.generateWeightVector();
-    }
-
-    private Map<String, Function> copyFeatures(Map<String, Function> featureMap) {
-        if (featureMap == null) return null;
-
-        Map<String, Function> newFeatureMap = new HashMap<>();
-        featureMap.forEach((feature, function) -> {
-            try {
-                newFeatureMap.put(feature, function.clone());
-            } catch (CloneNotSupportedException e) {
-                // Java8 stream does not handle checked exception properly and requires explicit handling
-                e.printStackTrace();
-            }
-        });
-        return newFeatureMap;
-    }
+    Map<String, Function> newFeatureMap = new HashMap<>();
+    featureMap.forEach((feature, function) -> {
+      try {
+        newFeatureMap.put(feature, function.clone());
+      } catch (CloneNotSupportedException e) {
+        // Java8 stream does not handle checked exception properly and requires explicit handling
+        e.printStackTrace();
+      }
+    });
+    return newFeatureMap;
+  }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/models/AdditiveModel.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/models/AdditiveModel.java
@@ -4,6 +4,7 @@ import com.airbnb.aerosolve.core.DebugScoreRecord;
 import com.airbnb.aerosolve.core.FeatureVector;
 import com.airbnb.aerosolve.core.ModelHeader;
 import com.airbnb.aerosolve.core.ModelRecord;
+import com.airbnb.aerosolve.core.features.SparseLabeledPoint;
 import com.airbnb.aerosolve.core.function.AbstractFunction;
 import com.airbnb.aerosolve.core.function.Function;
 import com.airbnb.aerosolve.core.function.FunctionUtil;
@@ -16,305 +17,376 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.util.*;
+import java.util.stream.Stream;
 
 import static com.airbnb.aerosolve.core.function.FunctionUtil.toFloat;
 
-// A generalized additive model with a parametric function per feature.
-// See http://en.wikipedia.org/wiki/Generalized_additive_model
+/**
+ * A generalized additive model with a parametric function per feature.
+ * See http://en.wikipedia.org/wiki/Generalized_additive_model
+ *
+ * Aside from common functionality AdditiveModel has special optimization that uses an indexer for features.
+ * This allows efficient storage of sparse feature vector such that they could be persist into memory or disk
+ * if desired.
+ * This is achieved by calling `generateFeatureIndexer` function after model has been initialized with all
+ * feature weights, which arranges all known features into an array. All feature vector can now be flatten
+ * into a sparse vector according to index of feature in corresponding feature indexer.
+ * Subsequent model update can then be made via array lookup instead of nested map lookup. This is done via
+ * calling `generateWeightVector` to populate the array of function corresponding to the feature.
+ */
 @Slf4j
 public class AdditiveModel extends AbstractModel implements Cloneable {
-  public static final String DENSE_FAMILY = "dense";
-  @Getter @Setter
-  private Map<String, Map<String, Function>> weights = new HashMap<>();
+    public static final String DENSE_FAMILY = "dense";
+    @Getter
+    @Setter
+    private Map<String, Map<String, Function>> weights = new HashMap<>();
 
-  // only MultiDimensionSpline using denseWeights
-  // whole dense features belongs to feature family DENSE_FAMILY
-  private Map<String, Function> denseWeights;
+    // only MultiDimensionSpline using denseWeights
+    // whole dense features belongs to feature family DENSE_FAMILY
+    private Map<String, Function> denseWeights;
 
-  private Map<String, Function> getOrCreateDenseWeights() {
-    if (denseWeights == null) {
-      denseWeights = weights.get(DENSE_FAMILY);
-      if (denseWeights == null) {
-        denseWeights = weights.put(DENSE_FAMILY, new HashMap<>());
-      }
-    }
-    return denseWeights;
-  }
-
-  @Override
-  public float scoreItem(FeatureVector combinedItem) {
-    Map<String, Map<String, Double>> flatFeatures = Util.flattenFeature(combinedItem);
-    return scoreFlatFeatures(flatFeatures) + scoreDenseFeatures(combinedItem.getDenseFeatures());
-  }
-
-  public float scoreDenseFeatures(Map<String, List<Double>> denseFeatures) {
-    float sum = 0;
-    if (denseFeatures != null && !denseFeatures.isEmpty()) {
-      Map<String, Function> denseWeights = getOrCreateDenseWeights();
-      for (Map.Entry<String, List<Double>> feature : denseFeatures.entrySet()) {
-        String featureName = feature.getKey();
-        Function fun = denseWeights.get(featureName);
-        if (fun == null) continue;
-        sum += fun.evaluate(toFloat(feature.getValue()));
-      }
-    }
-    return sum;
-  }
-
-  @Override
-  public float debugScoreItem(FeatureVector combinedItem,
-                              StringBuilder builder) {
-    Map<String, Map<String, Double>> flatFeatures = Util.flattenFeature(combinedItem);
-
-    float sum = 0.0f;
-    // order by the absolute value
-    PriorityQueue<Map.Entry<String, Float>> scores =
-        new PriorityQueue<>(100, new LinearModel.EntryComparator());
-
-    for (Map.Entry<String, Map<String, Double>> featureFamily : flatFeatures.entrySet()) {
-      Map<String, Function> familyWeightMap = weights.get(featureFamily.getKey());
-      if (familyWeightMap == null)
-        continue;
-      for (Map.Entry<String, Double> feature : featureFamily.getValue().entrySet()) {
-        Function func = familyWeightMap.get(feature.getKey());
-        if (func == null)
-          continue;
-        float val = feature.getValue().floatValue();
-        float subScore = func.evaluate(val);
-        sum += subScore;
-        String str = featureFamily.getKey() + ":" + feature.getKey() + "=" + val
-                     + " = " + subScore + "<br>\n";
-        scores.add(new AbstractMap.SimpleEntry<String, Float>(str, subScore));
-      }
-    }
-
-    Map<String, List<Double>> denseFeatures = combinedItem.getDenseFeatures();
-    if (denseFeatures != null) {
-      assert (denseWeights != null);
-      for (Map.Entry<String, List<Double>> feature : denseFeatures.entrySet()) {
-        String featureName = feature.getKey();
-        Function fun = denseWeights.get(featureName);
-        float[] val = toFloat(feature.getValue());
-        float subScore = fun.evaluate(val);
-        sum += subScore;
-        String str = DENSE_FAMILY + ":" + featureName + "=" + val
-            + " = " + subScore + "<br>\n";
-        scores.add(new AbstractMap.SimpleEntry<String, Float>(str, subScore));
-      }
-    }
-
-    final int MAX_COUNT = 100;
-    builder.append("Top scores ===>\n");
-    if (!scores.isEmpty()) {
-      int count = 0;
-      float subsum = 0.0f;
-      while (!scores.isEmpty()) {
-        Map.Entry<String, Float> entry = scores.poll();
-        builder.append(entry.getKey());
-        float val = entry.getValue();
-        subsum += val;
-        count = count + 1;
-        if (count >= MAX_COUNT) {
-          builder.append("Leftover = " + (sum - subsum) + '\n');
-          break;
+    private Map<String, Function> getOrCreateDenseWeights() {
+        if (denseWeights == null) {
+            denseWeights = weights.get(DENSE_FAMILY);
+            if (denseWeights == null) {
+                denseWeights = weights.put(DENSE_FAMILY, new HashMap<>());
+            }
         }
-      }
-    }
-    builder.append("Total = " + sum + '\n');
-
-    return sum;
-  }
-
-  @Override
-  public List<DebugScoreRecord> debugScoreComponents(FeatureVector combinedItem) {
-    Map<String, Map<String, Double>> flatFeatures = Util.flattenFeature(combinedItem);
-    List<DebugScoreRecord> scoreRecordsList = new ArrayList<>();
-
-    for (Map.Entry<String, Map<String, Double>> featureFamily : flatFeatures.entrySet()) {
-      Map<String, Function> familyWeightMap = weights.get(featureFamily.getKey());
-      if (familyWeightMap == null) continue;
-      for (Map.Entry<String, Double> feature : featureFamily.getValue().entrySet()) {
-        Function func = familyWeightMap.get(feature.getKey());
-        if (func == null) continue;
-        float val = feature.getValue().floatValue();
-        float weight = func.evaluate(val);
-        DebugScoreRecord record = new DebugScoreRecord();
-        record.setFeatureFamily(featureFamily.getKey());
-        record.setFeatureName(feature.getKey());
-        record.setFeatureValue(val);
-        record.setFeatureWeight(weight);
-        scoreRecordsList.add(record);
-      }
+        return denseWeights;
     }
 
-    Map<String, List<Double>> denseFeatures = combinedItem.getDenseFeatures();
-    if (denseFeatures != null) {
-      Map<String, Function> denseWeights = getOrCreateDenseWeights();
-      for (Map.Entry<String, List<Double>> feature : denseFeatures.entrySet()) {
-        String featureName = feature.getKey();
-        Function fun = denseWeights.get(featureName);
-        float[] val = toFloat(feature.getValue());
-        float weight = fun.evaluate(val);
-        DebugScoreRecord record = new DebugScoreRecord();
-        record.setFeatureFamily(DENSE_FAMILY);
-        record.setFeatureName(feature.getKey());
-        record.setDenseFeatureValue(feature.getValue());
-        record.setFeatureWeight(weight);
-        scoreRecordsList.add(record);
-      }
+    // featureIndexer maps features to a unique consecutive ascending index
+    // mapping training data via this index before shuffling can save a lot of time
+    @Getter
+    private Map<String, Map<String, Integer>> featureIndexer = new HashMap<>();
+    // weightVector takes the index generated above and construct an indexed weight function vector
+    @Getter
+    private Function[] weightVector = new Function[0];
+
+    /**
+     * Generate the feature indexer which maps each feature to a unique integer index
+     *
+     * @apiNote Subsequent `generateWeightVector` calls will use this index. This index does not automatically update
+     * when features are added or removed.
+     */
+    public AdditiveModel generateFeatureIndexer() {
+        featureIndexer.clear();
+
+        int count = 0;
+        for (Map.Entry<String, Map<String, Function>> family : weights.entrySet()) {
+            String familyName = family.getKey();
+            Map<String, Integer> featureIndex = new HashMap<>();
+            featureIndexer.put(familyName, featureIndex);
+            for (Map.Entry<String, Function> feature : family.getValue().entrySet()) {
+                featureIndex.put(feature.getKey(), count++);
+            }
+        }
+        // (re)initialize the weight vector to be populated
+        weightVector = new Function[count];
+        return this;
     }
 
-    return scoreRecordsList;
-  }
-
-  @Override
-  protected void loadInternal(ModelHeader header, BufferedReader reader) throws IOException {
-    long rows = header.getNumRecords();
-    slope = header.getSlope();
-    offset = header.getOffset();
-    weights = new HashMap<>();
-    for (long i = 0; i < rows; i++) {
-      String line = reader.readLine();
-      ModelRecord record = Util.decodeModel(line);
-      String family = record.getFeatureFamily();
-      String name = record.getFeatureName();
-      Map<String, Function> inner = weights.get(family);
-      if (inner == null) {
-        inner = new HashMap<>();
-        weights.put(family, inner);
-      }
-      inner.put(name, AbstractFunction.buildFunction(record));
+    /**
+     * Populate the weight vector with index weight function according to feature indexer
+     *
+     * @apiNote `generateFeatureIndexer` must be called before this function if there is any feature set modification
+     * No error/boundary checking is performed in this function. This function is automatically called during `clone`.
+     */
+    public AdditiveModel generateWeightVector() {
+        for (Map.Entry<String, Map<String, Integer>> family : featureIndexer.entrySet()) {
+            String familyName = family.getKey();
+            for (Map.Entry<String, Integer> feature : family.getValue().entrySet()) {
+                weightVector[feature.getValue()] = weights.get(familyName).get(feature.getKey());
+            }
+        }
+        return this;
     }
-  }
 
-  @Override
-  public void save(BufferedWriter writer) throws IOException {
-    ModelHeader header = new ModelHeader();
-    header.setModelType("additive");
-    header.setSlope(slope);
-    header.setOffset(offset);
-    long count = 0;
-    for (Map.Entry<String, Map<String, Function>> familyMap : weights.entrySet()) {
-      count += familyMap.getValue().size();
+    @Override
+    public float scoreItem(FeatureVector combinedItem) {
+        Map<String, Map<String, Double>> flatFeatures = Util.flattenFeature(combinedItem);
+        return scoreFlatFeatures(flatFeatures) + scoreDenseFeatures(combinedItem.getDenseFeatures());
     }
-    header.setNumRecords(count);
-    ModelRecord headerRec = new ModelRecord();
-    headerRec.setModelHeader(header);
-    writer.write(Util.encode(headerRec));
-    writer.newLine();
-    for (Map.Entry<String, Map<String, Function>> familyMap : weights.entrySet()) {
-      String featureFamily = familyMap.getKey();
-      for (Map.Entry<String, Function> feature : familyMap.getValue().entrySet()) {
-        Function func = feature.getValue();
-        String featureName = feature.getKey();
-        writer.write(Util.encode(func.toModelRecord(featureFamily, featureName)));
+
+    public float scoreDenseFeatures(Map<String, List<Double>> denseFeatures) {
+        float sum = 0;
+        if (denseFeatures != null && !denseFeatures.isEmpty()) {
+            Map<String, Function> denseWeights = getOrCreateDenseWeights();
+            for (Map.Entry<String, List<Double>> feature : denseFeatures.entrySet()) {
+                String featureName = feature.getKey();
+                Function fun = denseWeights.get(featureName);
+                if (fun == null) continue;
+                sum += fun.evaluate(toFloat(feature.getValue()));
+            }
+        }
+        return sum;
+    }
+
+    @Override
+    public float debugScoreItem(FeatureVector combinedItem,
+                                StringBuilder builder) {
+        Map<String, Map<String, Double>> flatFeatures = Util.flattenFeature(combinedItem);
+
+        float sum = 0.0f;
+        // order by the absolute value
+        PriorityQueue<Map.Entry<String, Float>> scores =
+                new PriorityQueue<>(100, new LinearModel.EntryComparator());
+
+        for (Map.Entry<String, Map<String, Double>> featureFamily : flatFeatures.entrySet()) {
+            Map<String, Function> familyWeightMap = weights.get(featureFamily.getKey());
+            if (familyWeightMap == null)
+                continue;
+            for (Map.Entry<String, Double> feature : featureFamily.getValue().entrySet()) {
+                Function func = familyWeightMap.get(feature.getKey());
+                if (func == null)
+                    continue;
+                float val = feature.getValue().floatValue();
+                float subScore = func.evaluate(val);
+                sum += subScore;
+                String str = featureFamily.getKey() + ":" + feature.getKey() + "=" + val
+                        + " = " + subScore + "<br>\n";
+                scores.add(new AbstractMap.SimpleEntry<String, Float>(str, subScore));
+            }
+        }
+
+        Map<String, List<Double>> denseFeatures = combinedItem.getDenseFeatures();
+        if (denseFeatures != null) {
+            assert (denseWeights != null);
+            for (Map.Entry<String, List<Double>> feature : denseFeatures.entrySet()) {
+                String featureName = feature.getKey();
+                Function fun = denseWeights.get(featureName);
+                float[] val = toFloat(feature.getValue());
+                float subScore = fun.evaluate(val);
+                sum += subScore;
+                String str = DENSE_FAMILY + ":" + featureName + "=" + val
+                        + " = " + subScore + "<br>\n";
+                scores.add(new AbstractMap.SimpleEntry<String, Float>(str, subScore));
+            }
+        }
+
+        final int MAX_COUNT = 100;
+        builder.append("Top scores ===>\n");
+        if (!scores.isEmpty()) {
+            int count = 0;
+            float subsum = 0.0f;
+            while (!scores.isEmpty()) {
+                Map.Entry<String, Float> entry = scores.poll();
+                builder.append(entry.getKey());
+                float val = entry.getValue();
+                subsum += val;
+                count = count + 1;
+                if (count >= MAX_COUNT) {
+                    builder.append("Leftover = " + (sum - subsum) + '\n');
+                    break;
+                }
+            }
+        }
+        builder.append("Total = " + sum + '\n');
+
+        return sum;
+    }
+
+    @Override
+    public List<DebugScoreRecord> debugScoreComponents(FeatureVector combinedItem) {
+        Map<String, Map<String, Double>> flatFeatures = Util.flattenFeature(combinedItem);
+        List<DebugScoreRecord> scoreRecordsList = new ArrayList<>();
+
+        for (Map.Entry<String, Map<String, Double>> featureFamily : flatFeatures.entrySet()) {
+            Map<String, Function> familyWeightMap = weights.get(featureFamily.getKey());
+            if (familyWeightMap == null) continue;
+            for (Map.Entry<String, Double> feature : featureFamily.getValue().entrySet()) {
+                Function func = familyWeightMap.get(feature.getKey());
+                if (func == null) continue;
+                float val = feature.getValue().floatValue();
+                float weight = func.evaluate(val);
+                DebugScoreRecord record = new DebugScoreRecord();
+                record.setFeatureFamily(featureFamily.getKey());
+                record.setFeatureName(feature.getKey());
+                record.setFeatureValue(val);
+                record.setFeatureWeight(weight);
+                scoreRecordsList.add(record);
+            }
+        }
+
+        Map<String, List<Double>> denseFeatures = combinedItem.getDenseFeatures();
+        if (denseFeatures != null) {
+            Map<String, Function> denseWeights = getOrCreateDenseWeights();
+            for (Map.Entry<String, List<Double>> feature : denseFeatures.entrySet()) {
+                String featureName = feature.getKey();
+                Function fun = denseWeights.get(featureName);
+                float[] val = toFloat(feature.getValue());
+                float weight = fun.evaluate(val);
+                DebugScoreRecord record = new DebugScoreRecord();
+                record.setFeatureFamily(DENSE_FAMILY);
+                record.setFeatureName(feature.getKey());
+                record.setDenseFeatureValue(feature.getValue());
+                record.setFeatureWeight(weight);
+                scoreRecordsList.add(record);
+            }
+        }
+
+        return scoreRecordsList;
+    }
+
+    @Override
+    protected void loadInternal(ModelHeader header, BufferedReader reader) throws IOException {
+        long rows = header.getNumRecords();
+        slope = header.getSlope();
+        offset = header.getOffset();
+        weights = new HashMap<>();
+        for (long i = 0; i < rows; i++) {
+            String line = reader.readLine();
+            ModelRecord record = Util.decodeModel(line);
+            String family = record.getFeatureFamily();
+            String name = record.getFeatureName();
+            Map<String, Function> inner = weights.get(family);
+            if (inner == null) {
+                inner = new HashMap<>();
+                weights.put(family, inner);
+            }
+            inner.put(name, AbstractFunction.buildFunction(record));
+        }
+    }
+
+    @Override
+    public void save(BufferedWriter writer) throws IOException {
+        ModelHeader header = new ModelHeader();
+        header.setModelType("additive");
+        header.setSlope(slope);
+        header.setOffset(offset);
+        long count = 0;
+        for (Map.Entry<String, Map<String, Function>> familyMap : weights.entrySet()) {
+            count += familyMap.getValue().size();
+        }
+        header.setNumRecords(count);
+        ModelRecord headerRec = new ModelRecord();
+        headerRec.setModelHeader(header);
+        writer.write(Util.encode(headerRec));
         writer.newLine();
-      }
+        for (Map.Entry<String, Map<String, Function>> familyMap : weights.entrySet()) {
+            String featureFamily = familyMap.getKey();
+            for (Map.Entry<String, Function> feature : familyMap.getValue().entrySet()) {
+                Function func = feature.getValue();
+                String featureName = feature.getKey();
+                writer.write(Util.encode(func.toModelRecord(featureFamily, featureName)));
+                writer.newLine();
+            }
+        }
+        writer.flush();
     }
-    writer.flush();
-  }
 
-  public float scoreFlatFeatures(Map<String, Map<String, Double>> flatFeatures) {
-    float sum = 0.0f;
-    for (Map.Entry<String, Map<String, Double>> featureFamily : flatFeatures.entrySet()) {
-      Map<String, Function> familyWeightMap = weights.get(featureFamily.getKey());
-      if (familyWeightMap == null) {
-        // not important families/features are removed from model
-        log.debug("miss featureFamily {}", featureFamily.getKey());
-        continue;
-      }
-      for (Map.Entry<String, Double> feature : featureFamily.getValue().entrySet()) {
-        Function func = familyWeightMap.get(feature.getKey());
-        if (func == null)
-          continue;
-        float val = feature.getValue().floatValue();
-        sum += func.evaluate(val);
-      }
+    public float scoreFlatFeatures(Map<String, Map<String, Double>> flatFeatures) {
+        float sum = 0.0f;
+        for (Map.Entry<String, Map<String, Double>> featureFamily : flatFeatures.entrySet()) {
+            Map<String, Function> familyWeightMap = weights.get(featureFamily.getKey());
+            if (familyWeightMap == null) {
+                // not important families/features are removed from model
+                log.debug("miss featureFamily {}", featureFamily.getKey());
+                continue;
+            }
+            for (Map.Entry<String, Double> feature : featureFamily.getValue().entrySet()) {
+                Function func = familyWeightMap.get(feature.getKey());
+                if (func == null)
+                    continue;
+                float val = feature.getValue().floatValue();
+                sum += func.evaluate(val);
+            }
+        }
+        return sum;
     }
-    return sum;
-  }
 
-  public Map<String, Function> getOrCreateFeatureFamily(String featureFamily) {
-    Map<String, Function> featFamily = weights.get(featureFamily);
-    if (featFamily == null) {
-      featFamily = new HashMap<>();
-      weights.put(featureFamily, featFamily);
+    public float scoreFeatures(SparseLabeledPoint point, double dropout, Random rand) {
+        float prediction = 0;
+
+        for (int i = 0; i < point.indices.length; i++) {
+            if (dropout <= 0 || rand.nextDouble() > dropout) {
+                int index = point.indices[i];
+                Function function = weightVector[index];
+                float value = point.values[i];
+                prediction += function.evaluate(value);
+            }
+        }
+
+        for (int i = 0; i < point.denseIndices.length; i++) {
+            if (dropout <= 0 || rand.nextDouble() > dropout) {
+                int index = point.denseIndices[i];
+                Function function = weightVector[index];
+                float[] value = point.denseValues[i];
+                prediction += function.evaluate(value);
+            }
+        }
+
+        return prediction;
     }
-    return featFamily;
-  }
 
-  public void addFunction(String featureFamily, String featureName,
-                          Function function, boolean overwrite) {
-    if (function == null) {
-      throw new RuntimeException(featureFamily + " " + featureName + " function null");
+    public Map<String, Function> getOrCreateFeatureFamily(String featureFamily) {
+        Map<String, Function> featFamily = weights.get(featureFamily);
+        if (featFamily == null) {
+            featFamily = new HashMap<>();
+            weights.put(featureFamily, featFamily);
+        }
+        return featFamily;
     }
-    Map<String, Function> featFamily = getOrCreateFeatureFamily(featureFamily);
-    if (overwrite || !featFamily.containsKey(featureName)) {
-      featFamily.put(featureName, function);
+
+    public void addFunction(String featureFamily, String featureName,
+                            Function function, boolean overwrite) {
+        if (function == null) {
+            throw new RuntimeException(featureFamily + " " + featureName + " function null");
+        }
+        Map<String, Function> featFamily = getOrCreateFeatureFamily(featureFamily);
+        if (overwrite || !featFamily.containsKey(featureName)) {
+            featFamily.put(featureName, function);
+        }
     }
-  }
 
-  // Update weights based on gradient and learning rate
-  public void update(float gradWithLearningRate,
-                     float cap,
-                     Map<String, Map<String, Double>> flatFeatures) {
-    // update with lInfinite cap
-    for (Map.Entry<String, Map<String, Double>> featureFamily : flatFeatures.entrySet()) {
-      Map<String, Function> familyWeightMap = weights.get(featureFamily.getKey());
-      if (familyWeightMap == null) continue;
-      for (Map.Entry<String, Double> feature : featureFamily.getValue().entrySet()) {
-        Function func = familyWeightMap.get(feature.getKey());
-        if (func == null) continue;
-        float val = feature.getValue().floatValue();
-        func.update(-gradWithLearningRate, val);
-        func.LInfinityCap(cap);
-      }
+    public void update(float gradWithLearningRate, SparseLabeledPoint point, double dropout, Random rand) {
+        for (int i = 0; i < point.indices.length; i++) {
+            if (dropout <= 0 || rand.nextDouble() > dropout) {
+                int index = point.indices[i];
+                Function function = weightVector[index];
+                float value = point.values[i];
+                function.update(-gradWithLearningRate, value);
+            }
+        }
+
+        for (int i = 0; i < point.denseIndices.length; i++) {
+            if (dropout <= 0 || rand.nextDouble() > dropout) {
+                int index = point.denseIndices[i];
+                Function function = weightVector[index];
+                float[] value = point.denseValues[i];
+                function.update(-gradWithLearningRate, value);
+            }
+        }
     }
-  }
 
-  public void updateDense(float gradWithLearningRate,
-                          float cap,
-                          Map<String, List<Double>> denseFeatures) {
-    // update with lInfinite cap
-    if (denseFeatures != null && !denseFeatures.isEmpty()) {
-      Map<String, Function> denseWeights = getOrCreateDenseWeights();
-      for (Map.Entry<String, List<Double>> feature : denseFeatures.entrySet()) {
-        String featureName = feature.getKey();
-        Function func = denseWeights.get(featureName);
-        if (func == null) continue;
-        float[] val = FunctionUtil.toFloat(feature.getValue());
-        func.update(-gradWithLearningRate, val);
-        func.LInfinityCap(cap);
-      }
+    @Override
+    public AdditiveModel clone() throws CloneNotSupportedException {
+        AdditiveModel copy = (AdditiveModel) super.clone();
+
+        // deep copy weights
+        Map<String, Map<String, Function>> newWeights = new HashMap<>();
+        weights.forEach((k, v) -> newWeights.put(k, copyFeatures(v)));
+        copy.weights = newWeights;
+
+        copy.denseWeights = copyFeatures(denseWeights);
+
+        // regenerate weight vector
+        copy.weightVector = new Function[copy.weightVector.length];
+        return copy.generateWeightVector();
     }
-  }
 
-  @Override
-  public AdditiveModel clone() throws CloneNotSupportedException {
-    AdditiveModel copy = (AdditiveModel) super.clone();
+    private Map<String, Function> copyFeatures(Map<String, Function> featureMap) {
+        if (featureMap == null) return null;
 
-    // deep copy weights
-    Map<String, Map<String, Function>> newWeights = new HashMap<>();
-    weights.forEach((k, v) -> newWeights.put(k, copyFeatures(v)));
-    copy.weights = newWeights;
-
-    copy.denseWeights = copyFeatures(denseWeights);
-
-    return copy;
-  }
-
-  private Map<String, Function> copyFeatures(Map<String, Function> featureMap) {
-    if(featureMap == null) return null;
-
-    Map<String, Function> newFeatureMap = new HashMap<>();
-    featureMap.forEach((feature, function) -> {
-      try {
-        newFeatureMap.put(feature, function.clone());
-      } catch (CloneNotSupportedException e) {
-        // Java8 stream does not handle checked exception properly and requires explicit handling
-        e.printStackTrace();
-      }
-    });
-    return newFeatureMap;
-  }
+        Map<String, Function> newFeatureMap = new HashMap<>();
+        featureMap.forEach((feature, function) -> {
+            try {
+                newFeatureMap.put(feature, function.clone());
+            } catch (CloneNotSupportedException e) {
+                // Java8 stream does not handle checked exception properly and requires explicit handling
+                e.printStackTrace();
+            }
+        });
+        return newFeatureMap;
+    }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/ListTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/ListTransform.java
@@ -1,6 +1,7 @@
 package com.airbnb.aerosolve.core.transforms;
 
 import com.airbnb.aerosolve.core.FeatureVector;
+
 import com.typesafe.config.Config;
 
 import java.util.ArrayList;

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/ListTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/ListTransform.java
@@ -5,8 +5,8 @@ import com.typesafe.config.Config;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Vector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Created by hector_yee on 8/25/14.
@@ -32,6 +32,15 @@ public class ListTransform implements Transform {
   public void doTransform(FeatureVector featureVector) {
     for (Transform transform : transforms) {
       transform.doTransform(featureVector);
+    }
+  }
+
+  @Override
+  public void doTransform(Stream<FeatureVector> featureVectors) {
+    // collect stream because they can only be operated once
+    List<FeatureVector> vectors = featureVectors.collect(Collectors.toList());
+    for (Transform transform : transforms) {
+      transform.doTransform(vectors.stream());
     }
   }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/ListTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/ListTransform.java
@@ -6,8 +6,6 @@ import com.typesafe.config.Config;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Created by hector_yee on 8/25/14.
@@ -37,11 +35,10 @@ public class ListTransform implements Transform {
   }
 
   @Override
-  public void doTransform(Stream<FeatureVector> featureVectors) {
+  public void doTransform(Iterable<FeatureVector> featureVectors) {
     // collect stream because they can only be operated once
-    List<FeatureVector> vectors = featureVectors.collect(Collectors.toList());
     for (Transform transform : transforms) {
-      transform.doTransform(vectors.stream());
+      transform.doTransform(featureVectors);
     }
   }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/Transform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/Transform.java
@@ -4,15 +4,39 @@ import com.airbnb.aerosolve.core.FeatureVector;
 import com.typesafe.config.Config;
 
 import java.io.Serializable;
+import java.util.stream.Stream;
 
 /**
  * Created by hector_yee on 8/25/14.
  * Base class for feature transforms.
  */
 public interface Transform extends Serializable {
-  // Configure the transform from the supplied config and key.
-  void configure(Config config, String key);
+    /**
+     * Configure the transform from the supplied config and key.
+     * <p>
+     * This is where initialization should take place. Ideally we want this to be a constructor instead or use a
+     * builder pattern.
+     */
+    void configure(Config config, String key);
 
-  // Applies a transform to the featureVector.
-  void doTransform(FeatureVector featureVector);
+    /**
+     * Apply this transform to a single feature vector.
+     */
+    void doTransform(FeatureVector featureVector);
+
+    /**
+     * Applies this transform to a series of featureVector.
+     *
+     * @implNote this function can be overridden if the transform can be applied much more efficiency in (small) batches
+     * If such implementation exists, one would typically override the single feature vector implementation with the
+     * following instead:
+     * {@code
+     * @Override public void doTransform(FeatureVector featureVector) {
+     * doTransform(Stream.of(featureVector));
+     * }
+     * }
+     */
+    default void doTransform(Stream<FeatureVector> featureVectors) {
+        featureVectors.forEach(this::doTransform);
+    }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/Transform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/Transform.java
@@ -38,7 +38,7 @@ public interface Transform extends Serializable {
    * }
    * </pre>
    */
-  default void doTransform(Stream<FeatureVector> featureVectors) {
+  default void doTransform(Iterable<FeatureVector> featureVectors) {
     featureVectors.forEach(this::doTransform);
   }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/Transform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/Transform.java
@@ -1,6 +1,7 @@
 package com.airbnb.aerosolve.core.transforms;
 
 import com.airbnb.aerosolve.core.FeatureVector;
+
 import com.typesafe.config.Config;
 
 import java.io.Serializable;
@@ -11,32 +12,33 @@ import java.util.stream.Stream;
  * Base class for feature transforms.
  */
 public interface Transform extends Serializable {
-    /**
-     * Configure the transform from the supplied config and key.
-     * <p>
-     * This is where initialization should take place. Ideally we want this to be a constructor instead or use a
-     * builder pattern.
-     */
-    void configure(Config config, String key);
+  /**
+   * Configure the transform from the supplied config and key. <p> This is where initialization
+   * should take place. Ideally we want this to be a constructor instead or use a builder pattern.
+   */
+  void configure(Config config, String key);
 
-    /**
-     * Apply this transform to a single feature vector.
-     */
-    void doTransform(FeatureVector featureVector);
+  /**
+   * Apply this transform to a single feature vector.
+   */
+  void doTransform(FeatureVector featureVector);
 
-    /**
-     * Applies this transform to a series of featureVector.
-     *
-     * @implNote this function can be overridden if the transform can be applied much more efficiency in (small) batches
-     * If such implementation exists, one would typically override the single feature vector implementation with the
-     * following instead:
-     * {@code
-     * @Override public void doTransform(FeatureVector featureVector) {
-     * doTransform(Stream.of(featureVector));
-     * }
-     * }
-     */
-    default void doTransform(Stream<FeatureVector> featureVectors) {
-        featureVectors.forEach(this::doTransform);
-    }
+  /**
+   * Applies this transform to a series of featureVector.
+   *
+   * @implNote this function can be overridden if the transform can be applied much more efficiency
+   * in (small) batches If such implementation exists, one would typically override the single
+   * feature vector implementation with the following instead:
+   * <pre>
+   * {@code
+   *  @Override
+   *  public void doTransform(FeatureVector featureVector) {
+   *    doTransform(Stream.of(featureVector));
+   *  }
+   * }
+   * </pre>
+   */
+  default void doTransform(Stream<FeatureVector> featureVectors) {
+    featureVectors.forEach(this::doTransform);
+  }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/Transformer.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/Transformer.java
@@ -5,127 +5,146 @@ import com.airbnb.aerosolve.core.FeatureVector;
 import com.typesafe.config.Config;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Stream;
 
 public class Transformer implements Serializable {
 
-  private static final long serialVersionUID = 1569952057032186608L;
-  // The transforms to be applied to the context, item and combined
-  // (context | item) respectively.
-  private final Transform contextTransform;
-  private final Transform itemTransform;
-  private final Transform combinedTransform;
+    private static final long serialVersionUID = 1569952057032186608L;
+    // The transforms to be applied to the context, item and combined
+    // (context | item) respectively.
+    private final Transform contextTransform;
+    private final Transform itemTransform;
+    private final Transform combinedTransform;
 
-  public Transformer(Config config, String key) {
-    // Configures the model transforms.
-    // context_transform : name of ListTransform to apply to context
-    // item_transform : name of ListTransform to apply to each item
-    // combined_transform : name of ListTransform to apply to each (item context) pair
-    String contextTransformName = config.getString(key + ".context_transform");
-    contextTransform = TransformFactory.createTransform(config, contextTransformName);
-    String itemTransformName = config.getString(key + ".item_transform");
-    itemTransform = TransformFactory.createTransform(config, itemTransformName);
-    String combinedTransformName = config.getString(key + ".combined_transform");
-    combinedTransform = TransformFactory.createTransform(config, combinedTransformName);
-  }
+    public Transformer(Config config, String key) {
+        // Configures the model transforms.
+        // context_transform : name of ListTransform to apply to context
+        // item_transform : name of ListTransform to apply to each item
+        // combined_transform : name of ListTransform to apply to each (item context) pair
+        String contextTransformName = config.getString(key + ".context_transform");
+        contextTransform = TransformFactory.createTransform(config, contextTransformName);
+        String itemTransformName = config.getString(key + ".item_transform");
+        itemTransform = TransformFactory.createTransform(config, itemTransformName);
+        String combinedTransformName = config.getString(key + ".combined_transform");
+        combinedTransform = TransformFactory.createTransform(config, combinedTransformName);
+    }
 
-  // Helper functions for transforming context, items or combined feature vectors.
-  public void transformContext(FeatureVector context) {
-    if (contextTransform != null && context != null) {
-      contextTransform.doTransform(context);
+    // Helper functions for transforming context, items or combined feature vectors.
+    public void transformContext(FeatureVector context) {
+        if (contextTransform != null && context != null) {
+            contextTransform.doTransform(context);
+        }
     }
-  }
 
-  public void transformItem(FeatureVector item) {
-    if (itemTransform != null && item != null) {
-      itemTransform.doTransform(item);
+    public void transformItem(FeatureVector item) {
+        if (itemTransform != null && item != null) {
+            itemTransform.doTransform(item);
+        }
     }
-  }
 
-  public void transformItems(List<FeatureVector> items) {
-    if (items != null) {
-      for (FeatureVector item : items) {
-        transformItem(item);
-      }
+    public void transformItems(List<FeatureVector> items) {
+        if (items != null) {
+            items.forEach(this::transformItem);
+        }
     }
-  }
 
-  public void transformCombined(FeatureVector combined) {
-    if (combinedTransform != null && combined != null) {
-      combinedTransform.doTransform(combined);
+    /**
+     * Apply combined transform to a (already context-combined) feature vector
+     */
+    public void transformCombined(FeatureVector combined) {
+        if (combinedTransform != null && combined != null) {
+            combinedTransform.doTransform(combined);
+        }
     }
-  }
 
-  // In place apply all the transforms to the context and items
-  // and apply the combined transform to items.
-  public void combineContextAndItems(Example examples) {
-    transformContext(examples.context);
-    transformItems(examples.example);
-    addContextToItemsAndTransform(examples);
-  }
+    /**
+     * Apply combined transform to a stream of (already context-combined) feature vector
+     */
+    public void transformCombined(Stream<FeatureVector> combined) {
+        if (combinedTransform != null && combined != null) {
+            combinedTransform.doTransform(combined);
+        }
+    }
 
-  // Adds the context to items and applies the combined transform
-  public void addContextToItemsAndTransform(Example examples) {
-    Map<String, Set<String>> contextStringFeatures = null;
-    Map<String, Map<String, Double>> contextFloatFeatures = null;
-    Map<String, List<Double>> contextDenseFeatures = null;
-    if (examples.context != null) {
-      if (examples.context.stringFeatures != null) {
-        contextStringFeatures = examples.context.getStringFeatures();
-      }
-      if (examples.context.floatFeatures != null) {
-        contextFloatFeatures = examples.context.getFloatFeatures();
-      }
-      if (examples.context.denseFeatures != null) {
-        contextDenseFeatures = examples.context.getDenseFeatures();
-      }
+    /**
+     * In place apply all the transforms to the context and items,
+     * add context to examples,
+     * and apply the combined transform to now combined examples.
+     */
+    public void combineContextAndItems(Example examples) {
+        transformContext(examples.context);
+        transformItems(examples.example);
+        addContextToItemsAndTransform(examples);
     }
-    for (FeatureVector item : examples.example) {
-      addContextToItemAndTransform(
-          contextStringFeatures, contextFloatFeatures, contextDenseFeatures, item);
-    }
-  }
 
-  public void addContextToItemAndTransform(Map<String, Set<String>> contextStringFeatures,
-                                           Map<String, Map<String, Double>> contextFloatFeatures,
-                                           Map<String, List<Double>> contextDenseFeatures,
-                                           FeatureVector item) {
-    if (contextStringFeatures != null) {
-      if (item.getStringFeatures() == null) {
-        item.setStringFeatures(new HashMap<>());
-      }
-      Map<String, Set<String>> itemStringFeatures = item.getStringFeatures();
-      for (Map.Entry<String, Set<String>> stringFeature : contextStringFeatures.entrySet()) {
-        Set<String> stringFeatureValueCopy = new HashSet<>(stringFeature.getValue());
-        itemStringFeatures.put(stringFeature.getKey(), stringFeatureValueCopy);
-      }
+    /**
+     * Adds the context to items and applies the combined transform
+     */
+    public void addContextToItemsAndTransform(Example examples) {
+        addContextToItems(examples);
+        transformCombined(examples.example.stream());
     }
-    if (contextFloatFeatures != null) {
-      if (item.getFloatFeatures() == null) {
-        item.setFloatFeatures(new HashMap<>());
-      }
-      Map<String, Map<String, Double>> itemFloatFeatures = item.getFloatFeatures();
-      for (Map.Entry<String, Map<String, Double>> floatFeature : contextFloatFeatures.entrySet()) {
-        Map<String, Double> floatFeatureValueCopy = new HashMap<>(floatFeature.getValue());
-        itemFloatFeatures.put(floatFeature.getKey(), floatFeatureValueCopy);
-      }
+
+    /**
+     * Adds the context's features to examples' features
+     */
+    public void addContextToItems(Example examples) {
+        Map<String, Set<String>> contextStringFeatures = null;
+        Map<String, Map<String, Double>> contextFloatFeatures = null;
+        Map<String, List<Double>> contextDenseFeatures = null;
+        if (examples.context != null) {
+            if (examples.context.stringFeatures != null) {
+                contextStringFeatures = examples.context.getStringFeatures();
+            }
+            if (examples.context.floatFeatures != null) {
+                contextFloatFeatures = examples.context.getFloatFeatures();
+            }
+            if (examples.context.denseFeatures != null) {
+                contextDenseFeatures = examples.context.getDenseFeatures();
+            }
+        }
+        for (FeatureVector item : examples.example) {
+            addContextToItem(contextStringFeatures, contextFloatFeatures, contextDenseFeatures, item);
+        }
     }
-    if (contextDenseFeatures != null) {
-      if (item.getDenseFeatures() == null) {
-        item.setDenseFeatures(new HashMap<>());
-      }
-      Map<String, List<Double>> itemDenseFeatures = item.getDenseFeatures();
-      for (Map.Entry<String, List<Double>> denseFeature : contextDenseFeatures.entrySet()) {
-        List<Double> denseFeatureValueCopy = new ArrayList<>(denseFeature.getValue());
-        itemDenseFeatures.put(denseFeature.getKey(), denseFeatureValueCopy);
-      }
+
+    /**
+     * Adds context features to an individual feature vector
+     */
+    private void addContextToItem(Map<String, Set<String>> contextStringFeatures,
+                                  Map<String, Map<String, Double>> contextFloatFeatures,
+                                  Map<String, List<Double>> contextDenseFeatures,
+                                  FeatureVector item) {
+        if (contextStringFeatures != null) {
+            if (item.getStringFeatures() == null) {
+                item.setStringFeatures(new HashMap<>());
+            }
+            Map<String, Set<String>> itemStringFeatures = item.getStringFeatures();
+            for (Map.Entry<String, Set<String>> stringFeature : contextStringFeatures.entrySet()) {
+                Set<String> stringFeatureValueCopy = new HashSet<>(stringFeature.getValue());
+                itemStringFeatures.put(stringFeature.getKey(), stringFeatureValueCopy);
+            }
+        }
+        if (contextFloatFeatures != null) {
+            if (item.getFloatFeatures() == null) {
+                item.setFloatFeatures(new HashMap<>());
+            }
+            Map<String, Map<String, Double>> itemFloatFeatures = item.getFloatFeatures();
+            for (Map.Entry<String, Map<String, Double>> floatFeature : contextFloatFeatures.entrySet()) {
+                Map<String, Double> floatFeatureValueCopy = new HashMap<>(floatFeature.getValue());
+                itemFloatFeatures.put(floatFeature.getKey(), floatFeatureValueCopy);
+            }
+        }
+        if (contextDenseFeatures != null) {
+            if (item.getDenseFeatures() == null) {
+                item.setDenseFeatures(new HashMap<>());
+            }
+            Map<String, List<Double>> itemDenseFeatures = item.getDenseFeatures();
+            for (Map.Entry<String, List<Double>> denseFeature : contextDenseFeatures.entrySet()) {
+                List<Double> denseFeatureValueCopy = new ArrayList<>(denseFeature.getValue());
+                itemDenseFeatures.put(denseFeature.getKey(), denseFeatureValueCopy);
+            }
+        }
     }
-    transformCombined(item);
-  }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/Transformer.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/Transformer.java
@@ -2,149 +2,155 @@ package com.airbnb.aerosolve.core.transforms;
 
 import com.airbnb.aerosolve.core.Example;
 import com.airbnb.aerosolve.core.FeatureVector;
-import com.typesafe.config.Config;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
+
+import com.typesafe.config.Config;
 
 public class Transformer implements Serializable {
 
-    private static final long serialVersionUID = 1569952057032186608L;
-    // The transforms to be applied to the context, item and combined
-    // (context | item) respectively.
-    private final Transform contextTransform;
-    private final Transform itemTransform;
-    private final Transform combinedTransform;
+  private static final long serialVersionUID = 1569952057032186608L;
+  // The transforms to be applied to the context, item and combined
+  // (context | item) respectively.
+  private final Transform contextTransform;
+  private final Transform itemTransform;
+  private final Transform combinedTransform;
 
-    public Transformer(Config config, String key) {
-        // Configures the model transforms.
-        // context_transform : name of ListTransform to apply to context
-        // item_transform : name of ListTransform to apply to each item
-        // combined_transform : name of ListTransform to apply to each (item context) pair
-        String contextTransformName = config.getString(key + ".context_transform");
-        contextTransform = TransformFactory.createTransform(config, contextTransformName);
-        String itemTransformName = config.getString(key + ".item_transform");
-        itemTransform = TransformFactory.createTransform(config, itemTransformName);
-        String combinedTransformName = config.getString(key + ".combined_transform");
-        combinedTransform = TransformFactory.createTransform(config, combinedTransformName);
-    }
+  public Transformer(Config config, String key) {
+    // Configures the model transforms.
+    // context_transform : name of ListTransform to apply to context
+    // item_transform : name of ListTransform to apply to each item
+    // combined_transform : name of ListTransform to apply to each (item context) pair
+    String contextTransformName = config.getString(key + ".context_transform");
+    contextTransform = TransformFactory.createTransform(config, contextTransformName);
+    String itemTransformName = config.getString(key + ".item_transform");
+    itemTransform = TransformFactory.createTransform(config, itemTransformName);
+    String combinedTransformName = config.getString(key + ".combined_transform");
+    combinedTransform = TransformFactory.createTransform(config, combinedTransformName);
+  }
 
-    // Helper functions for transforming context, items or combined feature vectors.
-    public void transformContext(FeatureVector context) {
-        if (contextTransform != null && context != null) {
-            contextTransform.doTransform(context);
-        }
+  // Helper functions for transforming context, items or combined feature vectors.
+  public void transformContext(FeatureVector context) {
+    if (contextTransform != null && context != null) {
+      contextTransform.doTransform(context);
     }
+  }
 
-    public void transformItem(FeatureVector item) {
-        if (itemTransform != null && item != null) {
-            itemTransform.doTransform(item);
-        }
+  public void transformItem(FeatureVector item) {
+    if (itemTransform != null && item != null) {
+      itemTransform.doTransform(item);
     }
+  }
 
-    public void transformItems(List<FeatureVector> items) {
-        if (items != null) {
-            items.forEach(this::transformItem);
-        }
+  public void transformItems(List<FeatureVector> items) {
+    if (items != null) {
+      items.forEach(this::transformItem);
     }
+  }
 
-    /**
-     * Apply combined transform to a (already context-combined) feature vector
-     */
-    public void transformCombined(FeatureVector combined) {
-        if (combinedTransform != null && combined != null) {
-            combinedTransform.doTransform(combined);
-        }
+  /**
+   * Apply combined transform to a (already context-combined) feature vector
+   */
+  public void transformCombined(FeatureVector combined) {
+    if (combinedTransform != null && combined != null) {
+      combinedTransform.doTransform(combined);
     }
+  }
 
-    /**
-     * Apply combined transform to a stream of (already context-combined) feature vector
-     */
-    public void transformCombined(Stream<FeatureVector> combined) {
-        if (combinedTransform != null && combined != null) {
-            combinedTransform.doTransform(combined);
-        }
+  /**
+   * Apply combined transform to a stream of (already context-combined) feature vector
+   */
+  public void transformCombined(Stream<FeatureVector> combined) {
+    if (combinedTransform != null && combined != null) {
+      combinedTransform.doTransform(combined);
     }
+  }
 
-    /**
-     * In place apply all the transforms to the context and items,
-     * add context to examples,
-     * and apply the combined transform to now combined examples.
-     */
-    public void combineContextAndItems(Example examples) {
-        transformContext(examples.context);
-        transformItems(examples.example);
-        addContextToItemsAndTransform(examples);
-    }
+  /**
+   * In place apply all the transforms to the context and items,
+   * add context to examples,
+   * and apply the combined transform to now combined examples.
+   */
+  public void combineContextAndItems(Example examples) {
+    transformContext(examples.context);
+    transformItems(examples.example);
+    addContextToItemsAndTransform(examples);
+  }
 
-    /**
-     * Adds the context to items and applies the combined transform
-     */
-    public void addContextToItemsAndTransform(Example examples) {
-        addContextToItems(examples);
-        transformCombined(examples.example.stream());
-    }
+  /**
+   * Adds the context to items and applies the combined transform
+   */
+  public void addContextToItemsAndTransform(Example examples) {
+    addContextToItems(examples);
+    transformCombined(examples.example.stream());
+  }
 
-    /**
-     * Adds the context's features to examples' features
-     */
-    public void addContextToItems(Example examples) {
-        Map<String, Set<String>> contextStringFeatures = null;
-        Map<String, Map<String, Double>> contextFloatFeatures = null;
-        Map<String, List<Double>> contextDenseFeatures = null;
-        if (examples.context != null) {
-            if (examples.context.stringFeatures != null) {
-                contextStringFeatures = examples.context.getStringFeatures();
-            }
-            if (examples.context.floatFeatures != null) {
-                contextFloatFeatures = examples.context.getFloatFeatures();
-            }
-            if (examples.context.denseFeatures != null) {
-                contextDenseFeatures = examples.context.getDenseFeatures();
-            }
-        }
-        for (FeatureVector item : examples.example) {
-            addContextToItem(contextStringFeatures, contextFloatFeatures, contextDenseFeatures, item);
-        }
+  /**
+   * Adds the context's features to examples' features
+   */
+  public void addContextToItems(Example examples) {
+    Map<String, Set<String>> contextStringFeatures = null;
+    Map<String, Map<String, Double>> contextFloatFeatures = null;
+    Map<String, List<Double>> contextDenseFeatures = null;
+    if (examples.context != null) {
+      if (examples.context.stringFeatures != null) {
+        contextStringFeatures = examples.context.getStringFeatures();
+      }
+      if (examples.context.floatFeatures != null) {
+        contextFloatFeatures = examples.context.getFloatFeatures();
+      }
+      if (examples.context.denseFeatures != null) {
+        contextDenseFeatures = examples.context.getDenseFeatures();
+      }
     }
+    for (FeatureVector item : examples.example) {
+      addContextToItem(contextStringFeatures, contextFloatFeatures, contextDenseFeatures, item);
+    }
+  }
 
-    /**
-     * Adds context features to an individual feature vector
-     */
-    private void addContextToItem(Map<String, Set<String>> contextStringFeatures,
-                                  Map<String, Map<String, Double>> contextFloatFeatures,
-                                  Map<String, List<Double>> contextDenseFeatures,
-                                  FeatureVector item) {
-        if (contextStringFeatures != null) {
-            if (item.getStringFeatures() == null) {
-                item.setStringFeatures(new HashMap<>());
-            }
-            Map<String, Set<String>> itemStringFeatures = item.getStringFeatures();
-            for (Map.Entry<String, Set<String>> stringFeature : contextStringFeatures.entrySet()) {
-                Set<String> stringFeatureValueCopy = new HashSet<>(stringFeature.getValue());
-                itemStringFeatures.put(stringFeature.getKey(), stringFeatureValueCopy);
-            }
-        }
-        if (contextFloatFeatures != null) {
-            if (item.getFloatFeatures() == null) {
-                item.setFloatFeatures(new HashMap<>());
-            }
-            Map<String, Map<String, Double>> itemFloatFeatures = item.getFloatFeatures();
-            for (Map.Entry<String, Map<String, Double>> floatFeature : contextFloatFeatures.entrySet()) {
-                Map<String, Double> floatFeatureValueCopy = new HashMap<>(floatFeature.getValue());
-                itemFloatFeatures.put(floatFeature.getKey(), floatFeatureValueCopy);
-            }
-        }
-        if (contextDenseFeatures != null) {
-            if (item.getDenseFeatures() == null) {
-                item.setDenseFeatures(new HashMap<>());
-            }
-            Map<String, List<Double>> itemDenseFeatures = item.getDenseFeatures();
-            for (Map.Entry<String, List<Double>> denseFeature : contextDenseFeatures.entrySet()) {
-                List<Double> denseFeatureValueCopy = new ArrayList<>(denseFeature.getValue());
-                itemDenseFeatures.put(denseFeature.getKey(), denseFeatureValueCopy);
-            }
-        }
+  /**
+   * Adds context features to an individual feature vector
+   */
+  private void addContextToItem(Map<String, Set<String>> contextStringFeatures,
+                                Map<String, Map<String, Double>> contextFloatFeatures,
+                                Map<String, List<Double>> contextDenseFeatures,
+                                FeatureVector item) {
+    if (contextStringFeatures != null) {
+      if (item.getStringFeatures() == null) {
+        item.setStringFeatures(new HashMap<>());
+      }
+      Map<String, Set<String>> itemStringFeatures = item.getStringFeatures();
+      for (Map.Entry<String, Set<String>> stringFeature : contextStringFeatures.entrySet()) {
+        Set<String> stringFeatureValueCopy = new HashSet<>(stringFeature.getValue());
+        itemStringFeatures.put(stringFeature.getKey(), stringFeatureValueCopy);
+      }
     }
+    if (contextFloatFeatures != null) {
+      if (item.getFloatFeatures() == null) {
+        item.setFloatFeatures(new HashMap<>());
+      }
+      Map<String, Map<String, Double>> itemFloatFeatures = item.getFloatFeatures();
+      for (Map.Entry<String, Map<String, Double>> floatFeature : contextFloatFeatures.entrySet()) {
+        Map<String, Double> floatFeatureValueCopy = new HashMap<>(floatFeature.getValue());
+        itemFloatFeatures.put(floatFeature.getKey(), floatFeatureValueCopy);
+      }
+    }
+    if (contextDenseFeatures != null) {
+      if (item.getDenseFeatures() == null) {
+        item.setDenseFeatures(new HashMap<>());
+      }
+      Map<String, List<Double>> itemDenseFeatures = item.getDenseFeatures();
+      for (Map.Entry<String, List<Double>> denseFeature : contextDenseFeatures.entrySet()) {
+        List<Double> denseFeatureValueCopy = new ArrayList<>(denseFeature.getValue());
+        itemDenseFeatures.put(denseFeature.getKey(), denseFeatureValueCopy);
+      }
+    }
+  }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/Transformer.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/Transformer.java
@@ -67,7 +67,7 @@ public class Transformer implements Serializable {
   /**
    * Apply combined transform to a stream of (already context-combined) feature vector
    */
-  public void transformCombined(Stream<FeatureVector> combined) {
+  public void transformCombined(Iterable<FeatureVector> combined) {
     if (combinedTransform != null && combined != null) {
       combinedTransform.doTransform(combined);
     }
@@ -89,7 +89,7 @@ public class Transformer implements Serializable {
    */
   public void addContextToItemsAndTransform(Example examples) {
     addContextToItems(examples);
-    transformCombined(examples.example.stream());
+    transformCombined(examples.example);
   }
 
   /**

--- a/core/src/main/java/com/airbnb/aerosolve/core/util/Util.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/util/Util.java
@@ -6,450 +6,474 @@ package com.airbnb.aerosolve.core.util;
  * Utilities for machine learning
  */
 
-import com.airbnb.aerosolve.core.*;
+import com.airbnb.aerosolve.core.DebugScoreDiffRecord;
+import com.airbnb.aerosolve.core.DebugScoreRecord;
+import com.airbnb.aerosolve.core.Example;
+import com.airbnb.aerosolve.core.FeatureVector;
+import com.airbnb.aerosolve.core.KDTreeNode;
+import com.airbnb.aerosolve.core.ModelRecord;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Stream;
+import java.util.zip.GZIPInputStream;
+
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TDeserializer;
 import org.apache.thrift.TSerializer;
 
-import java.io.*;
-import java.util.*;
-import java.util.stream.Stream;
-import java.util.zip.GZIPInputStream;
-
 @Slf4j
 public class Util implements Serializable {
-    private static double LOG2 = Math.log(2);
+  private static double LOG2 = Math.log(2);
 
-    // Coder / decoder utilities for various protos. This makes it easy to
-    // manipulate in spark. e.g. if we  wanted to see the 50 weights in a model
-    // val top50 = sc.textFile("model.bz2").map(Util.decodeModel).sortBy(x => -x.weight).take(50);
-    public static String encode(TBase obj) {
-        TSerializer serializer = new TSerializer();
-        try {
-            byte[] bytes = serializer.serialize(obj);
-            return new String(Base64.encodeBase64(bytes));
-        } catch (Exception e) {
-            return "";
+  // Coder / decoder utilities for various protos. This makes it easy to
+  // manipulate in spark. e.g. if we  wanted to see the 50 weights in a model
+  // val top50 = sc.textFile("model.bz2").map(Util.decodeModel).sortBy(x => -x.weight).take(50);
+  public static String encode(TBase obj) {
+    TSerializer serializer = new TSerializer();
+    try {
+      byte[] bytes = serializer.serialize(obj);
+      return new String(Base64.encodeBase64(bytes));
+    } catch (Exception e) {
+      return "";
+    }
+  }
+
+  public static FeatureVector decodeFeatureVector(String str) {
+    return decode(FeatureVector.class, str);
+  }
+
+  public static FeatureVector createNewFeatureVector() {
+    FeatureVector featureVector = new FeatureVector();
+    Map<String, Map<String, Double>> floatFeatures = new HashMap<>();
+    Map<String, Set<String>> stringFeatures = new HashMap<>();
+    featureVector.setFloatFeatures(floatFeatures);
+    featureVector.setStringFeatures(stringFeatures);
+
+    return featureVector;
+  }
+
+  public static Example createNewExample() {
+    Example example = new Example();
+    example.setContext(createNewFeatureVector());
+    example.setExample(new ArrayList<FeatureVector>());
+
+    return example;
+  }
+
+  public static Example decodeExample(String str) {
+    return decode(Example.class, str);
+  }
+
+  public static ModelRecord decodeModel(String str) {
+    return decode(ModelRecord.class, str);
+  }
+
+  public static <T extends TBase> T decode(T base, String str) {
+    try {
+      byte[] bytes = Base64.decodeBase64(str.getBytes());
+      TDeserializer deserializer = new TDeserializer();
+      deserializer.deserialize(base, bytes);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    return base;
+  }
+
+  public static <T extends TBase> T decode(Class<T> clazz, String str) {
+    try {
+      return decode(clazz.newInstance(), str);
+    } catch (InstantiationException e) {
+      e.printStackTrace();
+    } catch (IllegalAccessException e) {
+      e.printStackTrace();
+    }
+    return null;
+  }
+
+  public static KDTreeNode decodeKDTreeNode(String str) {
+    return decode(KDTreeNode.class, str);
+  }
+
+  public static <T extends TBase> List<T> readFromGzippedStream(Class<T> clazz, InputStream inputStream) {
+    try {
+      if (inputStream != null) {
+        GZIPInputStream gzipInputStream = new GZIPInputStream(inputStream);
+        BufferedReader reader = new BufferedReader(new InputStreamReader(gzipInputStream));
+        List<T> list = new ArrayList<>();
+        String line = reader.readLine();
+        while (line != null) {
+          T t = Util.decode(clazz, line);
+          if (t == null) {
+            assert (false);
+            return Collections.EMPTY_LIST;
+          }
+          list.add(t);
+          line = reader.readLine();
         }
+        return list;
+      }
+    } catch (IOException e) {
+      e.printStackTrace();
     }
+    return Collections.EMPTY_LIST;
+  }
 
-    public static FeatureVector decodeFeatureVector(String str) {
-        return decode(FeatureVector.class, str);
+  public static void optionallyCreateStringFeatures(FeatureVector featureVector) {
+    if (featureVector.getStringFeatures() == null) {
+      Map<String, Set<String>> stringFeatures = new HashMap<>();
+      featureVector.setStringFeatures(stringFeatures);
     }
+  }
 
-    public static FeatureVector createNewFeatureVector() {
-        FeatureVector featureVector = new FeatureVector();
-        Map<String, Map<String, Double>> floatFeatures = new HashMap<>();
-        Map<String, Set<String>> stringFeatures = new HashMap<>();
-        featureVector.setFloatFeatures(floatFeatures);
-        featureVector.setStringFeatures(stringFeatures);
-
-        return featureVector;
+  public static void optionallyCreateFloatFeatures(FeatureVector featureVector) {
+    if (featureVector.getFloatFeatures() == null) {
+      Map<String, Map<String, Double>> floatFeatures = new HashMap<>();
+      featureVector.setFloatFeatures(floatFeatures);
     }
+  }
 
-    public static Example createNewExample() {
-        Example example = new Example();
-        example.setContext(createNewFeatureVector());
-        example.setExample(new ArrayList<FeatureVector>());
-
-        return example;
+  public static void setStringFeature(
+      FeatureVector featureVector,
+      String family,
+      String value) {
+    Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
+    if (stringFeatures == null) {
+      stringFeatures = new HashMap<>();
+      featureVector.setStringFeatures(stringFeatures);
     }
+    Set<String> stringFamily = getOrCreateStringFeature(family, stringFeatures);
+    stringFamily.add(value);
+  }
 
-    public static Example decodeExample(String str) {
-        return decode(Example.class, str);
+  public static Set<String> getOrCreateStringFeature(
+      String name,
+      Map<String, Set<String>> stringFeatures) {
+    Set<String> output = stringFeatures.get(name);
+    if (output == null) {
+      output = new HashSet<>();
+      stringFeatures.put(name, output);
     }
+    return output;
+  }
 
-    public static ModelRecord decodeModel(String str) {
-        return decode(ModelRecord.class, str);
+  public static Map<String, Double> getOrCreateFloatFeature(
+      String name,
+      Map<String, Map<String, Double>> floatFeatures) {
+    Map<String, Double> output = floatFeatures.get(name);
+    if (output == null) {
+      output = new HashMap<>();
+      floatFeatures.put(name, output);
     }
+    return output;
+  }
 
-    public static <T extends TBase> T decode(T base, String str) {
-        try {
-            byte[] bytes = Base64.decodeBase64(str.getBytes());
-            TDeserializer deserializer = new TDeserializer();
-            deserializer.deserialize(base, bytes);
-        } catch (Exception e) {
-            e.printStackTrace();
+  public static Map<String, List<Double>> getOrCreateDenseFeatures(FeatureVector featureVector) {
+    if (featureVector.getDenseFeatures() == null) {
+      Map<String, List<Double>> dense = new HashMap<>();
+      featureVector.setDenseFeatures(dense);
+    }
+    return featureVector.getDenseFeatures();
+  }
+
+  public static void setDenseFeature(
+      FeatureVector featureVector,
+      String name,
+      List<Double> value) {
+    Map<String, List<Double>> denseFeatures = featureVector.getDenseFeatures();
+    if (denseFeatures == null) {
+      denseFeatures = new HashMap<>();
+      featureVector.setDenseFeatures(denseFeatures);
+    }
+    denseFeatures.put(name, value);
+  }
+
+
+  public static HashCode getHashCode(String family, String value) {
+    Hasher hasher = Hashing.murmur3_128().newHasher();
+    hasher.putBytes(family.getBytes());
+    hasher.putBytes(value.getBytes());
+    return hasher.hash();
+  }
+
+  public static <K, V extends Comparable<V>> Map.Entry<K, V>[] sortByValuesDesc(final Map<K, V> map) {
+    if (map == null || map.size() == 0) {
+      return null;
+    }
+    try {
+      @SuppressWarnings("unchecked")
+      Map.Entry<K, V>[] array = map.entrySet().toArray(new Map.Entry[map.size()]);
+
+      Arrays.sort(array, new Comparator<Map.Entry<K, V>>() {
+        public int compare(Map.Entry<K, V> e1, Map.Entry<K, V> e2) {
+          return e2.getValue().compareTo(e1.getValue());
         }
-        return base;
-    }
+      });
 
-    public static <T extends TBase> T decode(Class<T> clazz, String str) {
-        try {
-            return decode(clazz.newInstance(), str);
-        } catch (InstantiationException e) {
-            e.printStackTrace();
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
+      return array;
+    } catch (Exception e) {
+    }
+    return null;
+  }
+
+  public static <K extends Comparable<K>, V> Map.Entry<K, V>[] sortByKeysAsc(final Map<K, V> map) {
+    if (map == null || map.size() == 0) {
+      return null;
+    }
+    try {
+      @SuppressWarnings("unchecked")
+      Map.Entry<K, V>[] array = map.entrySet().toArray(new Map.Entry[map.size()]);
+
+      Arrays.sort(array, new Comparator<Map.Entry<K, V>>() {
+        public int compare(Map.Entry<K, V> e1, Map.Entry<K, V> e2) {
+          return e1.getKey().compareTo(e1.getKey());
         }
-        return null;
+      });
+
+      return array;
+    } catch (Exception e) {
+    }
+    return null;
+  }
+
+  public static double logBase2(double value) {
+    return Math.log(value) / LOG2;
+  }
+
+  public static Map<Integer, Double> prepareRankMap(List<Double> scores, List<Double> utilities) {
+    Map<Integer, Double> rankMap = new HashMap<Integer, Double>();
+    if (scores == null || utilities == null || scores.size() != utilities.size()) {
+      return rankMap;
+    }
+    Map<Integer, Double> scoresMap = new HashMap<>();
+    for (int i = 0; i < scores.size(); i++) {
+      scoresMap.put(i, scores.get(i));
+    }
+    Map.Entry<Integer, Double>[] kvs = sortByValuesDesc(scoresMap);
+    for (int j = 0; j < kvs.length; j++) {
+      double util = utilities.get(kvs[j].getKey());
+      rankMap.put(j, util);
+    }
+    return rankMap;
+  }
+
+  public static <K, V> Map<K, V> safeMap(Map<K, V> map) {
+    if (map == null) {
+      return Collections.EMPTY_MAP;
+    } else {
+      return map;
+    }
+  }
+
+  /**
+   * Flatten a feature vector from example to a nested stream(feature family, stream(feature name.
+   * feature value))
+   */
+  public static Stream<? extends Map.Entry<String, Stream<? extends Map.Entry<String, Double>>>> flattenFeatureAsStream(FeatureVector featureVector) {
+    // reuse flatten with dropout = 0
+    return flattenFeatureWithDropoutAsStream(featureVector, 0.0, 0);
+  }
+
+  /**
+   * Flatten a feature vector from example to a nested map of feature family -> (feature -> value)
+   */
+  public static Map<String, Map<String, Double>> flattenFeature(FeatureVector featureVector) {
+    return flattenFeatureStreamToMap(flattenFeatureAsStream(featureVector));
+  }
+
+  private static Random random = new Random();
+
+  /**
+   * Flatten a feature vector from example to a nested map of feature family -> (feature -> value)
+   * with dropout
+   */
+  public static Map<String, Map<String, Double>> flattenFeatureWithDropout(FeatureVector featureVector, double dropout) {
+    long seed = random.nextLong();
+    return flattenFeatureStreamToMap(flattenFeatureWithDropoutAsStream(featureVector, dropout, seed));
+  }
+
+  /**
+   * Convert a flatten nested stream(feature family, stream(feature name. feature value)) to nested
+   * map of feature family -> (feature -> value)
+   */
+  private static Map<String, Map<String, Double>> flattenFeatureStreamToMap(Stream<? extends Map.Entry<String, Stream<? extends Map.Entry<String, Double>>>> stream) {
+    Map<String, Map<String, Double>> outputFeatureMap = new HashMap<>();
+
+    stream.forEach(inputFamilyEntry -> {
+      String familyName = inputFamilyEntry.getKey();
+      Map<String, Double> outputFeatureFamily = outputFeatureMap.get(familyName);
+      if (outputFeatureFamily == null) {
+        outputFeatureFamily = new HashMap<>();
+        outputFeatureMap.put(familyName, outputFeatureFamily);
+      }
+      // NB: this is necessary due to stream semantic where variable inside forEach has to be final
+      final Map<String, Double> finalFeatures = outputFeatureFamily;
+      inputFamilyEntry.getValue().forEach(feature -> finalFeatures.put(feature.getKey(), feature.getValue()));
+    });
+
+    return outputFeatureMap;
+  }
+
+  /**
+   * Convert a feature vector from example to a nested stream(feature family, stream(feature name.
+   * feature value)) with dropout
+   *
+   * @apiNote Understand Stream can only be iterated once just like iterator, it is crucial to set a
+   * random seed if one wants to reproduce consistent dropout result.
+   */
+  public static Stream<? extends Map.Entry<String, Stream<? extends Map.Entry<String, Double>>>> flattenFeatureWithDropoutAsStream(
+      FeatureVector featureVector, double dropout, long seed) {
+    // collect string features into a stream
+    Stream<? extends Map.Entry<String, Stream<? extends Map.Entry<String, Double>>>> stringFeatures = Stream.empty();
+    if (featureVector.stringFeatures != null) {
+      stringFeatures = featureVector.stringFeatures.entrySet().stream().map(entry -> {
+        Stream<? extends Map.Entry<String, Double>> values =
+            entry.getValue().stream()
+                .map(feature -> new HashMap.SimpleImmutableEntry<>(feature, 1.0));
+        return new HashMap.SimpleImmutableEntry<>(entry.getKey(), values);
+      });
     }
 
-    public static KDTreeNode decodeKDTreeNode(String str) {
-        return decode(KDTreeNode.class, str);
+    // collect float features into a stream
+    Stream<? extends Map.Entry<String, Stream<? extends Map.Entry<String, Double>>>> floatFeatures = Stream.empty();
+    if (featureVector.floatFeatures != null) {
+      floatFeatures = featureVector.floatFeatures.entrySet().stream().map(entry ->
+          new HashMap.SimpleImmutableEntry<>(entry.getKey(), entry.getValue().entrySet().stream())
+      );
     }
 
-    public static <T extends TBase> List<T> readFromGzippedStream(Class<T> clazz, InputStream inputStream) {
-        try {
-            if (inputStream != null) {
-                GZIPInputStream gzipInputStream = new GZIPInputStream(inputStream);
-                BufferedReader reader = new BufferedReader(new InputStreamReader(gzipInputStream));
-                List<T> list = new ArrayList<>();
-                String line = reader.readLine();
-                while (line != null) {
-                    T t = Util.decode(clazz, line);
-                    if (t == null) {
-                        assert (false);
-                        return Collections.EMPTY_LIST;
-                    }
-                    list.add(t);
-                    line = reader.readLine();
-                }
-                return list;
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return Collections.EMPTY_LIST;
+    // concat string and float features and apply dropout if necessary
+    Stream<? extends Map.Entry<String, Stream<? extends Map.Entry<String, Double>>>> flatFeatures = Stream.concat(stringFeatures, floatFeatures);
+    if (dropout > 0) {
+      Random random = new Random(seed);
+      // dropout needs to be applied in the inner most stream
+      return flatFeatures.map(
+          entry -> new HashMap.SimpleImmutableEntry<>(entry.getKey(), entry.getValue().filter(x -> random.nextDouble() >= dropout))
+      );
+    } else {
+      return flatFeatures;
+    }
+  }
+
+  public static class DebugDiffRecordComparator implements Comparator<DebugScoreDiffRecord> {
+    @Override
+    public int compare(DebugScoreDiffRecord e1, DebugScoreDiffRecord e2) {
+      double v1 = Math.abs(e1.getFeatureWeightDiff());
+      double v2 = Math.abs(e2.getFeatureWeightDiff());
+      if (v1 > v2) {
+        return -1;
+      } else if (v1 < v2) {
+        return 1;
+      }
+      return 0;
     }
 
-    public static void optionallyCreateStringFeatures(FeatureVector featureVector) {
-        if (featureVector.getStringFeatures() == null) {
-            Map<String, Set<String>> stringFeatures = new HashMap<>();
-            featureVector.setStringFeatures(stringFeatures);
-        }
+  }
+
+  private static Map<String, Map<String, Double>> debugScoreRecordListToMap(List<DebugScoreRecord> recordList) {
+    Map<String, Map<String, Double>> recordMap = new HashMap<>();
+
+    for (int i = 0; i < recordList.size(); i++) {
+      String key = recordList.get(i).featureFamily + '\t' + recordList.get(i).featureName;
+      Map<String, Double> record = new HashMap<>();
+      record.put("featureValue", recordList.get(i).featureValue);
+      record.put("featureWeight", recordList.get(i).featureWeight);
+      recordMap.put(key, record);
+    }
+    return recordMap;
+  }
+
+  public static List<DebugScoreDiffRecord> compareDebugRecords(List<DebugScoreRecord> record1,
+                                                               List<DebugScoreRecord> record2) {
+    List<DebugScoreDiffRecord> debugDiffRecord = new ArrayList<>();
+    final String featureValue = "featureValue";
+    final String featureWeight = "featureWeight";
+    Set<String> keys = new HashSet();
+
+    Map<String, Map<String, Double>> recordMap1 = debugScoreRecordListToMap(record1);
+    Map<String, Map<String, Double>> recordMap2 = debugScoreRecordListToMap(record2);
+    keys.addAll(recordMap1.keySet());
+    keys.addAll(recordMap2.keySet());
+
+    for (String key : keys) {
+      DebugScoreDiffRecord diffRecord = new DebugScoreDiffRecord();
+      double fv1 = 0.0;
+      double fv2 = 0.0;
+      double fw1 = 0.0;
+      double fw2 = 0.0;
+      if (recordMap1.get(key) != null) {
+        fv1 = recordMap1.get(key).get(featureValue);
+        fw1 = recordMap1.get(key).get(featureWeight);
+      }
+      if (recordMap2.get(key) != null) {
+        fv2 = recordMap2.get(key).get(featureValue);
+        fw2 = recordMap2.get(key).get(featureWeight);
+      }
+
+      String[] fvString = key.split("\t");
+
+      diffRecord.setFeatureFamily(fvString[0]);
+      diffRecord.setFeatureName(fvString[1]);
+      diffRecord.setFeatureValue1(fv1);
+      diffRecord.setFeatureValue2(fv2);
+      diffRecord.setFeatureWeight1(fw1);
+      diffRecord.setFeatureWeight2(fw2);
+      diffRecord.setFeatureWeightDiff(fw1 - fw2);
+      debugDiffRecord.add(diffRecord);
+    }
+    Collections.sort(debugDiffRecord, new DebugDiffRecordComparator());
+    return debugDiffRecord;
+  }
+
+  public static <T> Set<T> getIntersection(Set<T> a, Set<T> b) {
+    if (a == null || b == null) {
+      return Collections.EMPTY_SET;
     }
 
-    public static void optionallyCreateFloatFeatures(FeatureVector featureVector) {
-        if (featureVector.getFloatFeatures() == null) {
-            Map<String, Map<String, Double>> floatFeatures = new HashMap<>();
-            featureVector.setFloatFeatures(floatFeatures);
-        }
+    Set<T> small = (a.size() > b.size()) ? b : a;
+    Set<T> big = (a.size() > b.size()) ? a : b;
+
+    Set<T> intersection = new HashSet<T>(small);
+    intersection.retainAll(big);
+    return intersection;
+  }
+
+  public static float euclideanDistance(float[] x, List<Float> y) {
+    assert (x.length == y.size());
+    double sum = 0;
+    for (int i = 0; i < x.length; i++) {
+      final double dp = x[i] - y.get(i);
+      sum += dp * dp;
     }
+    return (float) Math.sqrt(sum);
+  }
 
-    public static void setStringFeature(
-            FeatureVector featureVector,
-            String family,
-            String value) {
-        Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
-        if (stringFeatures == null) {
-            stringFeatures = new HashMap<>();
-            featureVector.setStringFeatures(stringFeatures);
-        }
-        Set<String> stringFamily = getOrCreateStringFeature(family, stringFeatures);
-        stringFamily.add(value);
+  public static float euclideanDistance(List<Double> x, List<Float> y) {
+    assert (x.size() == y.size());
+    double sum = 0;
+    for (int i = 0; i < y.size(); i++) {
+      final double dp = x.get(i) - y.get(i);
+      sum += dp * dp;
     }
-
-    public static Set<String> getOrCreateStringFeature(
-            String name,
-            Map<String, Set<String>> stringFeatures) {
-        Set<String> output = stringFeatures.get(name);
-        if (output == null) {
-            output = new HashSet<>();
-            stringFeatures.put(name, output);
-        }
-        return output;
-    }
-
-    public static Map<String, Double> getOrCreateFloatFeature(
-            String name,
-            Map<String, Map<String, Double>> floatFeatures) {
-        Map<String, Double> output = floatFeatures.get(name);
-        if (output == null) {
-            output = new HashMap<>();
-            floatFeatures.put(name, output);
-        }
-        return output;
-    }
-
-    public static Map<String, List<Double>> getOrCreateDenseFeatures(FeatureVector featureVector) {
-        if (featureVector.getDenseFeatures() == null) {
-            Map<String, List<Double>> dense = new HashMap<>();
-            featureVector.setDenseFeatures(dense);
-        }
-        return featureVector.getDenseFeatures();
-    }
-
-    public static void setDenseFeature(
-            FeatureVector featureVector,
-            String name,
-            List<Double> value) {
-        Map<String, List<Double>> denseFeatures = featureVector.getDenseFeatures();
-        if (denseFeatures == null) {
-            denseFeatures = new HashMap<>();
-            featureVector.setDenseFeatures(denseFeatures);
-        }
-        denseFeatures.put(name, value);
-    }
-
-
-    public static HashCode getHashCode(String family, String value) {
-        Hasher hasher = Hashing.murmur3_128().newHasher();
-        hasher.putBytes(family.getBytes());
-        hasher.putBytes(value.getBytes());
-        return hasher.hash();
-    }
-
-    public static <K, V extends Comparable<V>> Map.Entry<K, V>[] sortByValuesDesc(final Map<K, V> map) {
-        if (map == null || map.size() == 0) {
-            return null;
-        }
-        try {
-            @SuppressWarnings("unchecked")
-            Map.Entry<K, V>[] array = map.entrySet().toArray(new Map.Entry[map.size()]);
-
-            Arrays.sort(array, new Comparator<Map.Entry<K, V>>() {
-                public int compare(Map.Entry<K, V> e1, Map.Entry<K, V> e2) {
-                    return e2.getValue().compareTo(e1.getValue());
-                }
-            });
-
-            return array;
-        } catch (Exception e) {
-        }
-        return null;
-    }
-
-    public static <K extends Comparable<K>, V> Map.Entry<K, V>[] sortByKeysAsc(final Map<K, V> map) {
-        if (map == null || map.size() == 0) {
-            return null;
-        }
-        try {
-            @SuppressWarnings("unchecked")
-            Map.Entry<K, V>[] array = map.entrySet().toArray(new Map.Entry[map.size()]);
-
-            Arrays.sort(array, new Comparator<Map.Entry<K, V>>() {
-                public int compare(Map.Entry<K, V> e1, Map.Entry<K, V> e2) {
-                    return e1.getKey().compareTo(e1.getKey());
-                }
-            });
-
-            return array;
-        } catch (Exception e) {
-        }
-        return null;
-    }
-
-    public static double logBase2(double value) {
-        return Math.log(value) / LOG2;
-    }
-
-    public static Map<Integer, Double> prepareRankMap(List<Double> scores, List<Double> utilities) {
-        Map<Integer, Double> rankMap = new HashMap<Integer, Double>();
-        if (scores == null || utilities == null || scores.size() != utilities.size()) {
-            return rankMap;
-        }
-        Map<Integer, Double> scoresMap = new HashMap<>();
-        for (int i = 0; i < scores.size(); i++) {
-            scoresMap.put(i, scores.get(i));
-        }
-        Map.Entry<Integer, Double>[] kvs = sortByValuesDesc(scoresMap);
-        for (int j = 0; j < kvs.length; j++) {
-            double util = utilities.get(kvs[j].getKey());
-            rankMap.put(j, util);
-        }
-        return rankMap;
-    }
-
-    public static <K, V> Map<K, V> safeMap(Map<K, V> map) {
-        if (map == null) {
-            return Collections.EMPTY_MAP;
-        } else {
-            return map;
-        }
-    }
-
-    /**
-     * Flatten a feature vector from example to a nested stream(feature family, stream(feature name. feature value))
-     */
-    public static Stream<? extends Map.Entry<String, Stream<? extends Map.Entry<String, Double>>>> flattenFeatureAsStream(FeatureVector featureVector) {
-        // reuse flatten with dropout = 0
-        return flattenFeatureWithDropoutAsStream(featureVector, 0.0, 0);
-    }
-
-    /**
-     * Flatten a feature vector from example to a nested map of feature family -> (feature -> value)
-     */
-    public static Map<String, Map<String, Double>> flattenFeature(FeatureVector featureVector) {
-        return flattenFeatureStreamToMap(flattenFeatureAsStream(featureVector));
-    }
-
-    private static Random random = new Random();
-
-    /**
-     * Flatten a feature vector from example to a nested map of feature family -> (feature -> value) with dropout
-     */
-    public static Map<String, Map<String, Double>> flattenFeatureWithDropout(FeatureVector featureVector, double dropout) {
-        long seed = random.nextLong();
-        return flattenFeatureStreamToMap(flattenFeatureWithDropoutAsStream(featureVector, dropout, seed));
-    }
-
-    /**
-     * Convert a flatten nested stream(feature family, stream(feature name. feature value)) to nested map of feature family -> (feature -> value)
-     */
-    private static Map<String, Map<String, Double>> flattenFeatureStreamToMap(Stream<? extends Map.Entry<String, Stream<? extends Map.Entry<String, Double>>>> stream) {
-        Map<String, Map<String, Double>> outputFeatureMap = new HashMap<>();
-
-        stream.forEach(inputFamilyEntry -> {
-            String familyName = inputFamilyEntry.getKey();
-            Map<String, Double> outputFeatureFamily = outputFeatureMap.get(familyName);
-            if (outputFeatureFamily == null) {
-                outputFeatureFamily = new HashMap<>();
-                outputFeatureMap.put(familyName, outputFeatureFamily);
-            }
-            // NB: this is necessary due to stream semantic where variable inside forEach has to be final
-            final Map<String, Double> finalFeatures = outputFeatureFamily;
-            inputFamilyEntry.getValue().forEach(feature -> finalFeatures.put(feature.getKey(), feature.getValue()));
-        });
-
-        return outputFeatureMap;
-    }
-
-    /**
-     * Convert a feature vector from example to a nested stream(feature family, stream(feature name. feature value)) with dropout
-     *
-     * @apiNote Understand Stream can only be iterated once just like iterator, it is crucial to set a random seed if one
-     * wants to reproduce consistent dropout result.
-     */
-    public static Stream<? extends Map.Entry<String, Stream<? extends Map.Entry<String, Double>>>> flattenFeatureWithDropoutAsStream(
-            FeatureVector featureVector, double dropout, long seed) {
-        // collect string features into a stream
-        Stream<? extends Map.Entry<String, Stream<? extends Map.Entry<String, Double>>>> stringFeatures = Stream.empty();
-        if (featureVector.stringFeatures != null) {
-            stringFeatures = featureVector.stringFeatures.entrySet().stream().map(entry -> {
-                Stream<? extends Map.Entry<String, Double>> values =
-                        entry.getValue().stream()
-                                .map(feature -> new HashMap.SimpleImmutableEntry<>(feature, 1.0));
-                return new HashMap.SimpleImmutableEntry<>(entry.getKey(), values);
-            });
-        }
-
-        // collect float features into a stream
-        Stream<? extends Map.Entry<String, Stream<? extends Map.Entry<String, Double>>>> floatFeatures = Stream.empty();
-        if (featureVector.floatFeatures != null) {
-            floatFeatures = featureVector.floatFeatures.entrySet().stream().map(entry ->
-                    new HashMap.SimpleImmutableEntry<>(entry.getKey(), entry.getValue().entrySet().stream())
-            );
-        }
-
-        // concat string and float features and apply dropout if necessary
-        Stream<? extends Map.Entry<String, Stream<? extends Map.Entry<String, Double>>>> flatFeatures = Stream.concat(stringFeatures, floatFeatures);
-        if (dropout > 0) {
-            Random random = new Random(seed);
-            // dropout needs to be applied in the inner most stream
-            return flatFeatures.map(
-                    entry -> new HashMap.SimpleImmutableEntry<>(entry.getKey(), entry.getValue().filter(x -> random.nextDouble() >= dropout))
-            );
-        } else {
-            return flatFeatures;
-        }
-    }
-
-    public static class DebugDiffRecordComparator implements Comparator<DebugScoreDiffRecord> {
-        @Override
-        public int compare(DebugScoreDiffRecord e1, DebugScoreDiffRecord e2) {
-            double v1 = Math.abs(e1.getFeatureWeightDiff());
-            double v2 = Math.abs(e2.getFeatureWeightDiff());
-            if (v1 > v2) {
-                return -1;
-            } else if (v1 < v2) {
-                return 1;
-            }
-            return 0;
-        }
-
-    }
-
-    private static Map<String, Map<String, Double>> debugScoreRecordListToMap(List<DebugScoreRecord> recordList) {
-        Map<String, Map<String, Double>> recordMap = new HashMap<>();
-
-        for (int i = 0; i < recordList.size(); i++) {
-            String key = recordList.get(i).featureFamily + '\t' + recordList.get(i).featureName;
-            Map<String, Double> record = new HashMap<>();
-            record.put("featureValue", recordList.get(i).featureValue);
-            record.put("featureWeight", recordList.get(i).featureWeight);
-            recordMap.put(key, record);
-        }
-        return recordMap;
-    }
-
-    public static List<DebugScoreDiffRecord> compareDebugRecords(List<DebugScoreRecord> record1,
-                                                                 List<DebugScoreRecord> record2) {
-        List<DebugScoreDiffRecord> debugDiffRecord = new ArrayList<>();
-        final String featureValue = "featureValue";
-        final String featureWeight = "featureWeight";
-        Set<String> keys = new HashSet();
-
-        Map<String, Map<String, Double>> recordMap1 = debugScoreRecordListToMap(record1);
-        Map<String, Map<String, Double>> recordMap2 = debugScoreRecordListToMap(record2);
-        keys.addAll(recordMap1.keySet());
-        keys.addAll(recordMap2.keySet());
-
-        for (String key : keys) {
-            DebugScoreDiffRecord diffRecord = new DebugScoreDiffRecord();
-            double fv1 = 0.0;
-            double fv2 = 0.0;
-            double fw1 = 0.0;
-            double fw2 = 0.0;
-            if (recordMap1.get(key) != null) {
-                fv1 = recordMap1.get(key).get(featureValue);
-                fw1 = recordMap1.get(key).get(featureWeight);
-            }
-            if (recordMap2.get(key) != null) {
-                fv2 = recordMap2.get(key).get(featureValue);
-                fw2 = recordMap2.get(key).get(featureWeight);
-            }
-
-            String[] fvString = key.split("\t");
-
-            diffRecord.setFeatureFamily(fvString[0]);
-            diffRecord.setFeatureName(fvString[1]);
-            diffRecord.setFeatureValue1(fv1);
-            diffRecord.setFeatureValue2(fv2);
-            diffRecord.setFeatureWeight1(fw1);
-            diffRecord.setFeatureWeight2(fw2);
-            diffRecord.setFeatureWeightDiff(fw1 - fw2);
-            debugDiffRecord.add(diffRecord);
-        }
-        Collections.sort(debugDiffRecord, new DebugDiffRecordComparator());
-        return debugDiffRecord;
-    }
-
-    public static <T> Set<T> getIntersection(Set<T> a, Set<T> b) {
-        if (a == null || b == null) {
-            return Collections.EMPTY_SET;
-        }
-
-        Set<T> small = (a.size() > b.size()) ? b : a;
-        Set<T> big = (a.size() > b.size()) ? a : b;
-
-        Set<T> intersection = new HashSet<T>(small);
-        intersection.retainAll(big);
-        return intersection;
-    }
-
-    public static float euclideanDistance(float[] x, List<Float> y) {
-        assert (x.length == y.size());
-        double sum = 0;
-        for (int i = 0; i < x.length; i++) {
-            final double dp = x[i] - y.get(i);
-            sum += dp * dp;
-        }
-        return (float) Math.sqrt(sum);
-    }
-
-    public static float euclideanDistance(List<Double> x, List<Float> y) {
-        assert (x.size() == y.size());
-        double sum = 0;
-        for (int i = 0; i < y.size(); i++) {
-            final double dp = x.get(i) - y.get(i);
-            sum += dp * dp;
-        }
-        return (float) Math.sqrt(sum);
-    }
+    return (float) Math.sqrt(sum);
+  }
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/util/Util.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/util/Util.java
@@ -18,399 +18,438 @@ import org.apache.thrift.TSerializer;
 
 import java.io.*;
 import java.util.*;
+import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 
 @Slf4j
 public class Util implements Serializable {
-  private static double LOG2 = Math.log(2);
-  // Coder / decoder utilities for various protos. This makes it easy to
-  // manipulate in spark. e.g. if we  wanted to see the 50 weights in a model
-  // val top50 = sc.textFile("model.bz2").map(Util.decodeModel).sortBy(x => -x.weight).take(50);
-  public static String encode(TBase obj) {
-    TSerializer serializer = new TSerializer();
-    try {
-      byte[] bytes = serializer.serialize(obj);
-      return new String(Base64.encodeBase64(bytes));
-    } catch (Exception e) {
-      return "";
-    }
-  }
-  public static FeatureVector decodeFeatureVector(String str) {
-    return decode(FeatureVector.class, str);
-  }
+    private static double LOG2 = Math.log(2);
 
-  public static FeatureVector createNewFeatureVector() {
-    FeatureVector featureVector = new FeatureVector();
-    Map<String, Map<String, Double>> floatFeatures = new HashMap<>();
-    Map<String, Set<String>> stringFeatures = new HashMap<>();
-    featureVector.setFloatFeatures(floatFeatures);
-    featureVector.setStringFeatures(stringFeatures);
-
-    return featureVector;
-  }
-
-  public static Example createNewExample() {
-    Example example = new Example();
-    example.setContext(createNewFeatureVector());
-    example.setExample(new ArrayList<FeatureVector>());
-
-    return example;
-  }
-
-  public static Example decodeExample(String str) {
-    return decode(Example.class, str);
-  }
-
-  public static ModelRecord decodeModel(String str) {
-    return decode(ModelRecord.class, str);
-  }
-
-  public static <T extends TBase> T decode(T base, String str) {
-    try {
-      byte[] bytes = Base64.decodeBase64(str.getBytes());
-      TDeserializer deserializer = new TDeserializer();
-      deserializer.deserialize(base, bytes);
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-    return base;
-  }
-
-  public static <T extends TBase> T decode(Class<T> clazz, String str) {
-    try {
-      return decode(clazz.newInstance(), str);
-    } catch (InstantiationException e) {
-      e.printStackTrace();
-    } catch (IllegalAccessException e) {
-      e.printStackTrace();
-    }
-    return null;
-  }
-
-  public static KDTreeNode decodeKDTreeNode(String str) {
-    return decode(KDTreeNode.class, str);
-  }
-
-  public static <T extends TBase> List<T> readFromGzippedStream(Class<T> clazz, InputStream inputStream) {
-    try {
-      if (inputStream != null) {
-        GZIPInputStream gzipInputStream = new GZIPInputStream(inputStream);
-        BufferedReader reader = new BufferedReader(new InputStreamReader(gzipInputStream));
-        List<T> list = new ArrayList<>();
-        String line = reader.readLine();
-        while(line != null) {
-          T t = Util.decode(clazz, line);
-          if (t == null) {
-            assert (false);
-            return Collections.EMPTY_LIST;
-          }
-          list.add(t);
-          line = reader.readLine();
+    // Coder / decoder utilities for various protos. This makes it easy to
+    // manipulate in spark. e.g. if we  wanted to see the 50 weights in a model
+    // val top50 = sc.textFile("model.bz2").map(Util.decodeModel).sortBy(x => -x.weight).take(50);
+    public static String encode(TBase obj) {
+        TSerializer serializer = new TSerializer();
+        try {
+            byte[] bytes = serializer.serialize(obj);
+            return new String(Base64.encodeBase64(bytes));
+        } catch (Exception e) {
+            return "";
         }
-        return list;
-      }
-    } catch (IOException e) {
-      e.printStackTrace();
     }
-    return Collections.EMPTY_LIST;
-  }
 
-  public static void optionallyCreateStringFeatures(FeatureVector featureVector) {
-    if (featureVector.getStringFeatures() == null) {
-      Map<String, Set<String>> stringFeatures = new HashMap<>();
-      featureVector.setStringFeatures(stringFeatures);
+    public static FeatureVector decodeFeatureVector(String str) {
+        return decode(FeatureVector.class, str);
     }
-  }
 
-  public static void optionallyCreateFloatFeatures(FeatureVector featureVector) {
-    if (featureVector.getFloatFeatures() == null) {
-      Map<String, Map<String, Double>> floatFeatures = new HashMap<>();
-      featureVector.setFloatFeatures(floatFeatures);
+    public static FeatureVector createNewFeatureVector() {
+        FeatureVector featureVector = new FeatureVector();
+        Map<String, Map<String, Double>> floatFeatures = new HashMap<>();
+        Map<String, Set<String>> stringFeatures = new HashMap<>();
+        featureVector.setFloatFeatures(floatFeatures);
+        featureVector.setStringFeatures(stringFeatures);
+
+        return featureVector;
     }
-  }
 
-  public static void setStringFeature(
-      FeatureVector featureVector,
-      String family,
-      String value) {
-    Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
-    if (stringFeatures == null) {
-      stringFeatures = new HashMap<>();
-      featureVector.setStringFeatures(stringFeatures);
+    public static Example createNewExample() {
+        Example example = new Example();
+        example.setContext(createNewFeatureVector());
+        example.setExample(new ArrayList<FeatureVector>());
+
+        return example;
     }
-    Set<String> stringFamily = getOrCreateStringFeature(family, stringFeatures);
-    stringFamily.add(value);
-  }
 
-  public static Set<String> getOrCreateStringFeature(
-      String name,
-      Map<String, Set<String>> stringFeatures) {
-    Set<String> output = stringFeatures.get(name);
-    if (output == null) {
-      output = new HashSet<>();
-      stringFeatures.put(name, output);
+    public static Example decodeExample(String str) {
+        return decode(Example.class, str);
     }
-    return output;
-  }
 
-  public static Map<String, Double> getOrCreateFloatFeature(
-      String name,
-      Map<String, Map<String, Double>> floatFeatures) {
-    Map<String, Double> output = floatFeatures.get(name);
-    if (output == null) {
-      output = new HashMap<>();
-      floatFeatures.put(name, output);
+    public static ModelRecord decodeModel(String str) {
+        return decode(ModelRecord.class, str);
     }
-    return output;
-  }
 
-  public static Map<String, List<Double>> getOrCreateDenseFeatures(FeatureVector featureVector) {
-    if (featureVector.getDenseFeatures() == null) {
-      Map<String, List<Double>> dense = new HashMap<>();
-      featureVector.setDenseFeatures(dense);
-    }
-    return featureVector.getDenseFeatures();
-  }
-
-  public static void setDenseFeature(
-      FeatureVector featureVector,
-      String name,
-      List<Double> value) {
-    Map<String, List<Double>> denseFeatures = featureVector.getDenseFeatures();
-    if (denseFeatures == null) {
-      denseFeatures = new HashMap<>();
-      featureVector.setDenseFeatures(denseFeatures);
-    }
-    denseFeatures.put(name, value);
-  }
-
-
-  public static HashCode getHashCode(String family, String value) {
-    Hasher hasher = Hashing.murmur3_128().newHasher();
-    hasher.putBytes(family.getBytes());
-    hasher.putBytes(value.getBytes());
-    return hasher.hash();
-  }
-
-  public static <K, V extends Comparable<V>> Map.Entry<K, V>[] sortByValuesDesc(final Map<K, V> map) {
-    if (map == null || map.size() == 0) {
-      return null;
-    }
-    try {
-      @SuppressWarnings("unchecked")
-      Map.Entry<K, V>[] array = map.entrySet().toArray(new Map.Entry[map.size()]);
-
-      Arrays.sort(array, new Comparator<Map.Entry<K, V>>() {
-        public int compare(Map.Entry<K, V> e1, Map.Entry<K, V> e2) {
-          return e2.getValue().compareTo(e1.getValue());
+    public static <T extends TBase> T decode(T base, String str) {
+        try {
+            byte[] bytes = Base64.decodeBase64(str.getBytes());
+            TDeserializer deserializer = new TDeserializer();
+            deserializer.deserialize(base, bytes);
+        } catch (Exception e) {
+            e.printStackTrace();
         }
-      });
-
-      return array;
-    } catch (Exception e) {
+        return base;
     }
-    return null;
-  }
 
-  public static <K extends Comparable<K>, V> Map.Entry<K, V>[] sortByKeysAsc(final Map<K, V> map) {
-    if (map == null || map.size() == 0) {
-      return null;
-    }
-    try {
-      @SuppressWarnings("unchecked")
-      Map.Entry<K, V>[] array = map.entrySet().toArray(new Map.Entry[map.size()]);
-
-      Arrays.sort(array, new Comparator<Map.Entry<K, V>>() {
-        public int compare(Map.Entry<K, V> e1, Map.Entry<K, V> e2) {
-          return e1.getKey().compareTo(e1.getKey());
+    public static <T extends TBase> T decode(Class<T> clazz, String str) {
+        try {
+            return decode(clazz.newInstance(), str);
+        } catch (InstantiationException e) {
+            e.printStackTrace();
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
         }
-      });
-
-      return array;
-    } catch (Exception e) {
+        return null;
     }
-    return null;
-  }
 
-  public static double logBase2(double value) {
-    return Math.log(value)/LOG2;
-  }
+    public static KDTreeNode decodeKDTreeNode(String str) {
+        return decode(KDTreeNode.class, str);
+    }
 
-  public static Map<Integer, Double> prepareRankMap(List<Double> scores, List<Double> utilities) {
-    Map<Integer, Double> rankMap = new HashMap<Integer, Double>();
-    if (scores == null || utilities == null || scores.size() != utilities.size()) {
-      return rankMap;
-    }
-    Map<Integer, Double> scoresMap = new HashMap<>();
-    for (int i = 0; i < scores.size(); i++) {
-      scoresMap.put(i, scores.get(i));
-    }
-    Map.Entry<Integer, Double>[] kvs = sortByValuesDesc(scoresMap);
-    for (int j = 0; j < kvs.length; j ++) {
-      double util = utilities.get(kvs[j].getKey());
-      rankMap.put(j, util);
-    }
-    return rankMap;
-  }
-
-  public static <K,V> Map<K, V> safeMap(Map<K, V> map) {
-    if (map == null) {
-      return Collections.EMPTY_MAP;
-    } else {
-      return map;
-    }
-  }
-
-  public static  Map<String, Map<String, Double>> flattenFeature(
-      FeatureVector featureVector) {
-    Map<String, Map<String, Double>> flatFeature = new HashMap<>();
-    if (featureVector.stringFeatures != null) {
-      for (Map.Entry<String, Set<String>> entry : featureVector.stringFeatures.entrySet()) {
-        Map<String, Double> out = new HashMap<>();
-        flatFeature.put(entry.getKey(), out);
-        for (String feature : entry.getValue()) {
-          out.put(feature, 1.0);
+    public static <T extends TBase> List<T> readFromGzippedStream(Class<T> clazz, InputStream inputStream) {
+        try {
+            if (inputStream != null) {
+                GZIPInputStream gzipInputStream = new GZIPInputStream(inputStream);
+                BufferedReader reader = new BufferedReader(new InputStreamReader(gzipInputStream));
+                List<T> list = new ArrayList<>();
+                String line = reader.readLine();
+                while (line != null) {
+                    T t = Util.decode(clazz, line);
+                    if (t == null) {
+                        assert (false);
+                        return Collections.EMPTY_LIST;
+                    }
+                    list.add(t);
+                    line = reader.readLine();
+                }
+                return list;
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
         }
-      }
+        return Collections.EMPTY_LIST;
     }
-    if (featureVector.floatFeatures != null) {
-      for (Map.Entry<String, Map<String, Double>> entry : featureVector.floatFeatures.entrySet()) {
-        Map<String, Double> out = new HashMap<>();
-        flatFeature.put(entry.getKey(), out);
-        for (Map.Entry<String, Double> feature : entry.getValue().entrySet()) {
-          out.put(feature.getKey(), feature.getValue());
+
+    public static void optionallyCreateStringFeatures(FeatureVector featureVector) {
+        if (featureVector.getStringFeatures() == null) {
+            Map<String, Set<String>> stringFeatures = new HashMap<>();
+            featureVector.setStringFeatures(stringFeatures);
         }
-      }
     }
-    return flatFeature;
-  }
 
-  public static  Map<String, Map<String, Double>> flattenFeatureWithDropout(
-      FeatureVector featureVector,
-      double dropout) {
-    Map<String, Map<String, Double>> flatFeature = new HashMap<>();
-    if (featureVector.stringFeatures != null) {
-      for (Map.Entry<String, Set<String>> entry : featureVector.stringFeatures.entrySet()) {
-        Map<String, Double> out = new HashMap<>();
-        flatFeature.put(entry.getKey(), out);
-        for (String feature : entry.getValue()) {
-          if (Math.random() < dropout) continue;
-          out.put(feature, 1.0);
+    public static void optionallyCreateFloatFeatures(FeatureVector featureVector) {
+        if (featureVector.getFloatFeatures() == null) {
+            Map<String, Map<String, Double>> floatFeatures = new HashMap<>();
+            featureVector.setFloatFeatures(floatFeatures);
         }
-      }
     }
-    if (featureVector.floatFeatures != null) {
-      for (Map.Entry<String, Map<String, Double>> entry : featureVector.floatFeatures.entrySet()) {
-        Map<String, Double> out = new HashMap<>();
-        flatFeature.put(entry.getKey(), out);
-        for (Map.Entry<String, Double> feature : entry.getValue().entrySet()) {
-          if (Math.random() < dropout) continue;
-          out.put(feature.getKey(), feature.getValue());
+
+    public static void setStringFeature(
+            FeatureVector featureVector,
+            String family,
+            String value) {
+        Map<String, Set<String>> stringFeatures = featureVector.getStringFeatures();
+        if (stringFeatures == null) {
+            stringFeatures = new HashMap<>();
+            featureVector.setStringFeatures(stringFeatures);
         }
-      }
-    }
-    return flatFeature;
-  }
-
-  public static class DebugDiffRecordComparator implements Comparator<DebugScoreDiffRecord> {
-    @Override
-    public int compare(DebugScoreDiffRecord e1, DebugScoreDiffRecord e2) {
-      double v1 = Math.abs(e1.getFeatureWeightDiff());
-      double v2 = Math.abs(e2.getFeatureWeightDiff());
-      if (v1 > v2) {
-        return -1;
-      } else if (v1 < v2) {
-        return 1;
-      }
-      return 0;
-    }
-  }
-
-  private static Map<String, Map<String, Double>> debugScoreRecordListToMap(List<DebugScoreRecord> recordList){
-    Map<String, Map<String, Double>> recordMap = new HashMap<>();
-
-    for(int i = 0; i < recordList.size(); i++){
-      String key = recordList.get(i).featureFamily + '\t' + recordList.get(i).featureName;
-      Map<String, Double> record = new HashMap<>();
-      record.put("featureValue", recordList.get(i).featureValue);
-      record.put("featureWeight", recordList.get(i).featureWeight);
-      recordMap.put(key, record);
-    }
-    return recordMap;
-  }
-
-  public static List<DebugScoreDiffRecord> compareDebugRecords(List<DebugScoreRecord> record1,
-                                                               List<DebugScoreRecord> record2){
-    List<DebugScoreDiffRecord> debugDiffRecord = new ArrayList<>();
-    final String featureValue = "featureValue";
-    final String featureWeight = "featureWeight";
-    Set<String> keys = new HashSet();
-
-    Map<String, Map<String, Double>> recordMap1 = debugScoreRecordListToMap(record1);
-    Map<String, Map<String, Double>> recordMap2 = debugScoreRecordListToMap(record2);
-    keys.addAll(recordMap1.keySet());
-    keys.addAll(recordMap2.keySet());
-
-    for(String key: keys){
-      DebugScoreDiffRecord diffRecord = new DebugScoreDiffRecord();
-      double fv1 = 0.0;
-      double fv2 = 0.0;
-      double fw1 = 0.0;
-      double fw2 = 0.0;
-      if(recordMap1.get(key) != null){
-        fv1 = recordMap1.get(key).get(featureValue);
-        fw1 = recordMap1.get(key).get(featureWeight);
-      }
-      if(recordMap2.get(key) != null){
-        fv2 = recordMap2.get(key).get(featureValue);
-        fw2 = recordMap2.get(key).get(featureWeight);
-      }
-
-      String[] fvString = key.split("\t");
-
-      diffRecord.setFeatureFamily(fvString[0]);
-      diffRecord.setFeatureName(fvString[1]);
-      diffRecord.setFeatureValue1(fv1);
-      diffRecord.setFeatureValue2(fv2);
-      diffRecord.setFeatureWeight1(fw1);
-      diffRecord.setFeatureWeight2(fw2);
-      diffRecord.setFeatureWeightDiff(fw1 - fw2);
-      debugDiffRecord.add(diffRecord);
-    }
-    Collections.sort(debugDiffRecord, new DebugDiffRecordComparator());
-    return debugDiffRecord;
-  }
-
-  public static <T> Set<T> getIntersection(Set<T> a, Set<T> b) {
-    if (a == null || b == null) {
-      return Collections.EMPTY_SET;
+        Set<String> stringFamily = getOrCreateStringFeature(family, stringFeatures);
+        stringFamily.add(value);
     }
 
-    Set<T> small = (a.size() > b.size())? b:a;
-    Set<T> big = (a.size() > b.size())? a:b;
-
-    Set<T> intersection = new HashSet<T>(small);
-    intersection.retainAll(big);
-    return intersection;
-  }
-
-  public static float euclideanDistance(float[] x, List<Float> y) {
-    assert (x.length == y.size());
-    double sum = 0;
-    for (int i = 0; i < x.length; i++) {
-      final double dp = x[i] - y.get(i);
-      sum += dp * dp;
+    public static Set<String> getOrCreateStringFeature(
+            String name,
+            Map<String, Set<String>> stringFeatures) {
+        Set<String> output = stringFeatures.get(name);
+        if (output == null) {
+            output = new HashSet<>();
+            stringFeatures.put(name, output);
+        }
+        return output;
     }
-    return (float) Math.sqrt(sum);
-  }
 
-  public static float euclideanDistance(List<Double> x, List<Float> y) {
-    assert (x.size() == y.size());
-    double sum = 0;
-    for (int i = 0; i < y.size(); i++) {
-      final double dp = x.get(i) - y.get(i);
-      sum += dp * dp;
+    public static Map<String, Double> getOrCreateFloatFeature(
+            String name,
+            Map<String, Map<String, Double>> floatFeatures) {
+        Map<String, Double> output = floatFeatures.get(name);
+        if (output == null) {
+            output = new HashMap<>();
+            floatFeatures.put(name, output);
+        }
+        return output;
     }
-    return (float) Math.sqrt(sum);
-  }
+
+    public static Map<String, List<Double>> getOrCreateDenseFeatures(FeatureVector featureVector) {
+        if (featureVector.getDenseFeatures() == null) {
+            Map<String, List<Double>> dense = new HashMap<>();
+            featureVector.setDenseFeatures(dense);
+        }
+        return featureVector.getDenseFeatures();
+    }
+
+    public static void setDenseFeature(
+            FeatureVector featureVector,
+            String name,
+            List<Double> value) {
+        Map<String, List<Double>> denseFeatures = featureVector.getDenseFeatures();
+        if (denseFeatures == null) {
+            denseFeatures = new HashMap<>();
+            featureVector.setDenseFeatures(denseFeatures);
+        }
+        denseFeatures.put(name, value);
+    }
+
+
+    public static HashCode getHashCode(String family, String value) {
+        Hasher hasher = Hashing.murmur3_128().newHasher();
+        hasher.putBytes(family.getBytes());
+        hasher.putBytes(value.getBytes());
+        return hasher.hash();
+    }
+
+    public static <K, V extends Comparable<V>> Map.Entry<K, V>[] sortByValuesDesc(final Map<K, V> map) {
+        if (map == null || map.size() == 0) {
+            return null;
+        }
+        try {
+            @SuppressWarnings("unchecked")
+            Map.Entry<K, V>[] array = map.entrySet().toArray(new Map.Entry[map.size()]);
+
+            Arrays.sort(array, new Comparator<Map.Entry<K, V>>() {
+                public int compare(Map.Entry<K, V> e1, Map.Entry<K, V> e2) {
+                    return e2.getValue().compareTo(e1.getValue());
+                }
+            });
+
+            return array;
+        } catch (Exception e) {
+        }
+        return null;
+    }
+
+    public static <K extends Comparable<K>, V> Map.Entry<K, V>[] sortByKeysAsc(final Map<K, V> map) {
+        if (map == null || map.size() == 0) {
+            return null;
+        }
+        try {
+            @SuppressWarnings("unchecked")
+            Map.Entry<K, V>[] array = map.entrySet().toArray(new Map.Entry[map.size()]);
+
+            Arrays.sort(array, new Comparator<Map.Entry<K, V>>() {
+                public int compare(Map.Entry<K, V> e1, Map.Entry<K, V> e2) {
+                    return e1.getKey().compareTo(e1.getKey());
+                }
+            });
+
+            return array;
+        } catch (Exception e) {
+        }
+        return null;
+    }
+
+    public static double logBase2(double value) {
+        return Math.log(value) / LOG2;
+    }
+
+    public static Map<Integer, Double> prepareRankMap(List<Double> scores, List<Double> utilities) {
+        Map<Integer, Double> rankMap = new HashMap<Integer, Double>();
+        if (scores == null || utilities == null || scores.size() != utilities.size()) {
+            return rankMap;
+        }
+        Map<Integer, Double> scoresMap = new HashMap<>();
+        for (int i = 0; i < scores.size(); i++) {
+            scoresMap.put(i, scores.get(i));
+        }
+        Map.Entry<Integer, Double>[] kvs = sortByValuesDesc(scoresMap);
+        for (int j = 0; j < kvs.length; j++) {
+            double util = utilities.get(kvs[j].getKey());
+            rankMap.put(j, util);
+        }
+        return rankMap;
+    }
+
+    public static <K, V> Map<K, V> safeMap(Map<K, V> map) {
+        if (map == null) {
+            return Collections.EMPTY_MAP;
+        } else {
+            return map;
+        }
+    }
+
+    /**
+     * Flatten a feature vector from example to a nested stream(feature family, stream(feature name. feature value))
+     */
+    public static Stream<? extends Map.Entry<String, Stream<? extends Map.Entry<String, Double>>>> flattenFeatureAsStream(FeatureVector featureVector) {
+        // reuse flatten with dropout = 0
+        return flattenFeatureWithDropoutAsStream(featureVector, 0.0, 0);
+    }
+
+    /**
+     * Flatten a feature vector from example to a nested map of feature family -> (feature -> value)
+     */
+    public static Map<String, Map<String, Double>> flattenFeature(FeatureVector featureVector) {
+        return flattenFeatureStreamToMap(flattenFeatureAsStream(featureVector));
+    }
+
+    private static Random random = new Random();
+
+    /**
+     * Flatten a feature vector from example to a nested map of feature family -> (feature -> value) with dropout
+     */
+    public static Map<String, Map<String, Double>> flattenFeatureWithDropout(FeatureVector featureVector, double dropout) {
+        long seed = random.nextLong();
+        return flattenFeatureStreamToMap(flattenFeatureWithDropoutAsStream(featureVector, dropout, seed));
+    }
+
+    /**
+     * Convert a flatten nested stream(feature family, stream(feature name. feature value)) to nested map of feature family -> (feature -> value)
+     */
+    private static Map<String, Map<String, Double>> flattenFeatureStreamToMap(Stream<? extends Map.Entry<String, Stream<? extends Map.Entry<String, Double>>>> stream) {
+        Map<String, Map<String, Double>> outputFeatureMap = new HashMap<>();
+
+        stream.forEach(inputFamilyEntry -> {
+            String familyName = inputFamilyEntry.getKey();
+            Map<String, Double> outputFeatureFamily = outputFeatureMap.get(familyName);
+            if (outputFeatureFamily == null) {
+                outputFeatureFamily = new HashMap<>();
+                outputFeatureMap.put(familyName, outputFeatureFamily);
+            }
+            // NB: this is necessary due to stream semantic where variable inside forEach has to be final
+            final Map<String, Double> finalFeatures = outputFeatureFamily;
+            inputFamilyEntry.getValue().forEach(feature -> finalFeatures.put(feature.getKey(), feature.getValue()));
+        });
+
+        return outputFeatureMap;
+    }
+
+    /**
+     * Convert a feature vector from example to a nested stream(feature family, stream(feature name. feature value)) with dropout
+     *
+     * @apiNote Understand Stream can only be iterated once just like iterator, it is crucial to set a random seed if one
+     * wants to reproduce consistent dropout result.
+     */
+    public static Stream<? extends Map.Entry<String, Stream<? extends Map.Entry<String, Double>>>> flattenFeatureWithDropoutAsStream(
+            FeatureVector featureVector, double dropout, long seed) {
+        // collect string features into a stream
+        Stream<? extends Map.Entry<String, Stream<? extends Map.Entry<String, Double>>>> stringFeatures = Stream.empty();
+        if (featureVector.stringFeatures != null) {
+            stringFeatures = featureVector.stringFeatures.entrySet().stream().map(entry -> {
+                Stream<? extends Map.Entry<String, Double>> values =
+                        entry.getValue().stream()
+                                .map(feature -> new HashMap.SimpleImmutableEntry<>(feature, 1.0));
+                return new HashMap.SimpleImmutableEntry<>(entry.getKey(), values);
+            });
+        }
+
+        // collect float features into a stream
+        Stream<? extends Map.Entry<String, Stream<? extends Map.Entry<String, Double>>>> floatFeatures = Stream.empty();
+        if (featureVector.floatFeatures != null) {
+            floatFeatures = featureVector.floatFeatures.entrySet().stream().map(entry ->
+                    new HashMap.SimpleImmutableEntry<>(entry.getKey(), entry.getValue().entrySet().stream())
+            );
+        }
+
+        // concat string and float features and apply dropout if necessary
+        Stream<? extends Map.Entry<String, Stream<? extends Map.Entry<String, Double>>>> flatFeatures = Stream.concat(stringFeatures, floatFeatures);
+        if (dropout > 0) {
+            Random random = new Random(seed);
+            // dropout needs to be applied in the inner most stream
+            return flatFeatures.map(
+                    entry -> new HashMap.SimpleImmutableEntry<>(entry.getKey(), entry.getValue().filter(x -> random.nextDouble() >= dropout))
+            );
+        } else {
+            return flatFeatures;
+        }
+    }
+
+    public static class DebugDiffRecordComparator implements Comparator<DebugScoreDiffRecord> {
+        @Override
+        public int compare(DebugScoreDiffRecord e1, DebugScoreDiffRecord e2) {
+            double v1 = Math.abs(e1.getFeatureWeightDiff());
+            double v2 = Math.abs(e2.getFeatureWeightDiff());
+            if (v1 > v2) {
+                return -1;
+            } else if (v1 < v2) {
+                return 1;
+            }
+            return 0;
+        }
+
+    }
+
+    private static Map<String, Map<String, Double>> debugScoreRecordListToMap(List<DebugScoreRecord> recordList) {
+        Map<String, Map<String, Double>> recordMap = new HashMap<>();
+
+        for (int i = 0; i < recordList.size(); i++) {
+            String key = recordList.get(i).featureFamily + '\t' + recordList.get(i).featureName;
+            Map<String, Double> record = new HashMap<>();
+            record.put("featureValue", recordList.get(i).featureValue);
+            record.put("featureWeight", recordList.get(i).featureWeight);
+            recordMap.put(key, record);
+        }
+        return recordMap;
+    }
+
+    public static List<DebugScoreDiffRecord> compareDebugRecords(List<DebugScoreRecord> record1,
+                                                                 List<DebugScoreRecord> record2) {
+        List<DebugScoreDiffRecord> debugDiffRecord = new ArrayList<>();
+        final String featureValue = "featureValue";
+        final String featureWeight = "featureWeight";
+        Set<String> keys = new HashSet();
+
+        Map<String, Map<String, Double>> recordMap1 = debugScoreRecordListToMap(record1);
+        Map<String, Map<String, Double>> recordMap2 = debugScoreRecordListToMap(record2);
+        keys.addAll(recordMap1.keySet());
+        keys.addAll(recordMap2.keySet());
+
+        for (String key : keys) {
+            DebugScoreDiffRecord diffRecord = new DebugScoreDiffRecord();
+            double fv1 = 0.0;
+            double fv2 = 0.0;
+            double fw1 = 0.0;
+            double fw2 = 0.0;
+            if (recordMap1.get(key) != null) {
+                fv1 = recordMap1.get(key).get(featureValue);
+                fw1 = recordMap1.get(key).get(featureWeight);
+            }
+            if (recordMap2.get(key) != null) {
+                fv2 = recordMap2.get(key).get(featureValue);
+                fw2 = recordMap2.get(key).get(featureWeight);
+            }
+
+            String[] fvString = key.split("\t");
+
+            diffRecord.setFeatureFamily(fvString[0]);
+            diffRecord.setFeatureName(fvString[1]);
+            diffRecord.setFeatureValue1(fv1);
+            diffRecord.setFeatureValue2(fv2);
+            diffRecord.setFeatureWeight1(fw1);
+            diffRecord.setFeatureWeight2(fw2);
+            diffRecord.setFeatureWeightDiff(fw1 - fw2);
+            debugDiffRecord.add(diffRecord);
+        }
+        Collections.sort(debugDiffRecord, new DebugDiffRecordComparator());
+        return debugDiffRecord;
+    }
+
+    public static <T> Set<T> getIntersection(Set<T> a, Set<T> b) {
+        if (a == null || b == null) {
+            return Collections.EMPTY_SET;
+        }
+
+        Set<T> small = (a.size() > b.size()) ? b : a;
+        Set<T> big = (a.size() > b.size()) ? a : b;
+
+        Set<T> intersection = new HashSet<T>(small);
+        intersection.retainAll(big);
+        return intersection;
+    }
+
+    public static float euclideanDistance(float[] x, List<Float> y) {
+        assert (x.length == y.size());
+        double sum = 0;
+        for (int i = 0; i < x.length; i++) {
+            final double dp = x[i] - y.get(i);
+            sum += dp * dp;
+        }
+        return (float) Math.sqrt(sum);
+    }
+
+    public static float euclideanDistance(List<Double> x, List<Float> y) {
+        assert (x.size() == y.size());
+        double sum = 0;
+        for (int i = 0; i < y.size(); i++) {
+            final double dp = x.get(i) - y.get(i);
+            sum += dp * dp;
+        }
+        return (float) Math.sqrt(sum);
+    }
 }

--- a/core/src/test/resources/log4j.properties
+++ b/core/src/test/resources/log4j.properties
@@ -1,0 +1,19 @@
+# Set everything to be logged to the file target/unit-tests.log
+test.appender=file
+log4j.rootCategory=INFO, ${test.appender}
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.append=true
+log4j.appender.file.file=build/unit-tests.log
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
+
+# Tests that launch java subprocesses can set the "test.appender" system property to
+# "console" to avoid having the child process's logs overwrite the unit test's
+# log file.
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%t: %m%n
+
+# Ignore messages below warning level from Jetty, because it's a bit verbose
+log4j.logger.org.spark_project.jetty=WARN

--- a/training/build.gradle
+++ b/training/build.gradle
@@ -41,9 +41,11 @@ dependencies {
   provided 'org.apache.spark:spark-hive_2.10:1.5.2'
 
   testCompile 'org.apache.spark:spark-core_2.10:1.5.2'
+  testCompile 'org.apache.spark:spark-core_2.10:1.5.2:tests'
+  testCompile 'org.scalatest:scalatest_2.10:2.2.6'
   testCompile 'org.apache.spark:spark-hive_2.10:1.5.2'
   testCompile 'org.mockito:mockito-all:1.9.5'
-  testCompile 'org.slf4j:slf4j-simple:1.7.7'
+  testCompile 'org.slf4j:slf4j-log4j12:1.7.21'
 }
 
 compileScala {

--- a/training/src/main/scala/com/airbnb/aerosolve/training/LinearRankerUtils.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/LinearRankerUtils.scala
@@ -4,12 +4,16 @@ import com.airbnb.aerosolve.core.Example
 import com.airbnb.aerosolve.core.FeatureVector
 import com.airbnb.aerosolve.core.transforms.Transformer
 import com.typesafe.config.Config
-import org.slf4j.{LoggerFactory, Logger}
-import org.apache.spark.SparkContext
-import org.apache.spark.SparkContext._
+import org.slf4j.{Logger, LoggerFactory}
 import org.apache.spark.rdd.RDD
-
 import java.util
+import java.util.{Spliterator, Spliterators}
+import java.util.stream.StreamSupport
+
+import com.airbnb.aerosolve.core.features.SparseLabeledPoint
+import com.airbnb.aerosolve.core.models.AdditiveModel
+import com.airbnb.aerosolve.core.util.Util
+
 import scala.collection.mutable.HashMap
 import scala.collection.mutable.HashSet
 import scala.collection.mutable.ArrayBuffer
@@ -18,14 +22,14 @@ import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
 import scala.util.Random
 
-case class CompressedExample(pos : Array[(String, String)],
-                             neg : Array[(String, String)],
-                             label : Double);
+case class CompressedExample(pos: Array[(String, String)],
+                             neg: Array[(String, String)],
+                             label: Double);
 
 object LinearRankerUtils {
   private final val log: Logger = LoggerFactory.getLogger("LinearRankerUtils")
 
-  def getFeatures(sample : FeatureVector) : Array[(String, String)] = {
+  def getFeatures(sample: FeatureVector): Array[(String, String)] = {
     val features = HashSet[(String, String)]()
     sample.stringFeatures.foreach(family => {
       family._2.foreach(value => {
@@ -35,8 +39,8 @@ object LinearRankerUtils {
     features.toArray
   }
 
-  def getNumFeatures(ex : util.Map[java.lang.String, util.Map[java.lang.String, java.lang.Double]],
-                     rankKey : String) : Int = {
+  def getNumFeatures(ex: util.Map[java.lang.String, util.Map[java.lang.String, java.lang.Double]],
+                     rankKey: String): Int = {
     // Get the number of features in the example excluding the label
     var numFeature = 0
 
@@ -50,66 +54,66 @@ object LinearRankerUtils {
 
   // Does feature expansion on an example and buckets them by rank.
   def expandAndBucketizeExamples(
-                                 examples : Example,
-                                 transformer : Transformer,
-                                 rankKey : String) :
+                                  examples: Example,
+                                  transformer: Transformer,
+                                  rankKey: String):
   Array[Array[Array[(String, String)]]] = {
     transformer.combineContextAndItems(examples)
-    val samples : Seq[FeatureVector] = examples.example
+    val samples: Seq[FeatureVector] = examples.example
     val buckets = HashMap[Int, Buffer[Array[(String, String)]]]()
     samples
       .filter(x => x.stringFeatures != null &&
-                   x.floatFeatures != null &&
-                   x.floatFeatures.get(rankKey) != null)
+        x.floatFeatures != null &&
+        x.floatFeatures.get(rankKey) != null)
       .foreach(sample => {
-      val rankBucket : Int = sample.floatFeatures.get(rankKey).toSeq.head._2.toInt
-      val features = getFeatures(sample)
-      val entryOpt = buckets.get(rankBucket)
-      if (entryOpt.isEmpty) {
-        buckets.put(rankBucket, ArrayBuffer(features))
-      } else {
-        entryOpt.get.append(features)
-      }
-    })
+        val rankBucket: Int = sample.floatFeatures.get(rankKey).toSeq.head._2.toInt
+        val features = getFeatures(sample)
+        val entryOpt = buckets.get(rankBucket)
+        if (entryOpt.isEmpty) {
+          buckets.put(rankBucket, ArrayBuffer(features))
+        } else {
+          entryOpt.get.append(features)
+        }
+      })
     // Sort buckets in ascending order.
     buckets
       .toBuffer
-      .sortWith((x,y) => x._1 < y._1)
+      .sortWith((x, y) => x._1 < y._1)
       .map(x => x._2.toArray)
       .toArray
   }
 
   // Makes ranking training data
-  def rankingTrain(input : RDD[Example], config : Config, key : String) :
+  def rankingTrain(input: RDD[Example], config: Config, key: String):
   RDD[CompressedExample] = {
     input
       .mapPartitions(partition => {
-      val output = ArrayBuffer[CompressedExample]()
-      val rnd = new Random()
-      val rankKey: String = config.getString(key + ".rank_key")
-      val transformer = new Transformer(config, key)
-      partition.foreach(examples => {
-        val buckets = LinearRankerUtils.expandAndBucketizeExamples(examples, transformer, rankKey)
-        for (i <- 0 to buckets.size - 2) {
-          for (j <- i + 1 to buckets.size - 1) {
-            val neg = buckets(i)(rnd.nextInt(buckets(i).size)).toSet
-            val pos = buckets(j)(rnd.nextInt(buckets(j).size)).toSet
-            val intersect = pos.intersect(neg)
-            // For ranking we have pairs of examples with label always 1.0.
-            val out = CompressedExample(pos.diff(intersect).toArray,
-                                        neg.diff(intersect).toArray,
-                                        label = 1.0)
-            output.append(out)
+        val output = ArrayBuffer[CompressedExample]()
+        val rnd = new Random()
+        val rankKey: String = config.getString(key + ".rank_key")
+        val transformer = new Transformer(config, key)
+        partition.foreach(examples => {
+          val buckets = LinearRankerUtils.expandAndBucketizeExamples(examples, transformer, rankKey)
+          for (i <- 0 to buckets.size - 2) {
+            for (j <- i + 1 to buckets.size - 1) {
+              val neg = buckets(i)(rnd.nextInt(buckets(i).size)).toSet
+              val pos = buckets(j)(rnd.nextInt(buckets(j).size)).toSet
+              val intersect = pos.intersect(neg)
+              // For ranking we have pairs of examples with label always 1.0.
+              val out = CompressedExample(pos.diff(intersect).toArray,
+                neg.diff(intersect).toArray,
+                label = 1.0)
+              output.append(out)
+            }
           }
-        }
+        })
+        output.iterator
       })
-      output.iterator
-    })
   }
 
-  def score(feature : Array[(String, String)],
-             weightMap : collection.mutable.Map[(String, String), (Double, Double)]) : Double = {
-    var sum : Double = 0
+  def score(feature: Array[(String, String)],
+            weightMap: collection.mutable.Map[(String, String), (Double, Double)]): Double = {
+    var sum: Double = 0
     feature.foreach(v => {
       val opt = weightMap.get(v)
       if (opt != None) {
@@ -119,49 +123,172 @@ object LinearRankerUtils {
     sum
   }
 
-  // Makes an example pointwise while preserving the float features.
+  /**
+    * Makes an example pointwise by combining context and flatmap with feature transforms.
+    * Each observation is further flattened to [[SparseLabeledPoint]] format where features are indexed
+    * by a specified [[AdditiveModel]].
+    */
+  def makePointwiseFloatVector(examples: RDD[Example],
+                               transformer: Transformer,
+                               params: AdditiveModelTrainer.AdditiveTrainerParams,
+                               model: AdditiveModel,
+                               isTraining: Example => Boolean = _ => true,
+                               groupSize: Int = 100): RDD[SparseLabeledPoint] = {
+    val assemblerTimer = examples.sparkContext.accumulator(0L, "pointAssembler")
+
+    makePointwiseFloat(examples, transformer, groupSize)
+      .mapPartitions {
+        examples =>
+          val featureIndex = model.getFeatureIndexer
+          val denseFeatureIndexer = featureIndex.get(AdditiveModel.DENSE_FAMILY)
+
+          // reuse buffer for each example to avoid GC
+          val indices = new ArrayBuffer[Int]()
+          val values = new ArrayBuffer[Float]()
+          // for dense features, each feature is a List<Double> to be converted to float[]
+          val denseIndices = new ArrayBuffer[Int]()
+          val denseValues = new ArrayBuffer[Array[Float]]()
+
+          examples.map {
+            example =>
+              val t0 = System.nanoTime()
+
+              // clear buffer from last example
+              indices.clear()
+              values.clear()
+              denseIndices.clear()
+              denseValues.clear()
+
+              val featureVector = example.example.get(0)
+
+              Util.flattenFeatureAsStream(featureVector)
+                .iterator
+                .foreach {
+                  featureFamily =>
+                    val familyIndex = featureIndex.get(featureFamily.getKey)
+                    if (familyIndex != null) {
+                      featureFamily.getValue.iterator().foreach {
+                        feature =>
+                          val index = familyIndex.get(feature.getKey)
+                          if (index != null) {
+                            indices += index.intValue()
+                            values += feature.getValue.floatValue()
+                          }
+                      }
+                    }
+                }
+
+              val denseFeatures = featureVector.denseFeatures
+              if (denseFeatureIndexer != null && denseFeatures != null) {
+                denseFeatures.iterator.foreach {
+                  case (featureName, featureValues) =>
+                    val index = denseFeatureIndexer.get(featureName)
+                    if (index != null) {
+                      denseIndices += index.intValue()
+
+                      val featureLength = featureValues.size()
+                      val valueArray = new Array[Float](featureLength)
+                      var i = 0
+                      while (i < featureLength) {
+                        valueArray(i) = featureValues.get(i).floatValue()
+                        i += 1
+                      }
+
+                      denseValues += valueArray
+                    }
+                }
+              }
+
+              val label =
+                if (params.loss.function == AdditiveModelTrainer.LossFunctions.REGRESSION) {
+                  TrainingUtils.getLabel(featureVector, params.rankKey)
+                } else {
+                  TrainingUtils.getLabel(featureVector, params.rankKey, params.threshold)
+                }
+
+              assemblerTimer += (System.nanoTime() - t0)
+
+              new SparseLabeledPoint(
+                isTraining(example),
+                label,
+                indices.toArray, values.toArray,
+                denseIndices.toArray, denseValues.toArray
+              )
+          }
+      }
+  }
+
+  /**
+    * Makes an example pointwise by combining context and flatmap with feature transforms.
+    * Transform is applied in batch fashion so some transformers can be more
+    * efficiently applied. (e.g. XGBoostTransform)
+    */
   def makePointwiseFloat(
-                    examples : RDD[Example],
-                    config : Config,
-                    key : String) : RDD[Example] = {
-    val transformer = new Transformer(config, key)
-    examples.map(example => {
-      val buffer = collection.mutable.ArrayBuffer[Example]()
-      example.example.asScala.foreach(x => {
+                          examples: RDD[Example],
+                          transformer: Transformer,
+                          groupSize: Int = 100): RDD[Example] = {
+    val transformerTimer = examples.sparkContext.accumulator(0L, "transformer")
+    examples.flatMap(example => {
+      transformer.transformContext(example.context)
+      example.example.iterator().map(x => {
+        transformer.transformItem(x)
+
         val newExample = new Example()
         newExample.setContext(example.context)
         newExample.addToExample(x)
-        transformer.combineContextAndItems(newExample)
-        buffer.append(newExample)
+
+        transformer.addContextToItems(newExample)
+
+        newExample
       })
-      buffer
+    }).mapPartitions(exampleIterator => {
+      exampleIterator.grouped(groupSize).flatMap {
+        examples =>
+          val t0 = System.nanoTime()
+
+          // create a stream from iterator for efficiency
+          val source = examples.iterator.flatMap(_.example).asJava
+          val spliterator = Spliterators.spliteratorUnknownSize(source, Spliterator.ORDERED)
+          val stream = StreamSupport.stream(spliterator, false)
+
+          transformer.transformCombined(stream)
+          transformerTimer += (System.nanoTime() - t0)
+          examples
+      }
     })
-    .flatMap(x => x)
   }
-  
+
+  // Makes an example pointwise while preserving the float features.
+  def makePointwiseFloat(examples: RDD[Example],
+                         config: Config,
+                         key: String): RDD[Example] = {
+    val transformer = new Transformer(config, key)
+    makePointwiseFloat(examples, transformer)
+  }
+
   // Transforms an RDD of examples
   def transformExamples(
-                    examples : RDD[Example],
-                    config : Config,
-                    key : String) : RDD[Example] = {
+                         examples: RDD[Example],
+                         config: Config,
+                         key: String): RDD[Example] = {
     val transformer = new Transformer(config, key)
     examples.map(example => {
-        transformer.combineContextAndItems(example)
-        example.unsetContext()
-        example
-      })
+      transformer.combineContextAndItems(example)
+      example.unsetContext()
+      example
+    })
   }
 
   // Since examples are bags of user impressions, for pointwise algoriths
   // we need to shuffle each feature vector separately.
-  def makePointwise(examples : RDD[Example],
-                    config : Config,
-                    key : String,
-                    rankKey : String) : RDD[Example] = {
+  def makePointwise(examples: RDD[Example],
+                    config: Config,
+                    key: String,
+                    rankKey: String): RDD[Example] = {
     val transformer = new Transformer(config, key)
     examples.map(example => {
       val buffer = collection.mutable.ArrayBuffer[Example]()
-      example.example.asScala.foreach{x => {
+      example.example.asScala.foreach { x => {
         val newExample = new Example()
         newExample.setContext(example.context)
         newExample.addToExample(x)
@@ -169,24 +296,25 @@ object LinearRankerUtils {
         // For space reasons remove all float features except rankKey.
         val floatFeatures = newExample.example.get(0).getFloatFeatures
         if (floatFeatures != null) {
-          val rank : java.util.Map[java.lang.String, java.lang.Double] =
+          val rank: java.util.Map[java.lang.String, java.lang.Double] =
             floatFeatures.get(rankKey)
-          val newFloat : java.util.Map[java.lang.String,
+          val newFloat: java.util.Map[java.lang.String,
             java.util.Map[java.lang.String, java.lang.Double]] =
             new java.util.HashMap()
           newFloat.put(rankKey, rank)
           newExample.example.get(0).setFloatFeatures(newFloat)
         }
         buffer.append(newExample)
-      }}
+      }
+      }
       buffer
     })
       .flatMap(x => x)
   }
 
-  def makePointwiseCompressed(examples : RDD[Example],
-                    config : Config,
-                    key : String) : RDD[CompressedExample] = {
+  def makePointwiseCompressed(examples: RDD[Example],
+                              config: Config,
+                              key: String): RDD[CompressedExample] = {
     val rankKey: String = config.getString(key + ".rank_key")
     val pointwise = makePointwise(examples, config, key, rankKey)
     pointwise.map(example => {

--- a/training/src/main/scala/com/airbnb/aerosolve/training/LinearRankerUtils.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/LinearRankerUtils.scala
@@ -241,13 +241,10 @@ object LinearRankerUtils {
         examples =>
           val t0 = System.nanoTime()
 
-          // create a stream from iterator for efficiency
-          val source = examples.iterator.flatMap(_.example).asJava
-          val spliterator = Spliterators.spliteratorUnknownSize(source, Spliterator.ORDERED)
-          val stream = StreamSupport.stream(spliterator, false)
-
-          transformer.transformCombined(stream)
+          val features = examples.iterator.flatMap(_.example).toIterable.asJava
+          transformer.transformCombined(features)
           transformerTimer += (System.nanoTime() - t0)
+
           examples
       }
     })

--- a/training/src/main/scala/com/airbnb/aerosolve/training/MlpModelTrainer.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/MlpModelTrainer.scala
@@ -473,6 +473,7 @@ object MlpModelTrainer {
       case FunctionForm.RELU => if (activation > 0) 1.0 else 0.0
       case FunctionForm.IDENTITY => 1.0
       case FunctionForm.TANH => 1.0 - activation * activation
+      case _ => throw new IllegalArgumentException(s"Unrecognized function: $func")
     }
   }
 }

--- a/training/src/main/scala/com/airbnb/aerosolve/training/MlpModelTrainer.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/MlpModelTrainer.scala
@@ -1,15 +1,12 @@
 package com.airbnb.aerosolve.training
 
-import com.airbnb.aerosolve.core.{FeatureVector, Example, FunctionForm}
 import com.airbnb.aerosolve.core.models.MlpModel
-
-import com.airbnb.aerosolve.core.util.FloatVector
-import com.airbnb.aerosolve.core.util.Util
+import com.airbnb.aerosolve.core.util.{FloatVector, Util}
+import com.airbnb.aerosolve.core.{Example, FeatureVector, FunctionForm}
 import com.typesafe.config.Config
-import org.slf4j.{LoggerFactory, Logger}
 import org.apache.spark.SparkContext
-import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
+import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.JavaConversions._
 import scala.util.Try
@@ -18,48 +15,48 @@ import scala.util.Try
   * A trainer that generates a MLP model.
   * TODO (Peng): add maxNorm regularizations
   */
-
 object MlpModelTrainer {
   private final val log: Logger = LoggerFactory.getLogger("MlpModelTrainer")
-  private final val LAYER_PREFIX : String = "$layer:"
-  private final val NODE_PREFIX : String = "$node:"
-  private final val BIAS_PREFIX : String = "$bias:"
+  private final val LAYER_PREFIX: String = "$layer:"
+  private final val NODE_PREFIX: String = "$node:"
+  private final val BIAS_PREFIX: String = "$bias:"
+
   case class TrainerOptions(loss: String,
                             margin: Double, // margin in Hinge loss or epsilon in regression
                             iteration: Int, // number of iterations to run
-                            subsample : Double, // determine mini-batch size
-                            threshold : Double, // threshold for binary classification
+                            subsample: Double, // determine mini-batch size
+                            threshold: Double, // threshold for binary classification
                             rankKey: String,
-                            learningRateInit : Double,  // initial learning rate
-                            learningRateDecay : Double, // learning rate decay rate
-                            momentumInit : Double, // initial momentum value
-                            momentumEnd : Double,  // ending momentum value
-                            momentumT : Int,
-                            dropout : Double, // dropout rate
-                            maxNorm : Double, // max norm
-                            weightDecay : Double, // l2 regularization parameter
-                            weightInitStd : Double, // weight initialization std
-                            cache : String,
-                            minCount : Int
+                            learningRateInit: Double, // initial learning rate
+                            learningRateDecay: Double, // learning rate decay rate
+                            momentumInit: Double, // initial momentum value
+                            momentumEnd: Double, // ending momentum value
+                            momentumT: Int,
+                            dropout: Double, // dropout rate
+                            maxNorm: Double, // max norm
+                            weightDecay: Double, // l2 regularization parameter
+                            weightInitStd: Double, // weight initialization std
+                            cache: String,
+                            minCount: Int
                            )
 
   case class NetWorkParams(activationFunctions: java.util.ArrayList[FunctionForm],
-                           nodeNumber : java.util.ArrayList[Integer])
+                           nodeNumber: java.util.ArrayList[Integer])
 
-  def train(sc : SparkContext,
-            input : RDD[Example],
-            config : Config,
-            key : String) : MlpModel = {
+  def train(sc: SparkContext,
+            input: RDD[Example],
+            config: Config,
+            key: String): MlpModel = {
     val trainerOptions = parseTrainingOptions(config.getConfig(key))
     val networkOptions = parseNetworkOptions(config.getConfig(key))
 
-    val raw : RDD[Example] =
+    val raw: RDD[Example] =
       LinearRankerUtils
         .makePointwiseFloat(input, config, key)
 
     val pointwise = trainerOptions.cache match {
       case "memory" => raw.cache()
-      case _ : String => raw
+      case _: String => raw
     }
 
     val model = setupModel(trainerOptions, networkOptions, pointwise)
@@ -73,10 +70,10 @@ object MlpModelTrainer {
     model
   }
 
-  def modelIteration(sc : SparkContext,
-                     options : TrainerOptions,
-                     model : MlpModel,
-                     pointwise : RDD[Example]) = {
+  def modelIteration(sc: SparkContext,
+                     options: TrainerOptions,
+                     model: MlpModel,
+                     pointwise: RDD[Example]) = {
 
     var learningRate = options.learningRateInit
     // initialize previous updates with 0
@@ -113,10 +110,10 @@ object MlpModelTrainer {
     }
   }
 
-  def computeGradient(sc : SparkContext,
-                      options : TrainerOptions,
-                      model : MlpModel,
-                      miniBatch : RDD[Example]) : Map[(String, String), FloatVector] = {
+  def computeGradient(sc: SparkContext,
+                      options: TrainerOptions,
+                      model: MlpModel,
+                      miniBatch: RDD[Example]): Map[(String, String), FloatVector] = {
     // compute the sum of gradient of examples in the mini-batch
     val modelBC = sc.broadcast(model)
     miniBatch
@@ -235,7 +232,7 @@ object MlpModelTrainer {
   }
 
   def updateModel(model: MlpModel,
-                  gradientContainer:  Map[(String, String), FloatVector],
+                  gradientContainer: Map[(String, String), FloatVector],
                   updateContainer: scala.collection.mutable.HashMap[(String, String), FloatVector],
                   momentum: Float,
                   learningRate: Float,
@@ -244,7 +241,7 @@ object MlpModelTrainer {
     // then update model weights (also update the prevUpdateContainer)
     val numHiddenLayers = model.getNumHiddenLayers
     for ((key, prevUpdate) <- updateContainer) {
-      val weightToUpdate : FloatVector = if (key._1.startsWith(LAYER_PREFIX)) {
+      val weightToUpdate: FloatVector = if (key._1.startsWith(LAYER_PREFIX)) {
         val layerId: Int = key._1.substring(LAYER_PREFIX.length).toInt
         assert(layerId >= 0 && layerId <= numHiddenLayers)
         if (key._2.equals(BIAS_PREFIX)) {
@@ -279,15 +276,15 @@ object MlpModelTrainer {
     }
   }
 
-  def trainAndSaveToFile(sc : SparkContext,
-                         input : RDD[Example],
-                         config : Config,
-                         key : String) = {
+  def trainAndSaveToFile(sc: SparkContext,
+                         input: RDD[Example],
+                         config: Config,
+                         key: String) = {
     val model = train(sc, input, config, key)
     TrainingUtils.saveModel(model, config, key + ".model_output")
   }
 
-  private def parseTrainingOptions(config : Config) : TrainerOptions = {
+  private def parseTrainingOptions(config: Config): TrainerOptions = {
     TrainerOptions(
       loss = config.getString("loss"),
       margin = config.getDouble("margin"),
@@ -309,15 +306,15 @@ object MlpModelTrainer {
     )
   }
 
-  private def parseNetworkOptions(config : Config) : NetWorkParams = {
+  private def parseNetworkOptions(config: Config): NetWorkParams = {
     val activationStr = config.getStringList("activations")
     val activations = new java.util.ArrayList[FunctionForm]()
     for (func: String <- activationStr) {
       activations.append(getFunctionForm(func))
     }
 
-    val nodeNumbers =  new java.util.ArrayList[Integer]()
-    for (num : Integer <- config.getIntList("node_number")) {
+    val nodeNumbers = new java.util.ArrayList[Integer]()
+    for (num: Integer <- config.getIntList("node_number")) {
       nodeNumbers.append(num)
     }
 
@@ -327,9 +324,9 @@ object MlpModelTrainer {
     )
   }
 
-  def setupModel(trainerOptions : TrainerOptions,
+  def setupModel(trainerOptions: TrainerOptions,
                  networkOptions: NetWorkParams,
-                 pointwise : RDD[Example]) : MlpModel = {
+                 pointwise: RDD[Example]): MlpModel = {
     val model = new MlpModel(
       networkOptions.activationFunctions,
       networkOptions.nodeNumber)
@@ -342,7 +339,7 @@ object MlpModelTrainer {
     val stats = TrainingUtils.getFeatureStatistics(trainerOptions.minCount, pointwise)
 
     // set up input layer weights
-    var count : Int = 0
+    var count: Int = 0
     for (kv <- stats) {
       val (family, feature) = kv._1
       if (family != trainerOptions.rankKey) {
@@ -370,7 +367,7 @@ object MlpModelTrainer {
     model
   }
 
-  private def setupUpdateContainer(model: MlpModel) : scala.collection.mutable.HashMap[(String, String), FloatVector] = {
+  private def setupUpdateContainer(model: MlpModel): scala.collection.mutable.HashMap[(String, String), FloatVector] = {
     val container = scala.collection.mutable.HashMap[(String, String), FloatVector]()
     // set up input layer weights gradient
     val inputLayerWeights = model.getInputLayerWeights
@@ -414,7 +411,7 @@ object MlpModelTrainer {
     update
   }
 
-  private def getFunctionForm(func: String) : FunctionForm = {
+  private def getFunctionForm(func: String): FunctionForm = {
     func match {
       case "sigmoid" => FunctionForm.SIGMOID
       case "relu" => FunctionForm.RELU
@@ -427,7 +424,7 @@ object MlpModelTrainer {
   private def updateMomentum(momentumInit: Double,
                              momentumEnd: Double,
                              momentumT: Int,
-                             iter: Int) : Double = {
+                             iter: Int): Double = {
     if (iter >= momentumT)
       return momentumEnd
     val frac = iter.toDouble / momentumT
@@ -458,7 +455,7 @@ object MlpModelTrainer {
     val label = TrainingUtils.getLabel(fv, option.rankKey)
     if (prediction - label > option.margin) {
       1.0
-    } else if (prediction - label < - option.margin) {
+    } else if (prediction - label < -option.margin) {
       -1.0
     } else {
       0.0

--- a/training/src/main/scala/com/airbnb/aerosolve/training/TrainingUtils.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/TrainingUtils.scala
@@ -116,7 +116,7 @@ object TrainingUtils {
       return None
     }
     val model = modelOpt.get()
-    return Some(model)
+    Some(model)
   }
 
   def loadPlattScaleWeights(filePath: String): Option[Array[Double]] = {
@@ -131,7 +131,7 @@ object TrainingUtils {
     for (weight <- calibrationModelStr.split(" "))
       calibrationWeights += weight.toDouble
 
-    return Some(calibrationWeights.toArray)
+    Some(calibrationWeights.toArray)
   }
 
   def debugScore(example: Example, model: AbstractModel, transformer: Transformer) = {
@@ -139,7 +139,7 @@ object TrainingUtils {
     for (ex <- example.example.asScala) {
       val builder = new java.lang.StringBuilder()
       model.debugScoreItem(example.example.get(0), builder)
-      val result = builder.toString()
+      val result = builder.toString
       println(result)
     }
   }
@@ -152,7 +152,7 @@ object TrainingUtils {
       return None
     }
     val result = files
-      .map(x => x.getPath().toString())
+      .map(x => x.getPath.toString)
       .toBuffer
       .sortWith((a, b) => a > b)
       .head

--- a/training/src/test/resources/log4j.properties
+++ b/training/src/test/resources/log4j.properties
@@ -1,0 +1,22 @@
+# Set everything to be logged to the file target/unit-tests.log
+test.appender=file
+log4j.rootCategory=INFO, ${test.appender}
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.append=true
+log4j.appender.file.file=build/unit-tests.log
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
+
+# Tests that launch java subprocesses can set the "test.appender" system property to
+# "console" to avoid having the child process's logs overwrite the unit test's
+# log file.
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%t: %m%n
+
+# Ignore messages below warning level from Jetty, because it's a bit verbose
+log4j.logger.org.spark-project.jetty=WARN
+log4j.logger.akka.slf4j=WARN
+log4j.logger.org.apache.spark.scheduler=WARN
+log4j.logger.org.apache.spark.storage=WARN

--- a/training/src/test/scala/com/airbnb/aerosolve/training/AdditiveModelTrainerTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/AdditiveModelTrainerTest.scala
@@ -1,19 +1,47 @@
 package com.airbnb.aerosolve.training
 
-import java.io.{StringReader, BufferedWriter, BufferedReader, StringWriter}
+import java.io.{BufferedReader, BufferedWriter, StringReader, StringWriter}
 
-import com.airbnb.aerosolve.core.models.{ModelFactory, AdditiveModel}
+import com.airbnb.aerosolve.core.models.{AdditiveModel, ModelFactory}
 import com.airbnb.aerosolve.core.Example
 import com.typesafe.config.ConfigFactory
-import org.apache.spark.SparkContext
-import org.junit.Test
+import org.apache.spark.{LocalSparkContext, SparkConf, SparkContext}
+import org.junit.{AfterClass, BeforeClass, Test}
 import org.slf4j.LoggerFactory
 import org.junit.Assert._
+
 import scala.collection.mutable.ArrayBuffer
+import scala.util.Random
+
+object AdditiveModelTrainerTest {
+
+  @transient private var _sc: SparkContext = _
+
+  def sc: SparkContext = _sc
+
+  var conf = new SparkConf(false).set("spark.sql.shuffle.partitions", "2")
+
+  @BeforeClass
+  def beforeAll() {
+    _sc = new SparkContext("local[4]", "test", conf)
+  }
+
+  @AfterClass
+  def afterAll() {
+    try {
+      LocalSparkContext.stop(_sc)
+      _sc = null
+    } finally {
+    }
+  }
+
+}
 
 class AdditiveModelTrainerTest {
+
   val log = LoggerFactory.getLogger("AdditiveModelTrainerTest")
-  def makeConfig(loss : String, dropout : Double, extraArgs : String) : String = {
+
+  def makeConfig(loss: String, dropout: Double, extraArgs: String): String = {
     """
       |identity_transform {
       |  transform : list
@@ -25,9 +53,9 @@ class AdditiveModelTrainerTest {
       |  %s
       |  rank_key : "$rank"
       |  rank_threshold : 0.0
-      |  learning_rate : 0.1
+      |  learning_rate : 0.5
       |  num_bins : 16
-      |  iterations : 10
+      |  iterations : 5
       |  smoothing_tolerance : 0.1
       |  linfinity_threshold : 0.01
       |  linfinity_cap : 10.0
@@ -38,11 +66,12 @@ class AdditiveModelTrainerTest {
       |  item_transform : identity_transform
       |  combined_transform : identity_transform
       |  model_output : ""
+      |  storage_level : MEMORY_ONLY
       |}
     """.stripMargin.format(loss, extraArgs, dropout)
   }
 
-  def makeRegressionConfig(extraArgs: String) : String = {
+  def makeRegressionConfig(extraArgs: String): String = {
     """
       |identity_transform {
       |  transform : list
@@ -51,12 +80,11 @@ class AdditiveModelTrainerTest {
       |model_config {
       |  num_bags : 3
       |  loss : "regression"
-      |  %s
       |  rank_key : "$rank"
       |  rank_threshold : 0.0
       |  learning_rate : 0.1
       |  num_bins : 16
-      |  iterations : 20
+      |  iterations : 5
       |  smoothing_tolerance : 0.1
       |  linfinity_threshold : 0.01
       |  linfinity_cap : 10.0
@@ -68,88 +96,90 @@ class AdditiveModelTrainerTest {
       |  item_transform : identity_transform
       |  combined_transform : identity_transform
       |  model_output : ""
+      |  storage_level : MEMORY_ONLY
+      |  %s
       |}
     """.stripMargin.format(extraArgs)
   }
 
   @Test
-  def testAdditiveModelTrainerSplineLogistic : Unit = {
+  def testAdditiveModelTrainerSplineLogistic: Unit = {
     testAdditiveModelTrainer("logistic", 0.0, "")
   }
 
   @Test
-  def testAdditiveModelTrainerSplineHinge : Unit = {
+  def testAdditiveModelTrainerSplineHinge: Unit = {
     testAdditiveModelTrainer("hinge", 0.0, "")
   }
 
   @Test
-  def testAdditiveModelTrainerSplineLogisticWithDropout : Unit = {
-    testAdditiveModelTrainer("logistic", 0.2, "")
+  def testAdditiveModelTrainerSplineLogisticWithDropout: Unit = {
+    testAdditiveModelTrainer("logistic", 0.1, "")
   }
 
   @Test
-  def testAdditiveModelTrainerSplineHingeWithMargin : Unit = {
+  def testAdditiveModelTrainerSplineHingeWithMargin: Unit = {
     testAdditiveModelTrainer("hinge", 0.0, "margin : 0.5")
   }
 
   @Test
-  def testAdditiveTrainerSplineHingeMultiscale : Unit = {
+  def testAdditiveTrainerSplineHingeMultiscale: Unit = {
     testAdditiveModelTrainer("hinge", 0.0, "multiscale : [5, 7, 16]")
   }
 
   @Test
-  def testAdditiveTrainerSplineHingeMultiscaleWithMargin : Unit = {
+  def testAdditiveTrainerSplineHingeMultiscaleWithMargin: Unit = {
     testAdditiveModelTrainer("hinge", 0.0, "margin : 0.5, multiscale : [5, 7, 16]")
   }
 
   @Test
-  def testAdditiveModelTrainerLinearHinge1 : Unit = {
+  def testAdditiveModelTrainerLinearHinge1: Unit = {
     testAdditiveModelTrainer("hinge", 0.0, "", "linear")
   }
 
   @Test
-  def testAdditiveModelTrainerLinearHinge2 : Unit = {
-  testAdditiveModelTrainer("hinge", 0.0, "linear_feature:[loc, xy]", "linear")
+  def testAdditiveModelTrainerLinearHinge2: Unit = {
+    testAdditiveModelTrainer("hinge", 0.0, "linear_feature:[loc, xy]", "linear")
   }
 
   @Test
-  def testAdditiveModelTrainerLinearLogistic : Unit = {
+  def testAdditiveModelTrainerLinearLogistic: Unit = {
     testAdditiveModelTrainer("logistic", 0.0, "linear_feature:[loc, xy]", "linear")
   }
 
   @Test
-  def testAdditiveModelTrainerLinearLogisticWithDropout : Unit = {
+  def testAdditiveModelTrainerLinearLogisticWithDropout: Unit = {
     testAdditiveModelTrainer("logistic", 0.1, "linear_feature:[loc, xy]", "linear")
   }
 
   @Test
-  def testAdditiveModelTrainerLinearHingeWithMargin : Unit = {
+  def testAdditiveModelTrainerLinearHingeWithMargin: Unit = {
     testAdditiveModelTrainer("hinge", 0.0, "margin:0.5, linear_feature:[loc, xy]", "linear")
   }
 
   @Test
-  def testAdditiveModelTrainerHybridHinge : Unit = {
+  def testAdditiveModelTrainerHybridHinge: Unit = {
     testAdditiveModelTrainer("hinge", 0.0, "linear_feature:[xy]", "linear")
   }
 
   @Test
-  def testAdditiveModelTrainerHybridLogistic : Unit = {
+  def testAdditiveModelTrainerHybridLogistic: Unit = {
     testAdditiveModelTrainer("logistic", 0.0, "linear_feature:[loc]", "linear")
   }
 
   @Test
-  def testAdditiveModelTrainerHybridLogisticWithDropout : Unit = {
+  def testAdditiveModelTrainerHybridLogisticWithDropout: Unit = {
     testAdditiveModelTrainer("logistic", 0.1, "linear_feature:[loc]", "linear")
   }
 
   @Test
-  def testAdditiveModelTrainerHybridHingeWithMargin : Unit = {
+  def testAdditiveModelTrainerHybridHingeWithMargin: Unit = {
     testAdditiveModelTrainer("hinge", 0.0, "margin:0.5, linear_feature:[xy]", "linear")
   }
 
   @Test
   def testAdditiveModelRegressionSpline1: Unit = {
-    testAdditiveModelTrainerRegression("", "flattenedQuadratic")
+    testAdditiveModelTrainerRegression("iterations:20", "flattenedQuadratic")
   }
 
   @Test
@@ -187,58 +217,48 @@ class AdditiveModelTrainerTest {
     testAdditiveModelTrainerRegression("linear_feature:[xy], multiscale : [5, 7, 16]", "linear")
   }
 
-  def testAdditiveModelTrainer(loss : String, dropout : Double, extraArgs : String, exampleFunc: String = "poly") = {
-    var sc = new SparkContext("local", "AdditiveModelTest")
-    try {
-      val (examples, label, numPos) = if (exampleFunc.equals("poly")) {
+  def testAdditiveModelTrainer(loss: String, dropout: Double, extraArgs: String, exampleFunc: String = "poly") = {
+    val sc = AdditiveModelTrainerTest.sc
+    Random.setSeed(42)
+    val (examples, label, numPos) = if (exampleFunc.equals("poly")) {
       TrainingTestHelper.makeClassificationExamples
-      } else {
+    } else {
       TrainingTestHelper.makeLinearClassificationExamples
-      }
-      val config = ConfigFactory.parseString(makeConfig(loss, dropout, extraArgs))
-      val input = sc.parallelize(examples)
-      val model = AdditiveModelTrainer.train(sc, input, config, "model_config")
-      testClassificationModel(model, examples, label, numPos)
-    } finally {
-      sc.stop
-      sc = null
-      // To avoid Akka rebinding to the same port, since it doesn't unbind immediately on shutdown
-      System.clearProperty("spark.master.port")
     }
+    val config = ConfigFactory.parseString(makeConfig(loss, dropout, extraArgs))
+    val input = sc.parallelize(examples).cache()
+    val model = AdditiveModelTrainer.train(sc, input, config, "model_config")
+    input.unpersist()
+
+    testClassificationModel(model, examples, label, numPos)
   }
 
   def testAdditiveModelTrainerRegression(extraArgs: String, exampleFunc: String) = {
-    var sc = new SparkContext("local", "AdditiveModelTest")
-    try {
-      val (examples, label) = if (exampleFunc.equals("linear")) {
-        TrainingTestHelper.makeLinearRegressionExamples()
-      } else {
-        TrainingTestHelper.makeRegressionExamples()
-      }
-
-      val (testingExample, testingLabel) = if (exampleFunc.equals("linear")) {
-        TrainingTestHelper.makeLinearRegressionExamples(25)
-      } else {
-        TrainingTestHelper.makeRegressionExamples(25)
-      }
-
-      val threshold = if (exampleFunc.equals("linear")) {
-        0.5
-      } else {
-        3.0
-      }
-
-      val config = ConfigFactory.parseString(makeRegressionConfig(extraArgs))
-      val input = sc.parallelize(examples)
-      val model = AdditiveModelTrainer.train(sc, input, config, "model_config")
-
-      testRegressionModel(model, examples, label, testingExample, testingLabel, threshold)
-    } finally {
-      sc.stop
-      sc = null
-      // To avoid Akka rebinding to the same port, since it doesn't unbind immediately on shutdown
-      System.clearProperty("spark.master.port")
+    val sc = AdditiveModelTrainerTest.sc
+    val (examples, label) = if (exampleFunc.equals("linear")) {
+      TrainingTestHelper.makeLinearRegressionExamples()
+    } else {
+      TrainingTestHelper.makeRegressionExamples()
     }
+
+    val (testingExample, testingLabel) = if (exampleFunc.equals("linear")) {
+      TrainingTestHelper.makeLinearRegressionExamples(25)
+    } else {
+      TrainingTestHelper.makeRegressionExamples(25)
+    }
+
+    val threshold = if (exampleFunc.equals("linear")) {
+      0.5
+    } else {
+      3.0
+    }
+
+    val config = ConfigFactory.parseString(makeRegressionConfig(extraArgs))
+    val input = sc.parallelize(examples).cache()
+    val model = AdditiveModelTrainer.train(sc, input, config, "model_config")
+    input.unpersist()
+
+    testRegressionModel(model, examples, label, testingExample, testingLabel, threshold)
   }
 
   def testClassificationModel(model: AdditiveModel,
@@ -246,8 +266,8 @@ class AdditiveModelTrainerTest {
                               label: ArrayBuffer[Double],
                               numPos: Int): Unit = {
     TrainingTestHelper.printAdditiveModel(model)
-    var numCorrect : Int = 0
-    var i : Int = 0
+    var numCorrect: Int = 0
+    var i: Int = 0
     val labelArr = label.toArray
     for (ex <- examples) {
       val score = model.scoreItem(ex.example.get(0))
@@ -256,21 +276,21 @@ class AdditiveModelTrainerTest {
       }
       i += 1
     }
-    val fracCorrect : Double = numCorrect * 1.0 / examples.length
+    val fracCorrect: Double = numCorrect * 1.0 / examples.length
     log.info("Num correct = %d, frac correct = %f, num pos = %d, num neg = %d"
-               .format(numCorrect, fracCorrect, numPos, examples.length - numPos))
+      .format(numCorrect, fracCorrect, numPos, examples.length - numPos))
     assertTrue(fracCorrect > 0.8)
 
     val swriter = new StringWriter()
     val writer = new BufferedWriter(swriter)
     model.save(writer)
     writer.close()
-    val str = swriter.toString()
+    val str = swriter.toString
     val sreader = new StringReader(str)
     val reader = new BufferedReader(sreader)
     log.info(str)
     val model2Opt = ModelFactory.createFromReader(reader)
-    assertTrue(model2Opt.isPresent())
+    assertTrue(model2Opt.isPresent)
     val model2 = model2Opt.get()
     for (ex <- examples) {
       val score = model.scoreItem(ex.example.get(0))
@@ -287,7 +307,7 @@ class AdditiveModelTrainerTest {
                           threshold: Double = 3.0): Unit = {
     TrainingTestHelper.printAdditiveModel(model)
     val trainLabelArr = trainingLabel.toArray
-    var trainTotalError : Double = 0
+    var trainTotalError: Double = 0
     var i = 0
     // compute training error
     for (ex <- trainingExample) {
@@ -302,7 +322,7 @@ class AdditiveModelTrainerTest {
     assertTrue(trainError < 3.0)
     // compute testing error
     val testLabelArr = testingLabel.toArray
-    var testTotalError : Double = 0
+    var testTotalError: Double = 0
     // compute training error
     i = 0
     for (ex <- testingExample) {

--- a/training/src/test/scala/com/airbnb/aerosolve/training/TrainingTestHelper.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/TrainingTestHelper.scala
@@ -12,9 +12,9 @@ import scala.collection.mutable.ArrayBuffer
 object TrainingTestHelper {
   val log = LoggerFactory.getLogger("TrainingTestHelper")
 
-  def makeExample(x : Double,
-                  y : Double,
-                  target : Double) : Example = {
+  def makeExample(x: Double,
+                  y: Double,
+                  target: Double): Example = {
     val example = new Example
     val item: FeatureVector = new FeatureVector
     item.setFloatFeatures(new java.util.HashMap)
@@ -39,9 +39,9 @@ object TrainingTestHelper {
     example
   }
 
-  def makeDenseExample(x : Double,
-                  y : Double,
-                  target : Double) : Example = {
+  def makeDenseExample(x: Double,
+                       y: Double,
+                       target: Double): Example = {
     val example = new Example
     val item: FeatureVector = new FeatureVector
     item.setDenseFeatures(new java.util.HashMap)
@@ -72,11 +72,11 @@ object TrainingTestHelper {
     (examples, label, numPos)
   }
 
-  def makeMulticlassExample(x : Double,
-                            y : Double,
-                            z : Double,
-                            label : (String, Double),
-                            label2 : Option[(String, Double)]) : Example = {
+  def makeMulticlassExample(x: Double,
+                            y: Double,
+                            z: Double,
+                            label: (String, Double),
+                            label2: Option[(String, Double)]): Example = {
     val example = new Example
     val item: FeatureVector = new FeatureVector
     item.setFloatFeatures(new java.util.HashMap)
@@ -100,7 +100,7 @@ object TrainingTestHelper {
     example
   }
 
-  def makeSimpleMulticlassClassificationExamples(multiLabel : Boolean) = {
+  def makeSimpleMulticlassClassificationExamples(multiLabel: Boolean) = {
     val examples = ArrayBuffer[Example]()
     val labels = ArrayBuffer[String]()
     val rnd = new java.util.Random(1234)
@@ -108,28 +108,24 @@ object TrainingTestHelper {
       var x = 2.0 * rnd.nextDouble() - 1.0
       var y = 2.0 * rnd.nextDouble() - 1.0
       val z = 2.0 * rnd.nextDouble() - 1.0
-      var label : String = ""
+      var label: String = ""
       rnd.nextInt(4) match {
-        case 0 => {
+        case 0 =>
           label = "top_left"
           x = x - 10.0
           y = y + 10.0
-        }
-        case 1 => {
+        case 1 =>
           label = "top_right"
           x = x + 10.0
           y = y + 10.0
-        }
-        case 2 => {
+        case 2 =>
           label = "bot_left"
           x = x - 10.0
           y = y - 10.0
-        }
-        case 3 => {
+        case 3 =>
           label = "bot_right"
           x = x + 10.0
           y = y - 10.0
-        }
       }
       labels += label
       if (multiLabel) {
@@ -152,17 +148,17 @@ object TrainingTestHelper {
       val z = 20.0 * rnd.nextDouble() - 10.0
       val d = math.sqrt(x * x + y * y + z * z)
       // Three nested layers inner, middle and outer
-      val label : String = if (d < 5) "inner" else
-                           if (d < 10) "middle" else "outer"
+      val label: String = if (d < 5) "inner"
+      else if (d < 10) "middle" else "outer"
       labels += label
       examples += makeMulticlassExample(x, y, z, (label, 1.0), None)
     }
     (examples, labels)
   }
 
-  def makeHybridExample(x : Double,
-                        y : Double,
-                        target : Double) : Example = {
+  def makeHybridExample(x: Double,
+                        y: Double,
+                        target: Double): Example = {
     val example = new Example
     val item: FeatureVector = new FeatureVector
     item.setFloatFeatures(new java.util.HashMap)
@@ -184,7 +180,7 @@ object TrainingTestHelper {
     val examples = ArrayBuffer[Example]()
     val label = ArrayBuffer[Double]()
     val rnd = new java.util.Random(1234)
-    var numPos : Int = 0
+    var numPos: Int = 0
     for (i <- 0 until 500) {
       val x = 2.0 * rnd.nextDouble() - 1.0
       val y = 10.0 * (2.0 * rnd.nextDouble() - 1.0)
@@ -205,7 +201,7 @@ object TrainingTestHelper {
     val examples = ArrayBuffer[Example]()
     val label = ArrayBuffer[Double]()
     val rnd = new java.util.Random(1234)
-    var numPos : Int = 0
+    var numPos: Int = 0
     for (i <- 0 until 200) {
       val x = 2.0 * rnd.nextDouble() - 1.0
       val y = 10.0 * (2.0 * rnd.nextDouble() - 1.0)
@@ -262,12 +258,12 @@ object TrainingTestHelper {
     for (familyMap <- weights) {
       for (featureMap <- familyMap._2.asScala) {
         log.info(("family=%s,feature=%s,"
-                  + "minVal=%f, maxVal=%f, weights=%s")
-                   .format(familyMap._1,
-                           featureMap._1,
-                           featureMap._2.spline.getMinVal,
-                           featureMap._2.spline.getMaxVal,
-                           featureMap._2.spline.getWeights.mkString(",")
+          + "minVal=%f, maxVal=%f, weights=%s")
+          .format(familyMap._1,
+            featureMap._1,
+            featureMap._2.spline.getMinVal,
+            featureMap._2.spline.getMaxVal,
+            featureMap._2.spline.getWeights.mkString(",")
           )
         )
       }

--- a/training/src/test/scala/com/airbnb/aerosolve/training/TrainingTestHelper.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/TrainingTestHelper.scala
@@ -180,7 +180,7 @@ object TrainingTestHelper {
     example
   }
 
-  def makeClassificationExamples = {
+  lazy val makeClassificationExamples = {
     val examples = ArrayBuffer[Example]()
     val label = ArrayBuffer[Double]()
     val rnd = new java.util.Random(1234)
@@ -201,7 +201,7 @@ object TrainingTestHelper {
     (examples, label, numPos)
   }
 
-  def makeLinearClassificationExamples = {
+  lazy val makeLinearClassificationExamples = {
     val examples = ArrayBuffer[Example]()
     val label = ArrayBuffer[Double]()
     val rnd = new java.util.Random(1234)
@@ -227,7 +227,7 @@ object TrainingTestHelper {
     val label = ArrayBuffer[Double]()
     val rnd = new java.util.Random(randomSeed)
 
-    for (i <- 0 until 200) {
+    for (i <- 0 until 400) {
       val x = 4.0 * (2.0 * rnd.nextDouble() - 1.0)
       val y = 4.0 * (2.0 * rnd.nextDouble() - 1.0)
 


### PR DESCRIPTION
This is a huge one. Thanks for reviewing it in advance. You might want to examine commit by commit and also add `&w=1` or `?w=1` to the URL to ignore white spaces in the diff due to reformatting.

Aside a few minor optimizations mentioned in the commits, the major changes are:
1. Add `SparseLabeledPoint` for space efficient representation of feature vector
2. Add validation split into model trainer for better understanding of model convergence

## Sparse Representation
It shall be noted this implementation is not ideal in any sense but as a compromise to best fit in Aerosolve existing architecture without rewriting all the transforms.

`SparseLabeledPoint` store feature vector in the form of
```java
    public final int[] indices;
    public final float[] values;
    public final int[] denseIndices;
    public final float[][] denseValues;
```
where float and string features are stored in `indices,values` and dense features are stored in `denseIndices,denseValues`. The index of each feature is backed by `featureIndexer` in AdditiveModel of type `Map<String, Map<String, Integer>>`.

So instead of
```
Map(
  'family1' -> Map(
    `feature1' -> value1,
    `feature4' -> value2,
   ...),
  ...
)
```
we store features as
```
indices: [1, 4, ...]
values: [1, 2, ...]
```
Furthermore, to support efficient model updates with sparsely represented feature vector, we collect all features into `Function[] weightVector` where features are directly indexed by their corresponding index in the `featureIndexer`.

## Validation Split
Because SGD loss is rather jittery in short window frame and we perform averaging of model weights among other regularizations during each iterations, training loss appears to be a poor proxy to model convergence.
This PR adds an optional `isTraining` function to split training data into training and validation. After each iteration, validation loss is calculated without updating the model itself.
This gives a much clearer guidance to both learning rate specification, its appropriate decay rate, early stopping, and if model of any iterations might have been overfitted.
The final model is picked from the iteration with lowest validation loss instead.

## Speed Optimization
With validation loss, we were able to experiment with parameters and sampling technique with much better confidence. 
This PR also adds option to `sample_by_partition` which take a sample of partitions. This played nicely when there are lots of partitions and data is randomly distributed when they are pulled. It appears model can converge much faster when a smaller sample is chosen and run with a few more iterations.


@deerzq @jq @timyitong

p.s. I will update hackpad once this is merged to outline a few techniques and findings.
