### PR TITLE
Evaluation on List and RDD

### DIFF
--- a/training/src/test/scala/com/airbnb/aerosolve/training/EvaluationTest.scala
+++ b/training/src/test/scala/com/airbnb/aerosolve/training/EvaluationTest.scala
@@ -163,6 +163,34 @@ class EvaluationTest {
   }
 
   @Test
+  def evaluationInCorrectListTest(): Unit = {
+    val recs = generateDataPerfect(false).toList
+    var sc = new SparkContext("local", "EvaluationTest")
+    try {
+      val results1 = Evaluation.evaluateBinaryClassification(recs, 11, "!HOLD_F1").toMap
+      val results2 = Evaluation.evaluateBinaryClassification(sc.parallelize(recs), 11, "!HOLD_F1").toMap
+      log.info("Non-RDD eval")
+      results1.foreach(res => log.info("%s = %f".format(res._1, res._2)))
+      log.info("RDD eval")
+      results2.foreach(res => log.info("%s = %f".format(res._1, res._2)))
+
+      assertEquals(results1.getOrElse("!HOLD_AUC", 0.0), results2.getOrElse("!HOLD_ACC", 0.0), 0.1)
+      assertEquals(results1.getOrElse("!HOLD_PRECISION_RECALL_AUC", 0.0), results2.getOrElse("!HOLD_PRECISION_RECALL_AUC", 0.0), 0.1)
+      assertEquals(results1.getOrElse("!HOLD_F1", 0.0), results2.getOrElse("!HOLD_F1", 0.0), 0.1)
+      assertEquals(results1.getOrElse("!HOLD_RECALL", 0.0), results2.getOrElse("!HOLD_RECALL", 0.0), 0.1)
+      assertEquals(results1.getOrElse("!HOLD_PRECISION", 0.0), results2.getOrElse("!HOLD_PRECISION", 0.0), 0.1)
+      assertEquals(results1.getOrElse("!HOLD_RMSE", 0.0), results2.getOrElse("!HOLD_RMSE", 0.0), 0.1)
+      assertEquals(results1.getOrElse("!HOLD_FPR", 0.0), results2.getOrElse("!HOLD_FPR", 0.0), 0.1)
+    } finally {
+      sc.stop
+      sc = null
+      // To avoid Akka rebinding to the same port,
+      // since it doesn't unbind immediately on shutdown
+      System.clearProperty("spark.master.port")
+    }
+  }
+
+  @Test
   def evaluationGaussianTest(): Unit = {
     val recs = generateDataGaussian
     var sc = new SparkContext("local", "EvaluationTest")
@@ -211,6 +239,27 @@ class EvaluationTest {
       // since it doesn't unbind immediately on shutdown
       System.clearProperty("spark.master.port")
     }
+  }
+
+  @Test
+  def evaluationGaussianListTest(): Unit = {
+    val recs = generateDataGaussian.toList
+    val results = Evaluation.evaluateBinaryClassification(recs, 11, "!HOLD_F1").toMap
+    results.foreach(res => log.info("%s = %f".format(res._1, res._2)))
+
+    val THRESHOLD = 0.7
+    assertTrue(results.getOrElse("!TRAIN_ACC", 0.0) > THRESHOLD)
+    assertTrue(results.getOrElse("!TRAIN_AUC", 0.0) > THRESHOLD)
+    assertTrue(results.getOrElse("!TRAIN_PRECISION_RECALL_AUC", 0.0) > THRESHOLD)
+    assertTrue(results.getOrElse("!TRAIN_F1", 0.0) > THRESHOLD)
+    assertTrue(results.getOrElse("!TRAIN_RECALL", 0.0) > THRESHOLD)
+    assertTrue(results.getOrElse("!TRAIN_PRECISION", 0.0) > THRESHOLD)
+    assertTrue(results.getOrElse("!HOLD_ACC", 0.0) > THRESHOLD)
+    assertTrue(results.getOrElse("!HOLD_AUC", 0.0) > THRESHOLD)
+    assertTrue(results.getOrElse("!HOLD_PRECISION_RECALL_AUC", 0.0) > THRESHOLD)
+    assertTrue(results.getOrElse("!HOLD_F1", 0.0) > THRESHOLD)
+    assertTrue(results.getOrElse("!HOLD_RECALL", 0.0) > THRESHOLD)
+    assertTrue(results.getOrElse("!HOLD_PRECISION", 0.0) > THRESHOLD)
   }
 
   @Test


### PR DESCRIPTION
It turns out evaluation on list is indeed useful when we want to perform them on bucketed dataset. Those bucketed results are often small enough that they can run on executor in parallel. Adding List based evaluation back for binary classification with a little bit of suboptimal DRY.


@luanjunyi @deerzq @jq 