### PR TITLE
Float Label Transform

### DIFF
--- a/core/src/main/java/com/airbnb/aerosolve/core/transforms/FloatLabelTransform.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/transforms/FloatLabelTransform.java
@@ -1,0 +1,69 @@
+package com.airbnb.aerosolve.core.transforms;
+
+import com.airbnb.aerosolve.core.FeatureVector;
+import com.airbnb.aerosolve.core.util.Util;
+
+import java.util.Map;
+
+import com.typesafe.config.Config;
+
+/**
+ * Convert a Float feature to binary LABEL based on threshold value. This is intended for
+ * binary classification where LABEL is either -1 or 1. MergeStrategy describe how existing
+ * LABEL is treated.
+ *
+ * The purpose of MergeStrategy is to help combining float features into LABEL. For example,
+ * using OVERRIDE_NEGATIVE is equivalent to LABEL with feature1 >= threshold1 or feature2 >= threshold2,
+ * using OVERRIDE_POSITIVE is equivalent to LABEL with feature1 >= threshold1 and feature2 >= threshold2.
+ */
+public class FloatLabelTransform implements Transform {
+  enum MergeStrategy {
+    OVERRIDE, // override existing label
+    OVERRIDE_NEGATIVE, // override negative label but keep positive label
+    OVERRIDE_POSITIVE, // override positive label but keep negative label
+    SKIP // preserve existing label (only replace if observation is un-labeled)
+  }
+
+  private String fieldName1;
+  private String key1;
+  private double threshold;
+  private MergeStrategy mergeStrategy;
+
+  @Override
+  public void configure(Config config, String key) {
+    fieldName1 = config.getString(key + ".field1");
+    key1 = config.getString(key + ".key1");
+    threshold = config.getDouble(key + ".threshold");
+    mergeStrategy = MergeStrategy.valueOf(config.getString(key + ".merge").toUpperCase());
+  }
+
+  @Override
+  public void doTransform(FeatureVector featureVector) {
+    Map<String, Double> labelFeature = Util.getOrCreateFloatFeature("LABEL", featureVector.floatFeatures);
+
+    Double label = labelFeature.get("");
+
+    if (mergeStrategy == MergeStrategy.SKIP && label != null) return;
+
+    Map<String, Double> floatFeature = featureVector.floatFeatures.get(fieldName1);
+    if (floatFeature != null) {
+      Double featureValue = floatFeature.get(key1);
+      if (featureValue != null) {
+        double newLabel = featureValue >= threshold ? 1 : -1;
+
+        if (
+          // fill in missing label
+            label == null ||
+                // ignore existing label
+                mergeStrategy == MergeStrategy.OVERRIDE ||
+                // override negative label
+                (mergeStrategy == MergeStrategy.OVERRIDE_NEGATIVE && label < 0 && newLabel > 0) ||
+                // override positive label
+                (mergeStrategy == MergeStrategy.OVERRIDE_POSITIVE && label > 0 && newLabel < 0)
+            ) {
+          labelFeature.put("", newLabel);
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/java/com/airbnb/aerosolve/core/transforms/FloatLabelTransformTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/transforms/FloatLabelTransformTest.java
@@ -1,0 +1,163 @@
+package com.airbnb.aerosolve.core.transforms;
+
+import com.airbnb.aerosolve.core.FeatureVector;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class FloatLabelTransformTest {
+  private FeatureVector makeFeatureVector(Double value, Double label) {
+    Map<String, Map<String, Double>> floatFeatures = new HashMap<>();
+
+    if (value != null) {
+      Map<String, Double> map = new HashMap<>();
+      map.put("50th", value);
+      floatFeatures.put("DECILES", map);
+    }
+
+    if (label != null) {
+      Map<String, Double> map = new HashMap<>();
+      map.put("", label);
+      floatFeatures.put("LABEL", map);
+    }
+
+    FeatureVector featureVector = new FeatureVector();
+    featureVector.setFloatFeatures(floatFeatures);
+    return featureVector;
+  }
+
+  private FloatLabelTransform createTransform(FloatLabelTransform.MergeStrategy mergeStrategy) {
+    Config config = ConfigFactory.parseString("test_float_label {\n" +
+        " transform : float_label\n" +
+        " field1 : DECILES\n" +
+        " key1 : 50th\n" +
+        " threshold : 10\n" +
+        " merge : " + mergeStrategy.toString() + "\n" +
+        "}");
+
+    FloatLabelTransform transform = new FloatLabelTransform();
+    transform.configure(config, "test_float_label");
+
+    return transform;
+  }
+
+  private double getLabel(FeatureVector featureVector) {
+    return featureVector.floatFeatures.get("LABEL").get("");
+  }
+
+  @Test
+  public void handleMissingFeature() {
+    FloatLabelTransform transform = createTransform(FloatLabelTransform.MergeStrategy.OVERRIDE);
+
+    // keep current label even though we could overwrite
+    FeatureVector featureVector1 = makeFeatureVector(null, 1.0);
+    transform.doTransform(featureVector1);
+    assertEquals(1, getLabel(featureVector1), 0.1);
+  }
+
+  @Test
+  public void OverwriteLabel() {
+    FloatLabelTransform transform = createTransform(FloatLabelTransform.MergeStrategy.OVERRIDE);
+
+    // fill in missing positive label
+    FeatureVector featureVector1 = makeFeatureVector(1.0, null);
+    transform.doTransform(featureVector1);
+    assertEquals(-1, getLabel(featureVector1), 0.1);
+
+    // fill in missing negative label
+    FeatureVector featureVector2 = makeFeatureVector(10.0, null);
+    transform.doTransform(featureVector2);
+    assertEquals(1, getLabel(featureVector2), 0.1);
+
+    // overwrite positive label
+    FeatureVector featureVector3 = makeFeatureVector(1.0, 1.0);
+    transform.doTransform(featureVector3);
+    assertEquals(-1, getLabel(featureVector3), 0.1);
+
+    // overwrite negative label
+    FeatureVector featureVector4 = makeFeatureVector(10.0, -1.0);
+    transform.doTransform(featureVector4);
+    assertEquals(1, getLabel(featureVector4), 0.1);
+  }
+
+  @Test
+  public void keepExistingLabel() {
+    FloatLabelTransform transform = createTransform(FloatLabelTransform.MergeStrategy.SKIP);
+
+    // fill in missing positive label
+    FeatureVector featureVector1 = makeFeatureVector(1.0, null);
+    transform.doTransform(featureVector1);
+    assertEquals(-1, getLabel(featureVector1), 0.1);
+
+    // fill in missing negative label
+    FeatureVector featureVector2 = makeFeatureVector(10.0, null);
+    transform.doTransform(featureVector2);
+    assertEquals(1, getLabel(featureVector2), 0.1);
+
+    // preserve positive label
+    FeatureVector featureVector3 = makeFeatureVector(1.0, 1.0);
+    transform.doTransform(featureVector3);
+    assertEquals(1, getLabel(featureVector3), 0.1);
+
+    // preserve negative label
+    FeatureVector featureVector4 = makeFeatureVector(10.0, -1.0);
+    transform.doTransform(featureVector4);
+    assertEquals(-1, getLabel(featureVector4), 0.1);
+  }
+
+  @Test
+  public void keepPositiveLabel() {
+    FloatLabelTransform transform = createTransform(FloatLabelTransform.MergeStrategy.OVERRIDE_NEGATIVE);
+
+    // fill in missing positive label
+    FeatureVector featureVector1 = makeFeatureVector(1.0, null);
+    transform.doTransform(featureVector1);
+    assertEquals(-1, getLabel(featureVector1), 0.1);
+
+    // fill in missing negative label
+    FeatureVector featureVector2 = makeFeatureVector(10.0, null);
+    transform.doTransform(featureVector2);
+    assertEquals(1, getLabel(featureVector2), 0.1);
+
+    // preserve positive label
+    FeatureVector featureVector3 = makeFeatureVector(1.0, 1.0);
+    transform.doTransform(featureVector3);
+    assertEquals(1, getLabel(featureVector3), 0.1);
+
+    // overwrite negative label
+    FeatureVector featureVector4 = makeFeatureVector(10.0, -1.0);
+    transform.doTransform(featureVector4);
+    assertEquals(1, getLabel(featureVector4), 0.1);
+  }
+
+  @Test
+  public void keepNegativeLabel() {
+    FloatLabelTransform transform = createTransform(FloatLabelTransform.MergeStrategy.OVERRIDE_POSITIVE);
+
+    // fill in missing positive label
+    FeatureVector featureVector1 = makeFeatureVector(1.0, null);
+    transform.doTransform(featureVector1);
+    assertEquals(-1, getLabel(featureVector1), 0.1);
+
+    // fill in missing negative label
+    FeatureVector featureVector2 = makeFeatureVector(10.0, null);
+    transform.doTransform(featureVector2);
+    assertEquals(1, getLabel(featureVector2), 0.1);
+
+    // overwrite positive label
+    FeatureVector featureVector3 = makeFeatureVector(1.0, 1.0);
+    transform.doTransform(featureVector3);
+    assertEquals(-1, getLabel(featureVector3), 0.1);
+
+    // preserve negative label
+    FeatureVector featureVector4 = makeFeatureVector(10.0, -1.0);
+    transform.doTransform(featureVector4);
+    assertEquals(-1, getLabel(featureVector4), 0.1);
+  }
+}


### PR DESCRIPTION
Add a new transform that creates LABEL feature based on a Float feature with a threshold value. With custom merge strategy, one can combine several float features into a single LABEL.

I also considered adding a LabelStrategy/Comparator/Ordering configuration, which would dictate what constitutes a positive label. However I couldn't find an out of the box enum that does the job (i.e. GTE, GT, EQ, NEQ, LT, LTE). I then feel like it is probably an overkill and we could just have a negate float feature transform to handle a naive cases. Or rephrase the model problem by swapping the definition of positive/negative label.

@yinlou @luanjunyi @timyitong @deerzq @jq 