### PR TITLE
add evaluation data source

### DIFF
--- a/training/src/main/resources/demo_multiclass_train.conf
+++ b/training/src/main/resources/demo_multiclass_train.conf
@@ -13,10 +13,14 @@ model_version: "a"
 model_type : "full_rank_linear"
 model_config : ${model_type}"_model_config"
 demo_table : "pricing.twenty_news_training_raw"
+# Can use a different table
+demo_table_eval : "pricing.twenty_news_training_raw"
 
 # Where to dump outputs; change prefix based on your HDFS directory layout
 prefix : "hdfs://airfs-silver/user/"${USER}"/multiclass_demo_pipeline"
 training_data : ${prefix}"/training_data"${training_data_version}
+eval_data : ${prefix}"/eval_data"${training_data_version}
+
 eval_output : ${prefix}"/eval_output/"${training_data_version}_${model_version}".eval"
 model_name : ${prefix}"/model/"${training_data_version}_${model_version}_${model_type}".model"
 model_dump : ${model_name}".tsv"
@@ -49,10 +53,15 @@ debug_transforms {
 }
 
 make_training {
-  hive_query : ${generic_hive_query}" from "${demo_table}
+  training_hive_query : ${generic_hive_query}" from "${demo_table}
+  training_output : ${training_data}
+
+  # Eval data is optional
+  eval_hive_query : ${generic_hive_query}" from "${demo_table_eval}
+  eval_output : ${eval_data}
+
   is_multiclass : true
   num_shards : 20
-  output : ${training_data}
 }
 
 train_model {
@@ -62,7 +71,7 @@ train_model {
 }
 
 eval_model {
-  input : ${training_data}
+  input : ${eval_data}
   subsample : ${eval_subsample}
   bins : 11
   model_config : ${model_config}

--- a/training/src/main/resources/demo_train.conf
+++ b/training/src/main/resources/demo_train.conf
@@ -16,10 +16,15 @@ model_version: "a"
 model_type : "linear"
 model_config : ${model_type}"_model_config"
 demo_table : "pricing.income_training_raw"
+# Can use a different table
+demo_table_eval : "pricing.income_training_raw"
+
 
 # Where to dump data; change prefix based on your HDFS directory layout
 prefix : "hdfs://airfs-silver/user/"${USER}"/demo_pipeline"
 training_data : ${prefix}"/training_data"${training_data_version}
+eval_data : ${prefix}"/eval_data"${training_data_version}
+
 eval_output : ${prefix}"/eval_output/"${training_data_version}_${model_version}".eval"
 model_name : ${prefix}"/model/"${training_data_version}_${model_version}_${model_type}".model"
 model_dump : ${model_name}".tsv"
@@ -88,9 +93,13 @@ debug_transforms {
 }
 
 make_training {
-  hive_query : ${generic_hive_query}" from "${demo_table}
+  training_hive_query : ${generic_hive_query}" from "${demo_table}
+  training_output : ${training_data}
+  # Eval data is optional
+  eval_hive_query : ${generic_hive_query}" from "${demo_table_eval}
+  eval_output : ${eval_data}
+
   num_shards : 20
-  output : ${training_data}
 }
 
 train_model {
@@ -102,7 +111,7 @@ train_model {
 }
 
 eval_model {
-  input : ${training_data}
+  input : ${eval_data}
   subsample : ${eval_subsample}
   bins : 5
   model_config : ${model_config}

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/JobRunner.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/JobRunner.scala
@@ -47,7 +47,7 @@ object JobRunner extends Logging {
       try {
         job match {
           case "GenericMakeExamples" => GenericPipeline
-            .makeTrainingRun(sc, config)
+            .makeExampleRun(sc, config)
           case "GenericDebugExamples" => GenericPipeline
             .debugExampleRun(sc, config)
           case "GenericDebugTransforms" => GenericPipeline


### PR DESCRIPTION
The training and evaluation dataset is usually different and in a lot of the cases need to be separated by time not by random sample. e.g. training is data from 2015 and eval is data from 2016. 

The current Aerosolve config doesn’t support adding evaluation dataset. This PR is to add this option to the user. As suggested by @deerzq , I refactored the makeTraningrun to make it more generic to make both the training and evaluation dataset(optional)

@jq @saurfang 