### PR TITLE
[airlearner] utils bintray name now matches subproject name

### DIFF
--- a/airlearner/airlearner-utils/build.gradle
+++ b/airlearner/airlearner-utils/build.gradle
@@ -31,8 +31,8 @@ bintray {
   pkg {
     repo = 'aerosolve'
     userOrg = 'airbnb'
-    name = 'airlearner-util'
-    desc = 'airlearner util lib'
+    name = 'airlearner-utils'
+    desc = 'airlearner utils lib'
     websiteUrl = 'https://github.com/airbnb/aerosolve'
     issueTrackerUrl = 'https://github.com/airbnb/aerosolve/issues'
     vcsUrl = 'https://github.com/airbnb/aerosolve.git'


### PR DESCRIPTION
There was a discrepancy between the Bintray name and the name of the subproject in all other places.

This rectifies it by updating the bintray name.

@jq 