### PR TITLE
Make Point Feature Fixed

### DIFF
--- a/core/src/main/java/com/airbnb/aerosolve/core/function/Point.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/function/Point.java
@@ -6,6 +6,9 @@ import com.airbnb.aerosolve.core.ModelRecord;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * A point function y(x) = w where w is a constant. This usually represents one-hot feature.
+ */
 public class Point implements Function {
   private float weight;
 
@@ -30,27 +33,24 @@ public class Point implements Function {
     return new Point(aggWeight);
   }
 
-  /*
-    for string feature, aerosolve assume x[0] == 1
-   */
   @Override
   public float evaluate(float... x) {
-    return weight * x[0];
+    return weight;
   }
 
   @Override
   public float evaluate(List<Double> values) {
-    return weight * values.get(0).floatValue();
+    return weight;
   }
 
   @Override
   public void update(float delta, float... values) {
-    weight += delta * values[0];
+    weight += delta;
   }
 
   @Override
   public void update(float delta, List<Double> values) {
-    weight += delta * values.get(0);
+    weight += delta;
   }
 
   @Override

--- a/core/src/test/java/com/airbnb/aerosolve/core/function/PointTest.java
+++ b/core/src/test/java/com/airbnb/aerosolve/core/function/PointTest.java
@@ -17,4 +17,12 @@ public class PointTest {
     assertEquals(-3, point.evaluate(1.0f), 0);
   }
 
+  @Test
+  public void ConstantPoint() {
+    Point point = example();
+    assertEquals(-6, point.evaluate(1.0f), 0);
+    assertEquals(-6, point.evaluate(-1.0f), 0);
+    assertEquals(-6, point.evaluate(0f), 0);
+  }
+
 }


### PR DESCRIPTION
Instead of assuming value always is 1, make Point feature always output weight instead. Otherwise if we encounter features that we have not seen, we would make this an effective f(x)=w*x linear feature instead.

This is consistent with the way we use Point feature in AdditiveTrainer where Point is only provisioned when `stats.min == stats.max`.

@jq @deerzq 