### PR TITLE
[demo] fix bug in incomming predict

### DIFF
--- a/demo/income_prediction/src/main/resources/income_prediction.conf
+++ b/demo/income_prediction/src/main/resources/income_prediction.conf
@@ -24,7 +24,6 @@ make_testing {
 
 train_model {
   input : ${trainingData}
-  model_output : ${additive_model_name}
   modelKey : ${modelKey}
 }
 

--- a/demo/income_prediction/src/main/resources/income_prediction.conf
+++ b/demo/income_prediction/src/main/resources/income_prediction.conf
@@ -24,14 +24,14 @@ make_testing {
 
 train_model {
   input : ${trainingData}
-  model_output : ${spline_model_name}
+  model_output : ${additive_model_name}
   modelKey : ${modelKey}
 }
 
 eval_testing {
   input : ${testingData}
   modelKey : ${modelKey}
-  model_output : ${spline_model_name}
+  model_output : ${additive_model_name}
   subsample : 1.0
   bins : 11
   is_training : false
@@ -40,7 +40,7 @@ eval_testing {
 eval_training {
   input : ${trainingData}
   modelKey : ${modelKey}
-  model_output : ${spline_model_name}
+  model_output : ${additive_model_name}
   subsample : 1.0
   bins : 11
   is_training : true


### PR DESCRIPTION
The config for this demo is inconsistent. The used model is `additive_model_with_dynamic_buckets` which specify the output to `${additive_model_name}`. However, eval_testing and eval_training read model from `${spline_model_name}`. This PR fix this bug so that they are consistent.

The `model_output` entry in train_model is not used at all, so it's removed.