### PR TITLE
Perform Evaluation on RDD

### DIFF
--- a/demo/image_impressionism/build.gradle
+++ b/demo/image_impressionism/build.gradle
@@ -16,11 +16,6 @@ dependencies {
     provided 'org.apache.spark:spark-core_2.10:1.2.1'
 }
 
-compileScala {
-    scalaCompileOptions.fork = true
-    scalaCompileOptions.forkOptions.jvmArgs = ['-XX:MaxPermSize=512m']
-}
-
 shadowJar {
   zip64 = true
 }

--- a/demo/income_prediction/build.gradle
+++ b/demo/income_prediction/build.gradle
@@ -17,11 +17,6 @@ dependencies {
   compile 'org.slf4j:slf4j-simple:1.7.7'
 }
 
-compileScala {
-    scalaCompileOptions.fork = true
-    scalaCompileOptions.forkOptions.jvmArgs = ['-XX:MaxPermSize=512m']
-}
-
 shadowJar {
   zip64 = true
 }

--- a/demo/twenty_news/build.gradle
+++ b/demo/twenty_news/build.gradle
@@ -17,11 +17,6 @@ dependencies {
   compile 'org.slf4j:slf4j-simple:1.7.7'
 }
 
-compileScala {
-    scalaCompileOptions.fork = true
-    scalaCompileOptions.forkOptions.jvmArgs = ['-XX:MaxPermSize=512m']
-}
-
 shadowJar {
   zip64 = true
 }

--- a/training/build.gradle
+++ b/training/build.gradle
@@ -57,11 +57,6 @@ dependencies {
   testCompile 'org.slf4j:slf4j-log4j12:1.7.21'
 }
 
-compileScala {
-  scalaCompileOptions.fork = true
-  scalaCompileOptions.forkOptions.jvmArgs = ['-XX:MaxPermSize=512m']
-}
-
 shadowJar {
   zip64 = true
 

--- a/training/src/test/scala/com/airbnb/aerosolve/training/EvaluationTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/EvaluationTest.scala
@@ -163,34 +163,6 @@ class EvaluationTest {
   }
 
   @Test
-  def evaluationInCorrectListTest(): Unit = {
-    val recs = generateDataPerfect(false).toList
-    var sc = new SparkContext("local", "EvaluationTest")
-    try {
-      val results1 = Evaluation.evaluateBinaryClassification(recs, 11, "!HOLD_F1").toMap
-      val results2 = Evaluation.evaluateBinaryClassification(sc.parallelize(recs), 11, "!HOLD_F1").toMap
-      log.info("Non-RDD eval")
-      results1.foreach(res => log.info("%s = %f".format(res._1, res._2)))
-      log.info("RDD eval")
-      results2.foreach(res => log.info("%s = %f".format(res._1, res._2)))
-
-      assertEquals(results1.getOrElse("!HOLD_AUC", 0.0), results2.getOrElse("!HOLD_ACC", 0.0), 0.1)
-      assertEquals(results1.getOrElse("!HOLD_PRECISION_RECALL_AUC", 0.0), results2.getOrElse("!HOLD_PRECISION_RECALL_AUC", 0.0), 0.1)
-      assertEquals(results1.getOrElse("!HOLD_F1", 0.0), results2.getOrElse("!HOLD_F1", 0.0), 0.1)
-      assertEquals(results1.getOrElse("!HOLD_RECALL", 0.0), results2.getOrElse("!HOLD_RECALL", 0.0), 0.1)
-      assertEquals(results1.getOrElse("!HOLD_PRECISION", 0.0), results2.getOrElse("!HOLD_PRECISION", 0.0), 0.1)
-      assertEquals(results1.getOrElse("!HOLD_RMSE", 0.0), results2.getOrElse("!HOLD_RMSE", 0.0), 0.1)
-      assertEquals(results1.getOrElse("!HOLD_FPR", 0.0), results2.getOrElse("!HOLD_FPR", 0.0), 0.1)
-    } finally {
-      sc.stop
-      sc = null
-      // To avoid Akka rebinding to the same port,
-      // since it doesn't unbind immediately on shutdown
-      System.clearProperty("spark.master.port")
-    }
-  }
-
-  @Test
   def evaluationGaussianTest(): Unit = {
     val recs = generateDataGaussian
     var sc = new SparkContext("local", "EvaluationTest")
@@ -239,27 +211,6 @@ class EvaluationTest {
       // since it doesn't unbind immediately on shutdown
       System.clearProperty("spark.master.port")
     }
-  }
-
-  @Test
-  def evaluationGaussianListTest(): Unit = {
-    val recs = generateDataGaussian.toList
-    val results = Evaluation.evaluateBinaryClassification(recs, 11, "!HOLD_F1").toMap
-    results.foreach(res => log.info("%s = %f".format(res._1, res._2)))
-
-    val THRESHOLD = 0.7
-    assertTrue(results.getOrElse("!TRAIN_ACC", 0.0) > THRESHOLD)
-    assertTrue(results.getOrElse("!TRAIN_AUC", 0.0) > THRESHOLD)
-    assertTrue(results.getOrElse("!TRAIN_PRECISION_RECALL_AUC", 0.0) > THRESHOLD)
-    assertTrue(results.getOrElse("!TRAIN_F1", 0.0) > THRESHOLD)
-    assertTrue(results.getOrElse("!TRAIN_RECALL", 0.0) > THRESHOLD)
-    assertTrue(results.getOrElse("!TRAIN_PRECISION", 0.0) > THRESHOLD)
-    assertTrue(results.getOrElse("!HOLD_ACC", 0.0) > THRESHOLD)
-    assertTrue(results.getOrElse("!HOLD_AUC", 0.0) > THRESHOLD)
-    assertTrue(results.getOrElse("!HOLD_PRECISION_RECALL_AUC", 0.0) > THRESHOLD)
-    assertTrue(results.getOrElse("!HOLD_F1", 0.0) > THRESHOLD)
-    assertTrue(results.getOrElse("!HOLD_RECALL", 0.0) > THRESHOLD)
-    assertTrue(results.getOrElse("!HOLD_PRECISION", 0.0) > THRESHOLD)
   }
 
   @Test


### PR DESCRIPTION
Revert code clean up that merges the evaluation of records from RDD and List. Instead of merging the code path using List, perform evaluation on RDD instead to handle large dataset.

There is no reliable way to get a SparkContext especially with the way we set up our tests. Since there is really no need to run evaluation on List of records and lists can always be parallelize with single function call, we are removing evaluation on list altogether.


Related to #237 #231 

@jq @deerzq @luanjunyi 