### PR TITLE
Add option to initialize model using quantiles

### DIFF
--- a/core/src/main/java/com/airbnb/aerosolve/core/features/Features.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/features/Features.java
@@ -54,9 +54,6 @@ public class Features {
   // TODO  make it more generic, for example, taking care of dense feature
   public Example toExample(boolean isMultiClass) {
     assert (names.length == values.length);
-    if (names.length != values.length) {
-      throw new RuntimeException("names.length != values.length");
-    }
     Example example = new Example();
     FeatureVector featureVector = new FeatureVector();
     example.addToExample(featureVector);
@@ -125,7 +122,7 @@ public class Features {
     String family = getStringFamily(featurePair);
     Set<String> feature = Util.getOrCreateStringFeature(family, stringFeatures);
     String featureName = featurePair.getRight();
-    char str = (b.booleanValue()) ? TRUE_FEATURE : FALSE_FEATURE;
+    char str = b ? TRUE_FEATURE : FALSE_FEATURE;
     feature.add(featureName + STRING_FEATURE_SEPARATOR + str);
   }
 

--- a/core/src/main/java/com/airbnb/aerosolve/core/function/AbstractFunction.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/function/AbstractFunction.java
@@ -4,7 +4,6 @@ import com.airbnb.aerosolve.core.FunctionForm;
 import com.airbnb.aerosolve.core.ModelRecord;
 import lombok.Getter;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -40,18 +39,10 @@ public abstract class AbstractFunction implements Function {
     try {
       return (Function) Class.forName("com.airbnb.aerosolve.core.function." +
           funcForm.name()).getDeclaredConstructor(ModelRecord.class).newInstance(record);
-    } catch (InstantiationException e) {
-      e.printStackTrace();
-    } catch (IllegalAccessException e) {
-      e.printStackTrace();
-    } catch (InvocationTargetException e) {
-      e.printStackTrace();
-    } catch (NoSuchMethodException e) {
-      e.printStackTrace();
-    } catch (ClassNotFoundException e) {
+    } catch (Exception e) {
       e.printStackTrace();
     }
-    throw new RuntimeException("no such function " + funcForm.name());
+    throw new RuntimeException("unable to decode " + funcForm.name());
   }
 
   @Override

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/MoveFloatToStringTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/MoveFloatToStringTransform.java
@@ -21,6 +21,7 @@ public class MoveFloatToStringTransform implements Transform {
   private String outputName;
   private List<String> keys;
   private double cap;
+  private boolean keep;
 
   @Override
   public void configure(Config config, String key) {
@@ -34,6 +35,11 @@ public class MoveFloatToStringTransform implements Transform {
       cap = config.getDouble(key + ".cap");
     } else {
       cap = 1e10;
+    }
+    if (config.hasPath(key + ".keep")) {
+      keep = config.getBoolean(key + ".keep");
+    } else {
+      keep = false;
     }
   }
 
@@ -56,7 +62,9 @@ public class MoveFloatToStringTransform implements Transform {
     if (keys != null) {
       for (String key : keys) {
         moveFloat(feature1, output, key, cap, bucket);
-        feature1.remove(key);
+        if(!keep) {
+          feature1.remove(key);
+        }
       }
     } else {
       for (Iterator<Entry<String, Double>> iterator = feature1.entrySet().iterator();
@@ -65,7 +73,9 @@ public class MoveFloatToStringTransform implements Transform {
         String key = entry.getKey();
 
         moveFloat(feature1, output, key, cap, bucket);
-        iterator.remove();
+        if(!keep) {
+          iterator.remove();
+        }
       }
     }
   }

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/MoveFloatToStringTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/MoveFloatToStringTransform.java
@@ -13,7 +13,9 @@ import java.util.List;
 
 /**
  * Moves named fields from one family to another. If keys are not specified, all keys are moved
- * from the float family.
+ * from the float family. Features are capped via a `cap` config, which defaults to 1e10, to avoid
+ * exploding string features. The original float feature is removed but can be overridden using
+ * `keep` boolean config.
  */
 public class MoveFloatToStringTransform implements Transform {
   private String fieldName1;

--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/TransformFactory.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/TransformFactory.java
@@ -17,17 +17,13 @@ public class TransformFactory {
     }
 
     String name = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, transformName);
-    Transform result = null;
+    Transform result;
     try {
       result = (Transform) Class.forName("com.airbnb.aerosolve.core.transforms." + name + "Transform").newInstance();
-      result.configure(config, key);
-    } catch (InstantiationException e) {
-      e.printStackTrace();
-    } catch (IllegalAccessException e) {
-      e.printStackTrace();
-    } catch (ClassNotFoundException e) {
-      e.printStackTrace();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
+    result.configure(config, key);
     return result;
   }
 }

--- a/demo/income_prediction/src/main/resources/income_prediction.conf
+++ b/demo/income_prediction/src/main/resources/income_prediction.conf
@@ -85,6 +85,9 @@ additive_model {
   rank_key : "$rank"
   multiscale : [ 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 64 ]
   linear_feature: ["S"]
+  // Optionally initialize spline features using quantiles instead of min/max
+  // This is useful if features tend to be heavily skewed
+  // init_quantiles : [0.05, 0.95]
   // What kind of loss function
   loss : "hinge"
   learning_rate : 0.1

--- a/training/src/main/scala/com/airbnb/aerosolve/training/ScoreCalibrator.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/ScoreCalibrator.scala
@@ -41,7 +41,7 @@ object ScoreCalibrator {
     var iter = 0
     var old_offset = 0.0
     var old_slope = 1.0
-    val partitionedInput = input.repartition(numBags)
+    val partitionedInput = input.repartition(numBags).cache()
     do {
       old_offset = params(0)
       old_slope = params(1)
@@ -52,6 +52,7 @@ object ScoreCalibrator {
     } while((math.abs(old_offset - params(0)) > tolerance
       || math.abs(old_slope - params(1)) > tolerance)
       && iter <= maxIter)
+    partitionedInput.unpersist()
 
     params
   }

--- a/training/src/test/scala/com/airbnb/aerosolve/training/TrainingUtilsTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/TrainingUtilsTest.scala
@@ -41,9 +41,6 @@ class TrainingUtilsTest {
       // To avoid Akka rebinding to the same port,
       // since it doesn't unbind immediately on shutdown
       System.clearProperty("spark.master.port")
-      // To avoid HiveContext creation error
-      // https://issues.apache.org/jira/browse/SPARK-10872
-      FileUtils.deleteQuietly(new File("metastore_db/dbex.lck"))
     }
   }
 
@@ -107,9 +104,6 @@ class TrainingUtilsTest {
       // To avoid Akka rebinding to the same port,
       // since it doesn't unbind immediately on shutdown
       System.clearProperty("spark.master.port")
-      // To avoid HiveContext creation error
-      // https://issues.apache.org/jira/browse/SPARK-10872
-      FileUtils.deleteQuietly(new File("metastore_db/dbex.lck"))
     }
   }
 

--- a/training/src/test/scala/com/airbnb/aerosolve/training/TrainingUtilsTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/TrainingUtilsTest.scala
@@ -1,11 +1,14 @@
 package com.airbnb.aerosolve.training
 
+import java.io.File
+
 import org.slf4j.LoggerFactory
 import org.junit.Test
 import org.apache.spark.SparkContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import com.airbnb.aerosolve.core.util.Util
+import org.apache.commons.io.FileUtils
 
 class TrainingUtilsTest {
   val log = LoggerFactory.getLogger("TrainingUtilsTest")
@@ -38,6 +41,9 @@ class TrainingUtilsTest {
       // To avoid Akka rebinding to the same port,
       // since it doesn't unbind immediately on shutdown
       System.clearProperty("spark.master.port")
+      // To avoid HiveContext creation error
+      // https://issues.apache.org/jira/browse/SPARK-10872
+      FileUtils.deleteQuietly(new File("metastore_db/dbex.lck"))
     }
   }
 
@@ -49,37 +55,37 @@ class TrainingUtilsTest {
     try {
       val statsArr = TrainingUtils.getFeatureStatistics(0, sc.parallelize(examples))
       val stats = statsArr.toMap
-      val statsX = stats.get(("loc", "x")).get
+      val statsX = stats(("loc", "x"))
       assertEquals(-1, statsX.min, 0.1)
       assertEquals(1, statsX.max, 0.1)
       assertEquals(0, statsX.mean, 0.1)
       // X is uniform between -1 and 1
       val xvar = 2.0 * 2.0 / 12.0
       assertEquals(xvar, statsX.variance, 0.1)
-      val statsY = stats.get(("loc", "y")).get
+      val statsY = stats(("loc", "y"))
       assertEquals(-10.0, statsY.min, 1.0)
       assertEquals(10.0, statsY.max, 1.0)
       assertEquals(0.0, statsY.mean, 1.0)
       // Y is uniform between -10 and 10
       val yvar = 20.0 * 20.0 / 12.0
       assertEquals(yvar, statsY.variance, 1.0)
-      val statsBias = stats.get(("BIAS", "B")).get
+      val statsBias = stats(("BIAS", "B"))
       assertEquals(1.0, statsBias.min, 0.1)
       assertEquals(1.0, statsBias.max, 0.1)
       assertEquals(1.0, statsBias.mean, 0.1)
       assertEquals(0.0, statsBias.variance, 0.1)
-      val statsNeg = stats.get(("NEG", "T")).get
+      val statsNeg = stats(("NEG", "T"))
       assertEquals(1.0, statsNeg.min, 0.1)
       assertEquals(1.0, statsNeg.max, 0.1)
       assertEquals(1.0, statsNeg.mean, 0.1)
       assertEquals(0.0, statsNeg.variance, 0.1)
 
       val dictionary = TrainingUtils.createStringDictionaryFromFeatureStatistics(statsArr, Set("$rank"))
-      assertEquals(4, dictionary.getDictionary().getEntryCount())
+      assertEquals(4, dictionary.getDictionary.getEntryCount)
       val ex = TrainingTestHelper.makeExample(2.0, 1.0, 2)
       log.info(ex.toString)
-      val vec = dictionary.makeVectorFromSparseFloats(Util.flattenFeature(ex.example.get(0)));
-      assertEquals(4, vec.values.length);
+      val vec = dictionary.makeVectorFromSparseFloats(Util.flattenFeature(ex.example.get(0)))
+      assertEquals(4, vec.values.length)
       log.info(vec.toString)
       val arr = scala.collection.mutable.ArrayBuffer[Float]()
       for (v <- vec.values) {
@@ -101,6 +107,46 @@ class TrainingUtilsTest {
       // To avoid Akka rebinding to the same port,
       // since it doesn't unbind immediately on shutdown
       System.clearProperty("spark.master.port")
+      // To avoid HiveContext creation error
+      // https://issues.apache.org/jira/browse/SPARK-10872
+      FileUtils.deleteQuietly(new File("metastore_db/dbex.lck"))
+    }
+  }
+
+  @Test
+  def testFeatureStatisticsWithQuantile(): Unit = {
+    val examples = TrainingTestHelper.makeSimpleClassificationExamples._1
+    var sc = new SparkContext("local", "TrainingUtilsTest")
+
+    try {
+      val statsArr = TrainingUtils.getFeatureStatistics(0, sc.parallelize(examples), Seq(0.1, 0.9))
+      val stats = statsArr.toMap
+      val statsX = stats(("loc", "x"))
+      assertEquals(-1, statsX.min, 0.1)
+      assertEquals(1, statsX.max, 0.1)
+      assertEquals(0, statsX.mean, 0.1)
+      assertEquals(-0.8, statsX.quantiles(0), 0.1)
+      assertEquals(0.8, statsX.quantiles(1), 0.1)
+      // X is uniform between -1 and 1
+      val xvar = 2.0 * 2.0 / 12.0
+      assertEquals(xvar, statsX.variance, 0.1)
+      val statsY = stats(("loc", "y"))
+      assertEquals(-10.0, statsY.min, 1.0)
+      assertEquals(10.0, statsY.max, 1.0)
+      assertEquals(0.0, statsY.mean, 1.0)
+      assertEquals(-8, statsY.quantiles(0), 1.0)
+      assertEquals(8, statsY.quantiles(1), 1.0)
+      // Y is uniform between -10 and 10
+    }
+    finally {
+      sc.stop
+      sc = null
+      // To avoid Akka rebinding to the same port,
+      // since it doesn't unbind immediately on shutdown
+      System.clearProperty("spark.master.port")
+      // To avoid HiveContext creation error
+      // https://issues.apache.org/jira/browse/SPARK-10872
+      FileUtils.deleteQuietly(new File("metastore_db/dbex.lck"))
     }
   }
 


### PR DESCRIPTION
Using quantiles (e.g. 5th, 95th) instead of min/max to initialie spline can create better buckets for features that are unimodal but heavily skewed.
Broadcast model during feature flattening to minimize task deserialization time (this is crucial for partition sample to work).
Initialize feature as point when min and max is the same for Spline. This will make BIAS a point feature instead of a Spline feature.
A few other code clean up.

@jq @deerzq @timyitong 