### PR TITLE
Add a data conversion job to cast Example to PhotonML Avro format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,15 @@ allprojects {
             options.addStringOption('Xdoclint:none', '-quiet')
         }
     }
+
+    // Configure Idea plugin
+    idea {
+        module {
+            scopes.PROVIDED.plus += [configurations.provided]
+
+            downloadJavadoc = true
+        }
+    }
 }
 
 subprojects {

--- a/demo/image_impressionism/build.gradle
+++ b/demo/image_impressionism/build.gradle
@@ -9,6 +9,8 @@ repositories {
 }
 
 dependencies {
+    compile 'org.scala-lang:scala-library:2.10.4'
+
     compile project(':training')
     compile 'org.slf4j:slf4j-simple:1.7.7'
     provided 'org.apache.spark:spark-core_2.10:1.2.1'

--- a/training/build.gradle
+++ b/training/build.gradle
@@ -31,7 +31,16 @@ bintray {
 }
 
 dependencies {
+  compile 'org.scala-lang:scala-library:2.10.4'
   compile project(':core')
+
+  compile ('org.apache.avro:avro:1.7.7') {
+    transitive = false
+  }
+  compile ('org.apache.avro:avro-mapred:1.7.7') {
+    transitive = false
+  }
+
   compile 'com.fasterxml.jackson.module:jackson-module-scala_2.10:2.4.2'
   compile 'joda-time:joda-time:2.5'
   compile 'org.apache.hadoop:hadoop-client:2.2.0'

--- a/training/src/main/resources/demo_convert_example_to_photonml_avro.conf
+++ b/training/src/main/resources/demo_convert_example_to_photonml_avro.conf
@@ -1,0 +1,26 @@
+// Assembling all three transformers together
+identity_transform {
+  transform : list
+  transforms : [ ]
+}
+
+combined_transform {
+  transform: list
+  transforms: []
+}
+
+// Indicating what are the extra feature namespaces needed to present in Avro
+avro_extra_namespaces: []
+
+input_hive_query: """
+  SELECT *
+  FROM tmp.training_data
+"""
+
+output_path: "hdfs://output/path"
+
+model_config {
+  context_transform : identity_transform
+  item_transform : identity_transform
+  combined_transform : combined_transform
+}

--- a/training/src/main/scala/com/airbnb/aerosolve/training/photon/ml/data/ConvertExamplesToPhotonMLAvroJob.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/photon/ml/data/ConvertExamplesToPhotonMLAvroJob.scala
@@ -1,0 +1,178 @@
+package com.airbnb.aerosolve.training.photon.ml.data
+
+import java.io.File
+
+import com.airbnb.aerosolve.core.{Example, FeatureVector}
+import com.airbnb.aerosolve.core.transforms.Transformer
+import com.airbnb.aerosolve.training.pipeline.GenericPipeline
+import com.airbnb.aerosolve.training.photon.ml.data.PhotonMLUtils._
+import com.typesafe.config.{Config, ConfigFactory, ConfigParseOptions, ConfigResolveOptions}
+import org.apache.avro.generic.{GenericData, GenericRecord}
+import org.apache.avro.mapred.AvroKey
+import org.apache.avro.mapreduce.{AvroJob, AvroKeyOutputFormat}
+import org.apache.avro.Schema
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.io.NullWritable
+import org.apache.hadoop.mapreduce.Job
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.rdd.RDD
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
+import scala.collection.immutable
+import scala.util.Try
+
+
+/**
+  * Providing a data conversion job casting Thrift [[com.airbnb.aerosolve.core.Example]] to PhotonML
+  * Avro format: https://github.com/linkedin/photon-ml#input-data-format
+  *
+  * @see resources/demo_convert_example_to_photonml_avro.conf about how to set up job configuration.
+  *
+  */
+object ConvertExamplesToPhotonMLAvroJob {
+  private val logger = LoggerFactory.getLogger(this.getClass())
+  private val LABEL = "label"
+
+  /**
+    * A single entry-point for launching this job from command line
+    *
+    * @param args Commandline arguments
+    */
+  def main(args: Array[String]): Unit = {
+    val configPath = new File(args(0))
+
+    val config = if (configPath.exists()) {
+      ConfigFactory.load(ConfigFactory.parseFile(configPath))
+    } else {
+      ConfigFactory.load(configPath.getPath(),
+        ConfigParseOptions.defaults.setAllowMissing(false),
+        ConfigResolveOptions.defaults)
+    }
+
+    val sparkConf = new SparkConf().setAppName("Convert Thrift Example to PhotonML Avro")
+    val sc = new SparkContext(sparkConf)
+
+    convertExamplesToPhotonGAMEAvro(sc, config)
+  }
+
+  private def getLabelFromExample(example: Example): Double = {
+    if (example.getExample().get(0).floatFeatures.get(GenericPipeline.LABEL).get("") > 0) {
+      1d
+    } else {
+      0d
+    }
+  }
+
+  /**
+    * This method converts an RDD of examples to PhotonML GAME Avro formats and save to HDFS.
+    * Could be used as an entry-point in programming.
+    *
+    * @param sc         The spark context
+    * @param taskConfig config of the task
+    */
+  def convertExamplesToPhotonGAMEAvro(sc: SparkContext,
+                                      taskConfig: Config): Unit = {
+    val (transformedData, avroSchema) = loadExamples(sc, taskConfig)
+
+    val outputPath = new Path(taskConfig.getString("output_path"))
+
+    val fs = outputPath.getFileSystem(new Configuration())
+    fs.delete(outputPath, true)
+
+    val avroSchemaStr = avroSchema.toString()
+    logger.info(s" Configured output Avro schema: ${avroSchema.toString(true)}")
+
+    val metaDataExtractorClass = Try(taskConfig.getString("meta_data_extractor_class"))
+      .getOrElse(classOf[SingleFloatFamilyMetaExtractor].getName())
+
+    val metaDataExtractorContext = Try(taskConfig
+      .getConfig("meta_data_extractor_context").entrySet().asScala
+      .map { case entry => (entry.getKey(), entry.getValue().toString()) }.toMap
+    ).getOrElse(immutable.Map[String, String]())
+
+    val trainingExampleAvros = transformedData.mapPartitions { case iter =>
+      val schema = new Schema.Parser().parse(avroSchemaStr)
+
+      val metaDataExtractor = Class.forName(metaDataExtractorClass)
+        .newInstance().asInstanceOf[ExampleMetaDataExtractor]
+
+      iter.map { case example =>
+        val record = new GenericData.Record(schema)
+
+        val label = getLabelFromExample(example)
+
+        // TODO decide which key to provide for training example, currently this is not a must-have field
+        // record.put(AVRO_UID, key)
+        record.put(AVRO_LABEL, label)
+        record.put(AVRO_META_DATA_MAP,
+          metaDataExtractor.buildMetaDataMap(example, metaDataExtractorContext))
+
+        createAvroFeatureArrays(record, example, schema)
+
+        record
+      }
+    }
+
+    val job = Job.getInstance
+    AvroJob.setOutputKeySchema(job, avroSchema)
+    val hadoopConf = job.getConfiguration()
+
+    // Compress Avro binary files
+    hadoopConf.set("mapreduce.output.fileoutputformat.compress", "true")
+    hadoopConf.set(AvroJob.CONF_OUTPUT_CODEC, "deflate")
+
+    // Save as Avro records
+    trainingExampleAvros
+      .map { r => (new AvroKey(r), NullWritable.get()) }
+      .saveAsNewAPIHadoopFile(outputPath.toString(),
+        classOf[AvroKey[GenericRecord]],
+        classOf[org.apache.hadoop.io.NullWritable],
+        classOf[AvroKeyOutputFormat[GenericRecord]],
+        hadoopConf)
+  }
+
+  // Load RDD[Example] according to context information
+  private def loadExamples(sc: SparkContext,
+                           taskConfig: Config): (RDD[Example], Schema) = {
+
+    val hiveTraining = GenericPipeline.runQuery(sc, taskConfig.getString("input_hive_query"))
+    val dataFrameSchema = hiveTraining.schema.fields
+
+    val namespaces = (dataFrameSchema.map { case f =>
+      val idx = f.name.indexOf("_")
+
+      if (idx == -1) {
+        f.name
+      } else {
+        f.name.substring(0, idx)
+      }
+    }.toSet[String] ++ taskConfig.getStringList("avro_extra_namespaces").asScala).toArray
+
+    // label namespace should not be treated as a feature
+    val avroSchema = makeTrainingExampleAvroSchema(featureNamespaces =
+      namespaces.filter(_.toLowerCase != LABEL))
+
+    // Read and cast to Examples
+    val examples = hiveTraining
+      .map(x => GenericPipeline.hiveTrainingToExample(x, dataFrameSchema, false))
+
+    // Pass through transformers
+    val transformer = new Transformer(taskConfig, "model_config")
+    val transformerBC = sc.broadcast(transformer)
+
+    val transformedExamples = examples.flatMap { case example =>
+      example.example.asScala.map { fv: FeatureVector =>
+        val newExample = new Example()
+        newExample.setContext(example.context)
+        newExample.addToExample(fv)
+        transformerBC.value.combineContextAndItems(newExample)
+
+        newExample
+      }
+    }
+
+    (transformedExamples, avroSchema)
+  }
+}

--- a/training/src/main/scala/com/airbnb/aerosolve/training/photon/ml/data/ExampleMetaDataExtractor.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/photon/ml/data/ExampleMetaDataExtractor.scala
@@ -1,0 +1,21 @@
+package com.airbnb.aerosolve.training.photon.ml.data
+
+import com.airbnb.aerosolve.core.Example
+
+import scala.collection.immutable
+
+/**
+  * A trait defines a general pattern for extracting meta data from Example
+  *
+  */
+trait ExampleMetaDataExtractor {
+
+  /**
+    * Build a meta data map given an example and optionally a context information map
+    *
+    * @param example An example
+    * @param context The context info map
+    */
+  def buildMetaDataMap(example: Example,
+                       context: immutable.Map[String, String]): java.util.Map[String, Long]
+}

--- a/training/src/main/scala/com/airbnb/aerosolve/training/photon/ml/data/PhotonMLUtils.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/photon/ml/data/PhotonMLUtils.scala
@@ -1,0 +1,198 @@
+package com.airbnb.aerosolve.training.photon.ml.data
+
+import com.airbnb.aerosolve.core.Example
+import org.apache.avro.generic.{GenericData, GenericRecord}
+import org.apache.avro.{Schema, SchemaBuilder}
+
+import scala.collection.immutable
+
+import scala.collection.JavaConverters._
+
+/**
+  * A collection of utils functions used by PhotonML related work.
+  *
+  */
+object PhotonMLUtils {
+  // Example label family field name
+  val LABEL = "label"
+
+  // Avro namespace
+  val AVRO_NAMESPACE = "com.airbnb.aerosolve.training.photon.ml.data.generated"
+
+  // Avro schema fields
+  val AVRO_UID = "uid"
+  val AVRO_LABEL = "label"
+
+  val AVRO_FEATURES = "features"
+  val AVRO_NAME = "name"
+  val AVRO_TERM = "term"
+  val AVRO_VALUE = "value"
+  val AVRO_META_DATA_MAP = "metadataMap"
+
+
+  /**
+    * Create a TrainingExampleAvro schema used by Photon ML:
+    * [[https://github.com/linkedin/photon-ml#input-data-format]]
+    *
+    * @param name              optionally provide a record name for the schema. This is useful when multiple
+    *                          Avro schemas are created and they needed to be distinguished.
+    * @param featureNamespaces if an array of namespaces are provided, we will create a list of
+    *                          extra feature arrays accordingly.
+    * @return an Avro schema instance
+    */
+  def makeTrainingExampleAvroSchema(name: String = "TrainingExampleAvro",
+                                    featureNamespaces: Array[String] = Array[String]()): Schema = {
+    // Define feature item schema
+    val featureItemSchema = SchemaBuilder.record("FeatureItem")
+      .namespace(AVRO_NAMESPACE)
+      .fields()
+      .name(AVRO_NAME).`type`().stringType().noDefault()
+      .name(AVRO_TERM).`type`().stringType().stringDefault("")
+      .name(AVRO_VALUE).`type`().doubleType().noDefault()
+      .endRecord()
+
+    // Define overall training record schema
+    val builder = SchemaBuilder.record(name)
+      .namespace(AVRO_NAMESPACE)
+      .fields()
+      .name(AVRO_UID).`type`().nullable().stringType().noDefault()
+      .name(AVRO_LABEL).`type`().doubleType().noDefault()
+      .name(AVRO_META_DATA_MAP).`type`().map().values().longType().noDefault()
+
+    // Global feature space, important to trigger noDefault() in the end otherwise, the field
+    // will not be successfully committed into the builder
+    builder.name(AVRO_FEATURES).`type`().array().items(featureItemSchema).noDefault()
+
+    // Optionally, if feature family is provided, create per feature family feature space
+    featureNamespaces.foreach { case namespace =>
+      builder.name(makeAvroFeaturesFieldName(namespace))
+        .`type`().array().items(featureItemSchema).noDefault()
+    }
+
+    builder.endRecord()
+  }
+
+  /**
+    * Create an Avro feature record
+    *
+    * @param schema feature item schema, necessary to provide since schemas with different names or
+    *               namespaces are considered to be different.
+    * @param name   feature name
+    * @param value  feature value
+    * @param term   feature term (optionally to be empty)
+    * @return the Avro feature item
+    */
+  def makeAvroFeatureItemRecord(schema: Schema,
+                                name: String,
+                                value: Double,
+                                term: String = ""): GenericRecord = {
+    val r = new GenericData.Record(schema)
+    r.put(AVRO_NAME, name)
+    r.put(AVRO_TERM, term)
+    r.put(AVRO_VALUE, value)
+    r
+  }
+
+  /**
+    * Returns the avro feature array field name for a certain feature family
+    *
+    * @param familyName
+    */
+  def makeAvroFeaturesFieldName(familyName: String): String = familyName.toLowerCase + AVRO_FEATURES.capitalize
+
+  /**
+    * Create an Avro feature array
+    *
+    * @param example       Thrift example
+    * @param schema   The avro record schema
+    * @return The converted Avro feature array
+    */
+  def createAvroFeatureArrays(record: GenericData.Record,
+                              example: Example,
+                              schema: Schema,
+                              familyBlacklist: immutable.Set[String] =
+                              immutable.Set[String]("default_string", "bias", "miss", LABEL)
+                             ): Unit = {
+    val arraySchema = schema.getField(AVRO_FEATURES).schema()
+    val featureSchema = arraySchema.getElementType()
+
+    val featureNamespaces = schema.getFields().asScala
+      .map(_.name())
+      .filter(_.endsWith(AVRO_FEATURES.capitalize)) ++ Array[String](AVRO_FEATURES)
+
+    for (fieldName <- featureNamespaces) {
+      record.put(fieldName, new java.util.ArrayList[GenericRecord]())
+    }
+
+    val s = example.getExample().get(0)
+
+    val denseFeatures = s.getDenseFeatures()
+    if (denseFeatures != null) {
+      val it = denseFeatures.entrySet().iterator()
+      while (it.hasNext()) {
+        val entry = it.next()
+
+        val ns = entry.getKey()
+        if (!familyBlacklist.contains(ns.toLowerCase())) {
+          var i = 0
+          val it2 = entry.getValue().iterator()
+
+          val features = record.get(makeAvroFeaturesFieldName(ns))
+            .asInstanceOf[java.util.List[GenericRecord]]
+
+          while (it2.hasNext()) {
+            val value = it2.next()
+            features.add(makeAvroFeatureItemRecord(featureSchema, String.valueOf(i), value, ""))
+            i += 1
+          }
+
+        }
+      }
+    }
+
+    val floatFeatures = s.getFloatFeatures()
+    if (floatFeatures != null) {
+      val it = floatFeatures.entrySet().iterator()
+      while (it.hasNext()) {
+        val entry = it.next()
+
+        val ns = entry.getKey()
+        if (!familyBlacklist.contains(ns.toLowerCase())) {
+          val features = record.get(makeAvroFeaturesFieldName(ns))
+            .asInstanceOf[java.util.List[GenericRecord]]
+
+          val it2 = entry.getValue().entrySet().iterator()
+          while (it2.hasNext()) {
+            val termValue = it2.next()
+
+            val term = termValue.getKey()
+            val value = termValue.getValue()
+            features.add(makeAvroFeatureItemRecord(featureSchema, term, value, ""))
+          }
+        }
+      }
+    }
+
+    val stringFeatures = s.getStringFeatures()
+    if (stringFeatures != null) {
+      val it = stringFeatures.entrySet().iterator()
+      while (it.hasNext()) {
+        val entry = it.next()
+
+        val ns = entry.getKey()
+
+        if (!familyBlacklist.contains(ns.toLowerCase())) {
+
+          val features = record.get(makeAvroFeaturesFieldName(ns))
+            .asInstanceOf[java.util.List[GenericRecord]]
+
+          val it2 = entry.getValue().iterator()
+          while (it2.hasNext()) {
+            val term = it2.next()
+            features.add(makeAvroFeatureItemRecord(featureSchema, term, 1.0d, ""))
+          }
+        }
+      }
+    }
+  }
+}

--- a/training/src/main/scala/com/airbnb/aerosolve/training/photon/ml/data/SingleFloatFamilyMetaExtractor.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/photon/ml/data/SingleFloatFamilyMetaExtractor.scala
@@ -1,0 +1,36 @@
+package com.airbnb.aerosolve.training.photon.ml.data
+
+import com.airbnb.aerosolve.core.Example
+
+import scala.collection.JavaConverters._
+import scala.collection.immutable
+
+
+/**
+  * An implementation of [[ExampleMetaDataExtractor]] that looks into one single float feature
+  * family of [[Example]] and cast all values into non-negative longs.
+  *
+  */
+class SingleFloatFamilyMetaExtractor
+  extends ExampleMetaDataExtractor {
+
+  override def buildMetaDataMap(example: Example,
+                                context: immutable.Map[String, String]): java.util.Map[String, Long] = {
+    val meta = new java.util.HashMap[String, Long]()
+    val metaFamily = context.getOrElse("metaFamily", "meta")
+
+    val f = example.getExample().get(0).floatFeatures
+
+    if (!f.containsKey(metaFamily)) {
+      throw new IllegalArgumentException(
+        s"meta data feature field: [${metaFamily}] not presented in " +
+          s"the example's float features: ${example.toString()}")
+    }
+
+    f.get(metaFamily).asScala.foreach { case (name, value) =>
+      meta.put(name, Math.abs(value.toLong))
+    }
+
+    meta
+  }
+}

--- a/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/JobRunner.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/pipeline/JobRunner.scala
@@ -2,6 +2,7 @@ package com.airbnb.aerosolve.training.pipeline
 
 import java.io.File
 
+import com.airbnb.aerosolve.training.photon.ml.data.ConvertExamplesToPhotonMLAvroJob
 import com.typesafe.config.{ConfigFactory, ConfigParseOptions, ConfigResolveOptions}
 import org.apache.spark.{Logging, SparkConf, SparkContext}
 
@@ -74,6 +75,8 @@ object JobRunner extends Logging {
           case "GenericParamSearch" => GenericPipeline
             .paramSearch(sc, config)
           case "NDTreeBuildFeatureMap" => NDTreePipeline.buildFeatureMapRun(sc, config)
+          case "ConvertExampleToPhotonMLAvro" => ConvertExamplesToPhotonMLAvroJob
+            .convertExamplesToPhotonGAMEAvro(sc, config)
           case _ => log.error("Unknown job " + job)
         }
       } catch {

--- a/training/src/test/scala/com/airbnb/aerosolve/training/photon/ml/data/PhotonMLUtilsTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/photon/ml/data/PhotonMLUtilsTest.scala
@@ -1,0 +1,207 @@
+package com.airbnb.aerosolve.training.photon.ml.data
+
+import com.airbnb.aerosolve.core.Example
+import com.airbnb.aerosolve.core.features.Features
+import org.apache.avro.Schema
+import org.apache.avro.generic.{GenericData, GenericRecord}
+import org.junit.Assert._
+import org.junit.Test
+
+import scala.collection.JavaConverters._
+
+/**
+  * This class tests [[PhotonMLUtils]].
+  *
+  */
+class PhotonMLUtilsTest {
+
+  import PhotonMLUtils._
+
+  private val EPS = 1e-7
+
+  private def verifyBasicTrainingExampleAvroFields(schema: Schema): Unit = {
+    assertEquals(schema.getNamespace(), AVRO_NAMESPACE)
+
+    val fields = schema.getFields().asScala
+
+    val namesSet = fields.map(_.name())
+    assertTrue(namesSet.size >= 4)
+    assertTrue(namesSet.contains(AVRO_UID))
+    assertTrue(namesSet.contains(AVRO_LABEL))
+    assertTrue(namesSet.contains(AVRO_META_DATA_MAP))
+    assertTrue(namesSet.contains(AVRO_FEATURES))
+
+    // Verify ordinary fields
+    val nullableUid = schema.getField(AVRO_UID).schema()
+    assertEquals(nullableUid.getType(), Schema.Type.UNION)
+    assertEquals(nullableUid.getTypes().asScala.map(_.getType()).toSet,
+      Set[Schema.Type](Schema.Type.NULL, Schema.Type.STRING))
+
+    assertEquals(schema.getField(AVRO_LABEL).schema().getType(), Schema.Type.DOUBLE)
+    val mapSchema = schema.getField(AVRO_META_DATA_MAP).schema()
+    assertEquals(mapSchema.getType(), Schema.Type.MAP)
+    assertEquals(mapSchema.getValueType().getType(), Schema.Type.LONG)
+
+    // Verify the default feature array field
+    val featureSchema = schema.getField(AVRO_FEATURES).schema().getElementType()
+    verifyFeatureItemSchema(featureSchema)
+
+    // Verify other fields (assuming all should be feature array type)
+    fields.filter(f => !namesSet.contains(f.name())).foreach { case featureField =>
+      assertTrue(featureField.name().endsWith(AVRO_FEATURES.capitalize))
+      verifyFeatureItemSchema(featureField.schema().getElementType())
+    }
+  }
+
+  private def verifyFeatureItemSchema(featureSchema: Schema): Unit = {
+    val fields = featureSchema.getFields().asScala
+
+    val namesSet = fields.map(_.name())
+    assertEquals(namesSet.size, 3)
+    assertTrue(namesSet.contains(AVRO_NAME))
+    assertTrue(namesSet.contains(AVRO_TERM))
+    assertTrue(namesSet.contains(AVRO_VALUE))
+
+    assertEquals(featureSchema.getField(AVRO_NAME).schema().getType(), Schema.Type.STRING)
+    assertEquals(featureSchema.getField(AVRO_TERM).schema().getType(), Schema.Type.STRING)
+    assertEquals(featureSchema.getField(AVRO_VALUE).schema().getType(), Schema.Type.DOUBLE)
+  }
+
+  @Test
+  def testMakeTrainingExampleAvroSchema(): Unit = {
+    val schema1 = makeTrainingExampleAvroSchema()
+    assertEquals(schema1.getName(), "TrainingExampleAvro")
+    verifyBasicTrainingExampleAvroFields(schema1)
+
+
+    val schema2 = makeTrainingExampleAvroSchema(name = "TrainingExampleAvroV2")
+    assertEquals(schema2.getName(), "TrainingExampleAvroV2")
+    verifyBasicTrainingExampleAvroFields(schema2)
+
+
+    val schema3 = makeTrainingExampleAvroSchema(name = "TrainingExampleAvroV3",
+      featureNamespaces = Array[String]("a", "b", "c"))
+    assertEquals(schema3.getName(), "TrainingExampleAvroV3")
+    verifyBasicTrainingExampleAvroFields(schema3)
+    assertEquals(schema3.getFields().size, 7)
+    verifyFeatureItemSchema(schema3.getField("a" +
+      AVRO_FEATURES.capitalize).schema().getElementType())
+    verifyFeatureItemSchema(schema3.getField("b" +
+      AVRO_FEATURES.capitalize).schema().getElementType())
+    verifyFeatureItemSchema(schema3.getField("c" +
+      AVRO_FEATURES.capitalize).schema().getElementType())
+  }
+
+  @Test
+  def testMakeAvroFeatureItemRecord(): Unit = {
+    val featureSchema = makeTrainingExampleAvroSchema().getField(AVRO_FEATURES)
+      .schema().getElementType()
+
+    val r = makeAvroFeatureItemRecord(featureSchema, "foo", 1.2d)
+    assertEquals("foo", r.get(AVRO_NAME))
+    assertTrue(r.get(AVRO_TERM).toString().isEmpty())
+    assertEquals(1.2d, r.get(AVRO_VALUE).asInstanceOf[Double], EPS)
+  }
+
+  @Test
+  def testMakeAvroFeaturesFieldName(): Unit = {
+    assertEquals("fooFeatures", makeAvroFeaturesFieldName("foo"))
+    assertEquals("Features", makeAvroFeaturesFieldName(""))
+    assertEquals("bar_aFeatures", makeAvroFeaturesFieldName("bar_A"))
+  }
+
+
+  private def mockExample(): Example = {
+    val builder = Features.builder()
+
+    builder.names(Array[String]("foo_a",
+      "foo_b",
+      "bar_c",
+      "tar_d"))
+
+    builder.values(Array[Object](
+      new java.lang.Double(1.0d),
+      new java.lang.Long(-2L),
+      new java.lang.Integer(5),
+      "a"
+    ))
+
+    builder.build().toExample(false)
+  }
+
+  private def mockExampleWithMissingFields(): Example = {
+    val builder = Features.builder()
+
+    builder.names(Array[String]("foo_a",
+      "bar_c"))
+
+    builder.values(Array[Object](
+      new java.lang.Double(1.0d),
+      new java.lang.Integer(5)
+    ))
+
+    builder.build().toExample(false)
+  }
+
+  @Test
+  def testCreateAvroFeatureArrays(): Unit = {
+    val schema = makeTrainingExampleAvroSchema(
+      featureNamespaces = Array[String]("foo", "bar", "tar"))
+
+    val record = new GenericData.Record(schema)
+
+    val example = mockExample()
+    println(example.toString())
+
+    createAvroFeatureArrays(record, example, schema)
+
+    val features = record.get(AVRO_FEATURES).asInstanceOf[java.util.List[GenericRecord]]
+    assertTrue(features.isEmpty())
+
+    val fooFeatures = record.get(makeAvroFeaturesFieldName("foo"))
+      .asInstanceOf[java.util.List[GenericRecord]]
+    assertEquals(fooFeatures.size(), 2)
+    val fooFL = fooFeatures.iterator().asScala.toSeq.sortBy(_.get(AVRO_NAME).toString())
+    assertEquals(fooFL(0).get(AVRO_NAME), "a")
+    assertEquals(fooFL(0).get(AVRO_TERM), "")
+    assertEquals(fooFL(0).get(AVRO_VALUE).asInstanceOf[Double], 1.0, EPS)
+    assertEquals(fooFL(1).get(AVRO_NAME), "b")
+    assertEquals(fooFL(1).get(AVRO_TERM), "")
+    assertEquals(fooFL(1).get(AVRO_VALUE).asInstanceOf[Double], -2.0, EPS)
+
+
+
+    val barFeatures = record.get(makeAvroFeaturesFieldName("bar"))
+      .asInstanceOf[java.util.List[GenericRecord]]
+    assertEquals(barFeatures.size(), 1)
+    assertEquals(barFeatures.get(0).get(AVRO_NAME), "c")
+    assertEquals(barFeatures.get(0).get(AVRO_TERM), "")
+    assertEquals(barFeatures.get(0).get(AVRO_VALUE).asInstanceOf[Double], 5d, EPS)
+
+    val tarFeatures = record.get(makeAvroFeaturesFieldName("tar"))
+      .asInstanceOf[java.util.List[GenericRecord]]
+    assertEquals(tarFeatures.size(), 1)
+    assertEquals(tarFeatures.get(0).get(AVRO_NAME), "d:a")
+    assertEquals(tarFeatures.get(0).get(AVRO_TERM), "")
+    assertEquals(tarFeatures.get(0).get(AVRO_VALUE).asInstanceOf[Double], 1d, EPS)
+
+
+    // Test if some fields are not presented in the schema
+    val exampleMissing = mockExampleWithMissingFields()
+    val record2 = new GenericData.Record(schema)
+    createAvroFeatureArrays(record2, exampleMissing, schema)
+    val fooFeatures2 = record2.get(makeAvroFeaturesFieldName("foo"))
+      .asInstanceOf[java.util.List[GenericRecord]]
+    assertEquals(fooFeatures2.size(), 1)
+    assertEquals(fooFeatures2.get(0).get(AVRO_NAME), "a")
+    assertEquals(fooFeatures2.get(0).get(AVRO_TERM), "")
+    assertEquals(fooFeatures2.get(0).get(AVRO_VALUE).asInstanceOf[Double], 1d, EPS)
+
+    val barFeatures2 = record.get(makeAvroFeaturesFieldName("bar"))
+      .asInstanceOf[java.util.List[GenericRecord]]
+    assertEquals(barFeatures2.size(), 1)
+    assertEquals(barFeatures2.get(0).get(AVRO_NAME), "c")
+    assertEquals(barFeatures2.get(0).get(AVRO_TERM), "")
+    assertEquals(barFeatures2.get(0).get(AVRO_VALUE).asInstanceOf[Double], 5d, EPS)
+  }
+}

--- a/training/src/test/scala/com/airbnb/aerosolve/training/photon/ml/data/SingleFloatFamilyMetaExtractorTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/photon/ml/data/SingleFloatFamilyMetaExtractorTest.scala
@@ -1,0 +1,56 @@
+package com.airbnb.aerosolve.training.photon.ml.data
+
+import com.airbnb.aerosolve.core.features.Features
+import com.airbnb.aerosolve.core.Example
+import org.junit.Assert._
+import org.junit.Test
+
+import scala.collection.immutable
+
+/**
+  * This class tests [[SingleFloatFamilyMetaExtractor]].
+  *
+  */
+class SingleFloatFamilyMetaExtractorTest {
+
+  private def mockExampleMetaFields(metaFamily: String): Example = {
+    val builder = Features.builder()
+    builder.names(Array[String](metaFamily + "_foo",
+      metaFamily + "_bar",
+      metaFamily + "_tar",
+      "randomF_b"))
+    builder.values(Array[Object](
+      new java.lang.Integer(123),
+      new java.lang.Double(100d),
+      new java.lang.Long(-321L),
+      new java.lang.Integer(20)))
+    builder.build().toExample(false)
+  }
+
+  @Test
+  def testMetaDataExtraction(): Unit = {
+    val extractor = new SingleFloatFamilyMetaExtractor()
+    val example = mockExampleMetaFields("meta")
+    val metaMap = extractor.buildMetaDataMap(example, immutable.Map[String, String]())
+
+    assertEquals(3, metaMap.size())
+    assertEquals(123L, metaMap.get("foo"))
+    assertEquals(100L, metaMap.get("bar"))
+    // Should make all ids >= 0
+    assertEquals(321L, metaMap.get("tar"))
+
+    val example2 = mockExampleMetaFields("metav2")
+    val metaMap2 = extractor.buildMetaDataMap(example2, immutable.Map[String, String]("metaFamily" -> "metav2"))
+    assertEquals(3, metaMap2.size())
+    assertEquals(123L, metaMap2.get("foo"))
+    assertEquals(100L, metaMap2.get("bar"))
+    assertEquals(321L, metaMap2.get("tar"))
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testMissingField(): Unit = {
+    val extractor = new SingleFloatFamilyMetaExtractor()
+    val example = mockExampleMetaFields("metav2")
+    extractor.buildMetaDataMap(example, immutable.Map[String, String]())
+  }
+}


### PR DESCRIPTION
Given an input of hive table, we would cast it to Example accordingly, applying all transformers possible; and then cast each featureFamily into a separate feature avro array named as:
```
[familyName]Features
```

A special `meta` family is reserved for creating corresponding group ids needed by PhotonML. They will be stored in an Avro ```string -> long``` map. (It's arguable why using longs, but right now seems like stringFeatures casting in Example would make the situation a bit tricky as we also have some implicit delimiter happening). I introduced a flexible trait to allow more sophisticated grouping id extraction (so if we later do want to use string ids instead, we can do that by providing a new `ExampleMetaDataExtractor` implementation), but for now, we are assuming we are extracting all group ids from float features `meta` family.

I added tests for all major components. Also tested on the cluster verified that the job works. 

to: @jq