### PR TITLE
dynamic bucketing in AUC calculation

### DIFF
--- a/training/src/main/scala/com/airbnb/aerosolve/training/Evaluation.scala
+++ b/training/src/main/scala/com/airbnb/aerosolve/training/Evaluation.scala
@@ -341,7 +341,7 @@ object Evaluation {
     val scores = records.map(r => (r.score, r.score))
     val (maxScore, minScore) = scores.reduce( {case (u, v) => (u._1 max v._1, u._2 min v._2) })
     val count = records.count()
-    val bucketSize = count / 10000 // Divide the area under ROC curve by 10000 vertical strips
+    val bucketSize = Math.max(1, count / 10000) // Divide the area under ROC curve by 10000 vertical strips
     log.info("%d eval record, bucket size = %d".format(count, bucketSize))
     if (minScore >= maxScore) {
       log.error("max score smaller than or equal to min score (%f, %f), total: %d".


### PR DESCRIPTION
**What**

Optimize the ROC-AUC calculation for dataset with uneven distributed scoring. AUC is calculated by first divide the whole area to 100 small vertical strips, approximate the areas for each strips and sum them up. In our existing implementation, we first get the min and max of all scores(probabilities) and evenly divide the space to 100 intervals, no matter how many records are in each interval.

This will make the AUC inaccurate for score distribution that is not uniformly distributed. During my experiment with short term labeling, our existing implementation returned AUC of 0.74. I take a sample offline and use sklearn to calculate, the result is 0.87. With this PR, the result is 0.85, which is far more reasonable.

For our base models, the error introduced by this approximation is much smaller.

**How**

Divide the score space unevenly according to the true distribution. More specifically, first sort the records by score, use zipWithIndex to get the rank of score, then use rank/bucketSize to get the bucket.

I also changed the bucket number from 100 to 10000, turns out not much difference. But I think 10000 is better since we do want more accurate estimation and can afford the computation resources.

@deerzq @saurfang 
