### PR TITLE
Write metrics to result file during eval

### DIFF
--- a/demo/income_prediction/README.md
+++ b/demo/income_prediction/README.md
@@ -68,9 +68,9 @@ You can inspect the model using
 ```
 spark-shell --master local[1] --jars build/libs/income_prediction-1.0.0-all.jar 
 scala> import com.airbnb.aerosolve.core.util.Util
-scala> val model = sc.textFile("output/model/spline.model").map(Util.decodeModel)
+scala> val model = sc.textFile("output/model/additive.model").map(Util.decodeModel)
 scala> model.take(5).foreach(println)
-ModelRecord(modelHeader:ModelHeader(modelType:spline, numRecords:53, numHidden:64, slope:1.0, offset:0.0))
+ModelRecord(modelHeader:ModelHeader(modelType:additive, numRecords:53, numHidden:64, slope:1.0, offset:0.0))
 ModelRecord(featureFamily:S, featureName:11th, weightVector:[-0.72265625, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], minVal:1.0, maxVal:2.0)
 ModelRecord(featureFamily:S, featureName:Local-gov, weightVector:[-0.125, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], minVal:1.0, maxVal:2.0)
 ModelRecord(featureFamily:S, featureName:Handlers-cleaners, weightVector:[-1.08203125, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], minVal:1.0, maxVal:2.0)
@@ -132,3 +132,21 @@ For example, you may get:
 ```
 
 The results may vary slightly in different runs.
+
+You can inspect the performance results using
+
+```
+spark-shell --master local[1] --jars build/libs/income_prediction-1.0.0-all.jar
+scala> sc.textFile("output/training_results").take(5).foreach(println)
+{
+"TRAIN_PRECISION_RECALL_AUC": 0.6679520282894851,
+"HOLD_PRECISION_RECALL_AUC": 0.0,
+"TRAIN_AUC": 0.8687429312496084,
+"TRAIN_AUC_STDDEV": 0.00599332027720505,
+scala> sc.textFile("output/testing_results").take(5).foreach(println)
+{
+"HOLD_TN": 9904.0,
+"HOLD_FN": 915.0,
+"HOLD_FP": 2531.0,
+"HOLD_SQERR": 2039.0555058585458,
+```

--- a/demo/income_prediction/src/main/resources/income_prediction.conf
+++ b/demo/income_prediction/src/main/resources/income_prediction.conf
@@ -8,6 +8,8 @@ testingInput : ${PWD}"/src/main/resources/adult.test"
 // Location of training data
 trainingData : ${rootDir}"/training_data"
 testingData : ${rootDir}"/testing_data"
+trainingResults : ${rootDir}"/training_results"
+testingResults : ${rootDir}"/testing_results"
 spline_model_name : ${rootDir}"/model/spline.model"
 additive_model_name: ${rootDir}"/model/additive.model"
 modelKey : "additive_model_with_dynamic_buckets"
@@ -34,6 +36,7 @@ eval_testing {
   subsample : 1.0
   bins : 11
   is_training : false
+  results_output_path : ${testingResults}
 }
 
 eval_training {
@@ -43,6 +46,7 @@ eval_training {
   subsample : 1.0
   bins : 11
   is_training : true
+  results_output_path : ${trainingResults}
 }
 
 // This transform does nothing.

--- a/training/src/main/scala/com/airbnb/aerosolve/training/Evaluation.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/Evaluation.scala
@@ -3,6 +3,7 @@ package com.airbnb.aerosolve.training
 import org.slf4j.{Logger, LoggerFactory}
 import org.apache.spark.rdd.RDD
 import com.airbnb.aerosolve.core.EvaluationRecord
+import com.airbnb.aerosolve.training.pipeline.ResultUtil
 import org.apache.spark.SparkContext._
 import scala.collection.{mutable, Map}
 import scala.collection.mutable.{ArrayBuffer, Buffer}

--- a/training/src/main/scala/com/airbnb/aerosolve/training/Evaluation.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/Evaluation.scala
@@ -120,12 +120,12 @@ object Evaluation {
     }
 
     metricsAppend(metrics, trainPR, holdPR, results)
-
     evaluateBinaryClassificationAUC(records, metrics, results)
 
+    // Write results
     thresholdsAppend(trainPR, holdPR, holdThresholdPrecisionRecall, trainThresholdPrecisionRecall)
-    val metricsArray = metrics.sortWith((a, b) => a._1 < b._1).toArray
-    ResultUtil.writeResults(resultsOutputPath, metricsArray, holdThresholdPrecisionRecall.toArray, trainThresholdPrecisionRecall.toArray)
+    val resultsArray = results.sortWith((a, b) => a._1 < b._1).toArray
+    ResultUtil.writeResults(resultsOutputPath, resultsArray, holdThresholdPrecisionRecall.toArray, trainThresholdPrecisionRecall.toArray)
 
     metrics
       .sortWith((a, b) => a._1 < b._1)
@@ -143,6 +143,7 @@ object Evaluation {
     var results = mutable.Buffer[(String, Double)]()
     var holdThresholdPrecisionRecall = mutable.Buffer[(Double, Double, Double)]()
     var trainThresholdPrecisionRecall = mutable.Buffer[(Double, Double, Double)]()
+
     // Search all thresholds for the best F1
     // At the same time collect the precision and recall.
     val trainPR = new ArrayBuffer[(Double, Double, Double)]()
@@ -164,9 +165,12 @@ object Evaluation {
     }
 
     metricsAppend(metrics, trainPR, holdPR, results)
-    thresholdsAppend(trainPR, holdPR, holdThresholdPrecisionRecall, trainThresholdPrecisionRecall)
-
     evaluateBinaryClassificationAUC(records, metrics, results)
+
+    // Write results
+    thresholdsAppend(trainPR, holdPR, holdThresholdPrecisionRecall, trainThresholdPrecisionRecall)
+    val resultsArray = results.sortWith((a, b) => a._1 < b._1).toArray
+    ResultUtil.writeResults(resultsOutputPath, resultsArray, holdThresholdPrecisionRecall.toArray, trainThresholdPrecisionRecall.toArray)
 
     metrics
       .sortWith((a, b) => a._1 < b._1)

--- a/training/src/main/scala/com/airbnb/aerosolve/training/Evaluation.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/Evaluation.scala
@@ -87,6 +87,24 @@ object Evaluation {
       .toArray
   }
 
+  def evaluateBinaryClassification(records : RDD[EvaluationRecord],
+                                   buckets : Int,
+                                   evalMetric : String,
+                                   resultOutputPath: String) : Array[(String, Double)] = {
+    val metrics = evaluateBinaryClassification(records, buckets, evalMetric)
+    ResultUtil.writeResults(metrics, resultOutputPath)
+    metrics
+  }
+
+  def evaluateBinaryClassification(records : List[EvaluationRecord],
+                                   buckets : Int,
+                                   evalMetric : String,
+                                   resultOutputPath: String) : Array[(String, Double)] = {
+    val metrics = evaluateBinaryClassification(records, buckets, evalMetric)
+    ResultUtil.writeResults(metrics, resultOutputPath)
+    metrics
+  }
+
   def evaluateMulticlassClassification(records : RDD[EvaluationRecord]) : Array[(String, Double)] = {
     records.flatMap(rec => {
       // Metric, value, count

--- a/training/src/main/scala/com/airbnb/aerosolve/training/Evaluation.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/Evaluation.scala
@@ -176,8 +176,7 @@ object Evaluation {
     metrics
   }
 
-  private def appendMetrics(metricsMap: Map[String, Double],
-                            threshold: Double): mutable.Buffer[(String, Double)] = {
+  private def appendMetrics(metricsMap: Map[String, Double], threshold: Double): mutable.Buffer[(String, Double)] = {
     val metrics = metricsMap.toBuffer
     val ttp = metricsMap.getOrElse("TRAIN_TP", 0.0)
     val ttn = metricsMap.getOrElse("TRAIN_TN", 0.0)

--- a/training/src/main/scala/com/airbnb/aerosolve/training/Evaluation.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/Evaluation.scala
@@ -34,7 +34,7 @@ object Evaluation {
                                    evalMetric : String,
                                    resultsOutputPath: String) : Array[(String, Double)] = {
     // Convert RDD to List
-    val recordsList = records.collect().toList;
+    val recordsList = records.collect().toList
     evaluateBinaryClassificationWithResults(recordsList, buckets, evalMetric, resultsOutputPath)
   }
 

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/GenericPipeline.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/GenericPipeline.scala
@@ -184,7 +184,7 @@ object GenericPipeline {
     val isRegression = Try(cfg.getBoolean("is_regression")).getOrElse(false)
     val isMulticlass = Try(cfg.getBoolean("is_multiclass")).getOrElse(false)
     val metric = cfg.getString("metric_to_maximize")
-    val resultsOutputPath = Try(cfg.getString("results_output_path")).getOrElse("")
+    val resultsOutputPath = Try(cfg.getString("results_output_path")).getOrElse(null)
     val (model, transformer) = getModelAndTransform(config, modelCfgName, modelName)
 
     val metrics = evalModelInternal(
@@ -501,11 +501,7 @@ object GenericPipeline {
     } else if (isMulticlass) {
       Evaluation.evaluateMulticlassClassification(records)
     } else {
-      if (resultsOutputPath == "") {
-        Evaluation.evaluateBinaryClassification(records, bins, metric)
-      } else {
-        Evaluation.evaluateBinaryClassification(records, bins, metric, resultsOutputPath)
-      }
+      Evaluation.evaluateBinaryClassificationWithResults(records, bins, metric, resultsOutputPath)
     }
 
     records.unpersist()

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/GenericPipeline.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/GenericPipeline.scala
@@ -184,7 +184,7 @@ object GenericPipeline {
     val isRegression = Try(cfg.getBoolean("is_regression")).getOrElse(false)
     val isMulticlass = Try(cfg.getBoolean("is_multiclass")).getOrElse(false)
     val metric = cfg.getString("metric_to_maximize")
-    val resultsOutputPath = Try(cfg.getString("results_output_path"))..getOrElse("")
+    val resultsOutputPath = Try(cfg.getString("results_output_path")).getOrElse("")
     val (model, transformer) = getModelAndTransform(config, modelCfgName, modelName)
 
     val metrics = evalModelInternal(

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/GenericPipeline.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/GenericPipeline.scala
@@ -167,23 +167,6 @@ object GenericPipeline {
     val metrics = evalCompute(sc, config, cfgKey, isTrainingFunc)
 
     metrics.foreach(x => log.info(if (x._1 contains "THRESHOLD") x._1 else x.toString))
-
-    // Write metrics to result
-    try {
-      val result: String = confi.getConfig(cfgKey).getString("result")
-      val fileSystem = FileSystem.get(new java.net.URI(result), new Configuration())
-      val file = fileSystem.create(new Path(result), true)
-      val writer = new BufferedWriter(new OutputStreamWriter(file))
-      metrics.foreach{ x => 
-        writer.write(if (x._1 contains "THRESHOLD") x._1 else x.toString)
-        writer.newLine()
-      }
-      writer.flush()
-      writer.close()
-      file.close()
-    } catch {
-      case _ : Throwable => log.error("Could not write to result")
-    }
   }
 
   def evalCompute(

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/GenericPipeline.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/GenericPipeline.scala
@@ -477,8 +477,8 @@ object GenericPipeline {
       isRegression: Boolean,
       isMulticlass: Boolean,
       metric: String,
-      isTraining: Example,
-      resultsOutputPath: String => Boolean) : Array[(String, Double)] = {
+      isTraining: Example => Boolean,
+      resultsOutputPath: String) : Array[(String, Double)] = {
     val examples = sc.textFile(inputPattern)
       .map(Util.decodeExample)
       .sample(false, subSample)

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/ResultUtil.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/ResultUtil.scala
@@ -1,19 +1,107 @@
 package com.airbnb.aerosolve.training.pipeline
 
 import com.airbnb.aerosolve.training._
+import scala.collection.mutable
 
 /*
  * Writes to result file
+ *
+ * Format:
+    {
+      "HOLD_PRECISION_RECALL_AUC": 0.897908,
+      "HOLD_ACC": 0.897908,
+      ...
+      "hold_threshold": [
+        0.021060,
+        0.313343,
+        0.897908,
+        1.190191,
+        1.482474
+      ],
+      "hold_recall": [
+        0.021060,
+        0.313343,
+        0.897908,
+        1.190191,
+        1.482474
+      ],
+      "hold_precision": [
+        0.021060,
+        0.313343,
+        0.897908,
+        1.190191,
+        1.482474
+      ],
+      "TRAIN_PRECISION_RECALL_AUC": 0.897908,
+      "TRAIN_ACC": 0.897908,
+      ...
+      "train_threshold": [
+        0.021060,
+        0.313343,
+        0.897908,
+        1.190191,
+        1.482474
+      ],
+      "train_recall": [
+        0.021060,
+        0.313343,
+        0.897908,
+        1.190191,
+        1.482474
+      ],
+      "train_precision": [
+        0.021060,
+        0.313343,
+        0.897908,
+        1.190191,
+        1.482474
+      ]
+    }
+ *
  */
 object ResultUtil {
-  def writeResults(metrics: Array[(String, Double)], resultOutputPath: String) = {
-    // Put into a one line json format
-    val elements = metrics.map{ x =>
-      val metricStr = if (x._1 contains "THRESHOLD") x._1 else x.toString
-      val line = "\'" + metricStr + "\'"
-      line
+  def writeResults(resultsOutputPath: String,
+                   metrics: Array[(String, Double)],
+                   holdThresholdPrecisionRecall: Array[(Double, Double, Double)],
+                   trainThresholdPrecisionRecall: Array[(Double, Double, Double)]) = {
+    var allMetrics = mutable.Buffer[String]()
+
+    // Add main metrics
+    for (i <- 0 until metrics.length - 1) {
+      val elem = metrics(i)
+      allMetrics.append("\"" + elem._1 + "\": " + elem._2)
     }
-    val json = elements.mkString("[", ",", "]")
-    PipelineUtil.writeStringToFile(json, resultOutputPath)
+
+    // Add hold precision recall metrics
+    var holdThresholds = mutable.Buffer[String]()
+    var holdPrecisions = mutable.Buffer[String]()
+    var holdRecalls = mutable.Buffer[String]()
+    for (i <- 0 until holdThresholdPrecisionRecall.length - 1) {
+      val elem = holdThresholdPrecisionRecall(i)
+      holdThresholds.append(elem._1.toString)
+      holdPrecisions.append(elem._2.toString)
+      holdRecalls.append(elem._3.toString)
+    }
+    allMetrics.append(holdThresholds.mkString("\"hold_threshold\": [", ",", "]"))
+    allMetrics.append(holdPrecisions.mkString("\"hold_precision\": [", ",", "]"))
+    allMetrics.append(holdRecalls.mkString("\"hold_recall\": [", ",", "]"))
+
+    // Add hold precision recall metrics
+    var trainThresholds = mutable.Buffer[String]()
+    var trainPrecisions = mutable.Buffer[String]()
+    var trainRecalls = mutable.Buffer[String]()
+    for (i <- 0 until trainThresholdPrecisionRecall.length - 1) {
+      val elem = trainThresholdPrecisionRecall(i)
+      trainThresholds.append(elem._1.toString)
+      trainPrecisions.append(elem._2.toString)
+      trainRecalls.append(elem._3.toString)
+    }
+    allMetrics.append(trainThresholds.mkString("\"train_threshold\": [", ",", "]"))
+    allMetrics.append(trainPrecisions.mkString("\"train_precision\": [", ",", "]"))
+    allMetrics.append(trainRecalls.mkString("\"train_recall\": [", ",", "]"))
+
+    // Write to file as a string
+    val json = allMetrics.mkString("{", ",", "}")
+    PipelineUtil.writeStringToFile(json, resultsOutputPath)
   }
 }

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/ResultUtil.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/ResultUtil.scala
@@ -1,25 +1,19 @@
 package com.airbnb.aerosolve.training.pipeline
 
-import java.io.{BufferedWriter, OutputStreamWriter}
-import java.net.URI
-
-import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.FileSystem
+import com.airbnb.aerosolve.training._
 
 /*
  * Writes to result file
  */
 object ResultUtil {
   def writeResults(metrics: Array[(String, Double)], resultOutputPath: String) = {
-    val fileSystem = FileSystem.get(new java.net.URI(result), new Configuration())
-    val file = fileSystem.create(new Path(result), true)
-    val writer = new BufferedWriter(new OutputStreamWriter(file))
-    metrics.foreach{ x => 
-      writer.write(if (x._1 contains "THRESHOLD") x._1 else x.toString)
-      writer.newLine()
+    // Put into a one line json format
+    val elements = metrics.map{ x =>
+      val metricStr = if (x._1 contains "THRESHOLD") x._1 else x.toString
+      val line = "\'" + metricStr + "\'"
+      line
     }
-    writer.flush()
-    writer.close()
-    file.close()
+    val json = elements.mkString("[", ",", "]")
+    PipelineUtil.writeStringToFile(json, resultOutputPath)
   }
 }

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/ResultUtil.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/ResultUtil.scala
@@ -1,0 +1,25 @@
+package com.airbnb.aerosolve.training.pipeline
+
+import java.io.{BufferedWriter, OutputStreamWriter}
+import java.net.URI
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.FileSystem
+
+/*
+ * Writes to result file
+ */
+object ResultUtil {
+  def writeResults(metrics: Array[(String, Double)], resultOutputPath: String) = {
+    val fileSystem = FileSystem.get(new java.net.URI(result), new Configuration())
+    val file = fileSystem.create(new Path(result), true)
+    val writer = new BufferedWriter(new OutputStreamWriter(file))
+    metrics.foreach{ x => 
+      writer.write(if (x._1 contains "THRESHOLD") x._1 else x.toString)
+      writer.newLine()
+    }
+    writer.flush()
+    writer.close()
+    file.close()
+  }
+}

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/ResultUtil.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/ResultUtil.scala
@@ -63,7 +63,8 @@ object ResultUtil {
   def writeResults(resultsOutputPath: String,
                    metrics: Array[(String, Double)],
                    holdThresholdPrecisionRecall: Array[(Double, Double, Double)],
-                   trainThresholdPrecisionRecall: Array[(Double, Double, Double)]) = {
+                   trainThresholdPrecisionRecall: Array[(Double, Double, Double)],
+                   writeResult: Boolean = true) = {
     var allMetrics = mutable.Buffer[String]()
 
     // Add main metrics
@@ -107,7 +108,12 @@ object ResultUtil {
     allMetrics.append(trainRecalls.mkString("\"TRAIN_RECALLS\": [\n", ",\n", "\n]"))
 
     // Write to file as a string
-    val json = allMetrics.mkString("{\n", ",\n", "\n}\n")
-    PipelineUtil.writeStringToFile(json, resultsOutputPath)
+    val jsonString = allMetrics.mkString("{\n", ",\n", "\n}\n")
+    if (writeResult) {
+      PipelineUtil.writeStringToFile(jsonString, resultsOutputPath)
+    }
+
+    // Return jsonString for testing
+    jsonString
   }
 }

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/ResultUtil.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/ResultUtil.scala
@@ -11,21 +11,21 @@ import scala.collection.mutable
       "HOLD_PRECISION_RECALL_AUC": 0.897908,
       "HOLD_ACC": 0.897908,
       ...
-      "hold_threshold": [
+      "HOLD_THRESHOLDS": [
         0.021060,
         0.313343,
         0.897908,
         1.190191,
         1.482474
       ],
-      "hold_recall": [
+      "HOLD_RECALLS": [
         0.021060,
         0.313343,
         0.897908,
         1.190191,
         1.482474
       ],
-      "hold_precision": [
+      "HOLD_PRECISIONS": [
         0.021060,
         0.313343,
         0.897908,
@@ -35,21 +35,21 @@ import scala.collection.mutable
       "TRAIN_PRECISION_RECALL_AUC": 0.897908,
       "TRAIN_ACC": 0.897908,
       ...
-      "train_threshold": [
+      "TRAIN_THRESHOLDS": [
         0.021060,
         0.313343,
         0.897908,
         1.190191,
         1.482474
       ],
-      "train_recall": [
+      "TRAIN_RECALLS": [
         0.021060,
         0.313343,
         0.897908,
         1.190191,
         1.482474
       ],
-      "train_precision": [
+      "TRAIN_PRECISIONS": [
         0.021060,
         0.313343,
         0.897908,
@@ -68,8 +68,12 @@ object ResultUtil {
 
     // Add main metrics
     for (i <- 0 until metrics.length - 1) {
-      val elem = metrics(i)
-      allMetrics.append("\"" + elem._1 + "\": " + elem._2)
+      var name = metrics(i)._1
+      if (name(0) == '!') {
+        name = name.substring(1)
+      }
+      val value = metrics(i)._2
+      allMetrics.append("\"" + name + "\": " + value)
     }
 
     // Add hold precision recall metrics
@@ -82,9 +86,9 @@ object ResultUtil {
       holdPrecisions.append(elem._2.toString)
       holdRecalls.append(elem._3.toString)
     }
-    allMetrics.append(holdThresholds.mkString("\"hold_threshold\": [", ",", "]"))
-    allMetrics.append(holdPrecisions.mkString("\"hold_precision\": [", ",", "]"))
-    allMetrics.append(holdRecalls.mkString("\"hold_recall\": [", ",", "]"))
+    allMetrics.append(holdThresholds.mkString("\"HOLD_THRESHOLDS\": [", ",", "]"))
+    allMetrics.append(holdPrecisions.mkString("\"HOLD_PRECISIONS\": [", ",", "]"))
+    allMetrics.append(holdRecalls.mkString("\"HOLD_RECALLS\": [", ",", "]"))
 
     // Add hold precision recall metrics
     var trainThresholds = mutable.Buffer[String]()
@@ -96,9 +100,9 @@ object ResultUtil {
       trainPrecisions.append(elem._2.toString)
       trainRecalls.append(elem._3.toString)
     }
-    allMetrics.append(trainThresholds.mkString("\"train_threshold\": [", ",", "]"))
-    allMetrics.append(trainPrecisions.mkString("\"train_precision\": [", ",", "]"))
-    allMetrics.append(trainRecalls.mkString("\"train_recall\": [", ",", "]"))
+    allMetrics.append(trainThresholds.mkString("\"TRAIN_THRESHOLDS\": [", ",", "]"))
+    allMetrics.append(trainPrecisions.mkString("\"TRAIN_PRECISIONS\": [", ",", "]"))
+    allMetrics.append(trainRecalls.mkString("\"TRAIN_RECALLS\": [", ",", "]"))
 
     // Write to file as a string
     val json = allMetrics.mkString("{", ",", "}")

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/ResultUtil.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/ResultUtil.scala
@@ -68,7 +68,7 @@ object ResultUtil {
     var allMetrics = mutable.Buffer[String]()
 
     // Add main metrics
-    for (i <- 0 until metrics.length - 1) {
+    for (i <- 0 until metrics.length) {
       var name = metrics(i)._1
       if (name(0) == '!') {
         name = name.substring(1)

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/ResultUtil.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/ResultUtil.scala
@@ -8,54 +8,54 @@ import scala.collection.mutable
  *
  * Format:
     {
-      "HOLD_PRECISION_RECALL_AUC": 0.897908,
-      "HOLD_ACC": 0.897908,
-      ...
-      "HOLD_THRESHOLDS": [
-        0.021060,
-        0.313343,
-        0.897908,
-        1.190191,
-        1.482474
-      ],
-      "HOLD_RECALLS": [
-        0.021060,
-        0.313343,
-        0.897908,
-        1.190191,
-        1.482474
-      ],
-      "HOLD_PRECISIONS": [
-        0.021060,
-        0.313343,
-        0.897908,
-        1.190191,
-        1.482474
-      ],
-      "TRAIN_PRECISION_RECALL_AUC": 0.897908,
-      "TRAIN_ACC": 0.897908,
-      ...
-      "TRAIN_THRESHOLDS": [
-        0.021060,
-        0.313343,
-        0.897908,
-        1.190191,
-        1.482474
-      ],
-      "TRAIN_RECALLS": [
-        0.021060,
-        0.313343,
-        0.897908,
-        1.190191,
-        1.482474
-      ],
-      "TRAIN_PRECISIONS": [
-        0.021060,
-        0.313343,
-        0.897908,
-        1.190191,
-        1.482474
-      ]
+    "HOLD_PRECISION_RECALL_AUC": 0.897908,
+    "HOLD_ACC": 0.897908,
+    ...
+    "HOLD_THRESHOLDS": [
+      0.021060,
+      0.313343,
+      0.897908,
+      1.190191,
+      1.482474
+    ],
+    "HOLD_RECALLS": [
+      0.021060,
+      0.313343,
+      0.897908,
+      1.190191,
+      1.482474
+    ],
+    "HOLD_PRECISIONS": [
+      0.021060,
+      0.313343,
+      0.897908,
+      1.190191,
+      1.482474
+    ],
+    "TRAIN_PRECISION_RECALL_AUC": 0.897908,
+    "TRAIN_ACC": 0.897908,
+    ...
+    "TRAIN_THRESHOLDS": [
+      0.021060,
+      0.313343,
+      0.897908,
+      1.190191,
+      1.482474
+    ],
+    "TRAIN_RECALLS": [
+      0.021060,
+      0.313343,
+      0.897908,
+      1.190191,
+      1.482474
+    ],
+    "TRAIN_PRECISIONS": [
+      0.021060,
+      0.313343,
+      0.897908,
+      1.190191,
+      1.482474
+    ]
     }
  *
  */
@@ -73,7 +73,9 @@ object ResultUtil {
         name = name.substring(1)
       }
       val value = metrics(i)._2
-      allMetrics.append("\"" + name + "\": " + value)
+      if (!value.isNaN) {
+        allMetrics.append("\"" + name + "\": " + value)
+      }
     }
 
     // Add hold precision recall metrics
@@ -82,13 +84,13 @@ object ResultUtil {
     var holdRecalls = mutable.Buffer[String]()
     for (i <- 0 until holdThresholdPrecisionRecall.length - 1) {
       val elem = holdThresholdPrecisionRecall(i)
-      holdThresholds.append(elem._1.toString)
-      holdPrecisions.append(elem._2.toString)
-      holdRecalls.append(elem._3.toString)
+      holdThresholds.append("\t" + elem._1.toString)
+      holdPrecisions.append("\t" + elem._2.toString)
+      holdRecalls.append("\t" + elem._3.toString)
     }
-    allMetrics.append(holdThresholds.mkString("\"HOLD_THRESHOLDS\": [", ",", "]"))
-    allMetrics.append(holdPrecisions.mkString("\"HOLD_PRECISIONS\": [", ",", "]"))
-    allMetrics.append(holdRecalls.mkString("\"HOLD_RECALLS\": [", ",", "]"))
+    allMetrics.append(holdThresholds.mkString("\"HOLD_THRESHOLDS\": [\n", ",\n", "\n]"))
+    allMetrics.append(holdPrecisions.mkString("\"HOLD_PRECISIONS\": [\n", ",\n", "\n]"))
+    allMetrics.append(holdRecalls.mkString("\"HOLD_RECALLS\": [\n", ",\n", "\n]"))
 
     // Add hold precision recall metrics
     var trainThresholds = mutable.Buffer[String]()
@@ -96,16 +98,16 @@ object ResultUtil {
     var trainRecalls = mutable.Buffer[String]()
     for (i <- 0 until trainThresholdPrecisionRecall.length - 1) {
       val elem = trainThresholdPrecisionRecall(i)
-      trainThresholds.append(elem._1.toString)
-      trainPrecisions.append(elem._2.toString)
-      trainRecalls.append(elem._3.toString)
+      trainThresholds.append("\t" + elem._1.toString)
+      trainPrecisions.append("\t" + elem._2.toString)
+      trainRecalls.append("\t" + elem._3.toString)
     }
-    allMetrics.append(trainThresholds.mkString("\"TRAIN_THRESHOLDS\": [", ",", "]"))
-    allMetrics.append(trainPrecisions.mkString("\"TRAIN_PRECISIONS\": [", ",", "]"))
-    allMetrics.append(trainRecalls.mkString("\"TRAIN_RECALLS\": [", ",", "]"))
+    allMetrics.append(trainThresholds.mkString("\"TRAIN_THRESHOLDS\": [\n", ",\n", "\n]"))
+    allMetrics.append(trainPrecisions.mkString("\"TRAIN_PRECISIONS\": [\n", ",\n", "\n]"))
+    allMetrics.append(trainRecalls.mkString("\"TRAIN_RECALLS\": [\n", ",\n", "\n]"))
 
     // Write to file as a string
-    val json = allMetrics.mkString("{", ",", "}")
+    val json = allMetrics.mkString("{\n", ",\n", "\n}\n")
     PipelineUtil.writeStringToFile(json, resultsOutputPath)
   }
 }

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/ResultUtil.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/ResultUtil.scala
@@ -92,7 +92,7 @@ object ResultUtil {
     allMetrics.append(holdPrecisions.mkString("\"HOLD_PRECISIONS\": [\n", ",\n", "\n]"))
     allMetrics.append(holdRecalls.mkString("\"HOLD_RECALLS\": [\n", ",\n", "\n]"))
 
-    // Add hold precision recall metrics
+    // Add train precision recall metrics
     var trainThresholds = mutable.Buffer[String]()
     var trainPrecisions = mutable.Buffer[String]()
     var trainRecalls = mutable.Buffer[String]()

--- a/training/src/test/scala/com/airbnb/aerosolve/training/pipeline/ResultUtilTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/pipeline/ResultUtilTest.scala
@@ -1,0 +1,30 @@
+package com.airbnb.aerosolve.training.pipeline
+
+import org.junit.Assert._
+import org.junit.Test
+
+import scala.util.parsing.json.JSON
+
+class ResultUtilTest {
+  @Test
+  def testExampleToEvaluationRecordMulticlass() = {
+    val metrics = Array(("!HOLD_AUC", 0.11), ("TRAIN_ACC", 0.22), ("TRAIN_AUC", 0.33));
+    val holdMetrics = Array((0.1, 0.2, 0.3), (1.1, 1.2, 1.3));
+    val trainMetrics = Array[(Double, Double, Double)]();
+    val resultString = ResultUtil.writeResults("resultsOutputPath", metrics, holdMetrics, trainMetrics, false);
+
+    // Convert Json string into Map[String, Any] and check format
+    val parsedMetrics = JSON.parseFull(resultString).get.asInstanceOf[Map[String, Any]];
+
+    assertEquals(parsedMetrics.get("HOLD_AUC").get.asInstanceOf[Double], 0.11, 1e-5);
+    assertEquals(parsedMetrics.get("TRAIN_ACC").get.asInstanceOf[Double], 0.22, 1e-5);
+
+    assertEquals(parsedMetrics.get("HOLD_THRESHOLDS").get.asInstanceOf[List[Double]].head, 0.1, 1e-5);
+    assertEquals(parsedMetrics.get("HOLD_PRECISIONS").get.asInstanceOf[List[Double]].head, 0.2, 1e-5);
+    assertEquals(parsedMetrics.get("HOLD_RECALLS").get.asInstanceOf[List[Double]].head, 0.3, 1e-5);
+
+    assertEquals(parsedMetrics.get("TRAIN_THRESHOLDS").get.asInstanceOf[List[Double]].isEmpty, true);
+    assertEquals(parsedMetrics.get("TRAIN_PRECISIONS").get.asInstanceOf[List[Double]].isEmpty, true);
+    assertEquals(parsedMetrics.get("TRAIN_RECALLS").get.asInstanceOf[List[Double]].isEmpty, true);
+  }
+}

--- a/training/src/test/scala/com/airbnb/aerosolve/training/pipeline/ResultUtilTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/pipeline/ResultUtilTest.scala
@@ -8,23 +8,23 @@ import scala.util.parsing.json.JSON
 class ResultUtilTest {
   @Test
   def testExampleToEvaluationRecordMulticlass() = {
-    val metrics = Array(("!HOLD_AUC", 0.11), ("TRAIN_ACC", 0.22), ("TRAIN_AUC", 0.33));
-    val holdMetrics = Array((0.1, 0.2, 0.3), (1.1, 1.2, 1.3));
-    val trainMetrics = Array[(Double, Double, Double)]();
-    val resultString = ResultUtil.writeResults("resultsOutputPath", metrics, holdMetrics, trainMetrics, false);
+    val metrics = Array(("!HOLD_AUC", 0.11), ("TRAIN_ACC", 0.22))
+    val holdMetrics = Array((0.1, 0.2, 0.3), (1.1, 1.2, 1.3))
+    val trainMetrics = Array[(Double, Double, Double)]()
+    val resultString = ResultUtil.writeResults("resultsOutputPath", metrics, holdMetrics, trainMetrics, false)
 
     // Convert Json string into Map[String, Any] and check format
-    val parsedMetrics = JSON.parseFull(resultString).get.asInstanceOf[Map[String, Any]];
+    val parsedMetrics = JSON.parseFull(resultString).get.asInstanceOf[Map[String, Any]]
 
-    assertEquals(parsedMetrics.get("HOLD_AUC").get.asInstanceOf[Double], 0.11, 1e-5);
-    assertEquals(parsedMetrics.get("TRAIN_ACC").get.asInstanceOf[Double], 0.22, 1e-5);
+    assertEquals(parsedMetrics.get("HOLD_AUC").get.asInstanceOf[Double], 0.11, 1e-5)
+    assertEquals(parsedMetrics.get("TRAIN_ACC").get.asInstanceOf[Double], 0.22, 1e-5)
 
-    assertEquals(parsedMetrics.get("HOLD_THRESHOLDS").get.asInstanceOf[List[Double]].head, 0.1, 1e-5);
-    assertEquals(parsedMetrics.get("HOLD_PRECISIONS").get.asInstanceOf[List[Double]].head, 0.2, 1e-5);
-    assertEquals(parsedMetrics.get("HOLD_RECALLS").get.asInstanceOf[List[Double]].head, 0.3, 1e-5);
+    assertEquals(parsedMetrics.get("HOLD_THRESHOLDS").get.asInstanceOf[List[Double]].head, 0.1, 1e-5)
+    assertEquals(parsedMetrics.get("HOLD_PRECISIONS").get.asInstanceOf[List[Double]].head, 0.2, 1e-5)
+    assertEquals(parsedMetrics.get("HOLD_RECALLS").get.asInstanceOf[List[Double]].head, 0.3, 1e-5)
 
-    assertEquals(parsedMetrics.get("TRAIN_THRESHOLDS").get.asInstanceOf[List[Double]].isEmpty, true);
-    assertEquals(parsedMetrics.get("TRAIN_PRECISIONS").get.asInstanceOf[List[Double]].isEmpty, true);
-    assertEquals(parsedMetrics.get("TRAIN_RECALLS").get.asInstanceOf[List[Double]].isEmpty, true);
+    assertEquals(parsedMetrics.get("TRAIN_THRESHOLDS").get.asInstanceOf[List[Double]].isEmpty, true)
+    assertEquals(parsedMetrics.get("TRAIN_PRECISIONS").get.asInstanceOf[List[Double]].isEmpty, true)
+    assertEquals(parsedMetrics.get("TRAIN_RECALLS").get.asInstanceOf[List[Double]].isEmpty, true)
   }
 }


### PR DESCRIPTION
If a user specifies a `result` parameter in the eval part of their config, then it will write all metrics to that file.

To: @jq @yinlou 