### PR TITLE
[utils] introduction of JMH to test sample performance

### DIFF
--- a/airlearner/airlearner-utils/build.gradle
+++ b/airlearner/airlearner-utils/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id 'me.champeau.gradle.jmh' version '0.3.1'
+}
+
 apply plugin: 'java'
 apply plugin: 'com.jfrog.bintray'
 
@@ -45,4 +49,9 @@ bintray {
 
 shadowJar {
   zip64 = true
+}
+
+// Note: If you run into issues with JMH, your first response should be to run `gradlew clean`
+jmh {
+  jmhVersion = '1.19'
 }

--- a/airlearner/airlearner-utils/src/jmh/scala/com/airbnb/common/ml/util/RandomUtilBenchmarks.scala
+++ b/airlearner/airlearner-utils/src/jmh/scala/com/airbnb/common/ml/util/RandomUtilBenchmarks.scala
@@ -1,0 +1,85 @@
+package com.airbnb.common.ml.util
+
+import scala.collection.mutable
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+
+
+object RandomUtilBenchmarks {
+
+
+  /**
+   * Perform testing of different Scala collection types as input to the
+   * `RandomUtil.sample` method.
+   */
+  @BenchmarkMode(Array(Mode.Throughput))
+  @Fork(value = 1, warmups = 0)
+  @Warmup(iterations = 4, time = 2)
+  @Measurement(iterations = 8, time = 2)
+  @State(value = Scope.Benchmark)
+  class SampleBenchmarks {
+
+    // Try different collection sizes
+    @Param(value = Array("1000", "10000"))
+    var numItemsToGenerate: Int = _
+
+    val ratios: Seq[Double] = Seq(0.85, 0.1, 0.05)
+
+
+    @Benchmark
+    def sampleArray(): Seq[Seq[Int]] = {
+      RandomUtil.sample(
+        Array.range(1, numItemsToGenerate),
+        ratios
+      )
+    }
+
+    @Benchmark
+    def sampleArraySeq(): Seq[Seq[Int]] = {
+      RandomUtil.sample(
+        mutable.ArraySeq.range(1, numItemsToGenerate),
+        ratios
+      )
+    }
+
+    @Benchmark
+    def sampleList(): Seq[Seq[Int]] = {
+      RandomUtil.sample(
+        List.range(1, numItemsToGenerate),
+        ratios
+      )
+    }
+
+    @Benchmark
+    def sampleSeq(): Seq[Seq[Int]] = {
+      RandomUtil.sample(
+        Seq.range(1, numItemsToGenerate),
+        ratios
+      )
+    }
+
+    @Benchmark
+    def sampleVector(): Seq[Seq[Int]] = {
+      RandomUtil.sample(
+        Vector.range(1, numItemsToGenerate),
+        ratios
+      )
+    }
+
+    @Benchmark
+    def sampleSeqToVector(): Seq[Seq[Int]] = {
+      RandomUtil.sample(
+        Seq.range(1, numItemsToGenerate).toVector,
+        ratios
+      )
+    }
+  }
+}

--- a/airlearner/airlearner-utils/src/main/scala/com/airbnb/common/ml/util/RandomUtil.scala
+++ b/airlearner/airlearner-utils/src/main/scala/com/airbnb/common/ml/util/RandomUtil.scala
@@ -29,19 +29,21 @@ object RandomUtil {
     bounds(index)
   }
 
-  def sample[T](items: Seq[T], ratios: Seq[Double]): Seq[Seq[T]]= {
-    val t = Random.shuffle(items)
-    slice(t, ratios)
+  def sample[T](items: Seq[T], ratios: Seq[Double]): Seq[Seq[T]] = {
+    val shuffledItems: Seq[T] = Random.shuffle(items)
+    slice(shuffledItems, ratios)
   }
 
-  def slice[T](items: Seq[T], ratios: Seq[Double]): Seq[Seq[T]]= {
-    val len = items.length
-    val start = ratios.scanLeft(0.0)(_ + _).take(ratios.length)
+  def slice[T](items: Seq[T], ratios: Seq[Double]): Seq[Seq[T]] = {
+    val itemCount: Int = items.length
+    val startPositions: Seq[Double] = ratios.scanLeft(0.0)(_ + _).take(ratios.length)
 
-    start.zip(ratios).map{
-      case (s:Double, size:Double) => {
-        val startPos: Int = (s * len).toInt
-        val endPos: Int = ((s + size)*len).toInt
+    // The range here is ratio-based, which is converted to index
+    // through multiplication with itemCount.
+    startPositions.zip(ratios).map {
+      case (rangeStart: Double, rangeLength: Double) => {
+        val startPos: Int = (rangeStart * itemCount).toInt
+        val endPos: Int = ((rangeStart + rangeLength) * itemCount).toInt
         items.slice(startPos, endPos)
       }
     }


### PR DESCRIPTION
This introduces [JMH](http://openjdk.java.net/projects/code-tools/jmh/), a micro-benchmarking toolkit for the JVM.

In this PR, it is used to evaluate the practical performance of different Scala `Seq` collections through the `RandomUtil.sample` method.

Results:
```
Benchmark                                                (numItemsToGenerate)   Mode  Cnt      Score      Error  Units
RandomUtilBenchmarks.SampleBenchmarks.sampleArray                        1000  thrpt    8  37631.355 ± 1220.891  ops/s
RandomUtilBenchmarks.SampleBenchmarks.sampleArray                       10000  thrpt    8   3753.914 ±  128.483  ops/s
RandomUtilBenchmarks.SampleBenchmarks.sampleArraySeq                     1000  thrpt    8  33349.426 ± 1213.678  ops/s
RandomUtilBenchmarks.SampleBenchmarks.sampleArraySeq                    10000  thrpt    8   3378.706 ±  186.838  ops/s
RandomUtilBenchmarks.SampleBenchmarks.sampleList                         1000  thrpt    8  11754.437 ± 1014.332  ops/s
RandomUtilBenchmarks.SampleBenchmarks.sampleList                        10000  thrpt    8   1736.299 ±  150.472  ops/s
RandomUtilBenchmarks.SampleBenchmarks.sampleSeq                          1000  thrpt    8  11741.910 ±  442.407  ops/s
RandomUtilBenchmarks.SampleBenchmarks.sampleSeq                         10000  thrpt    8   1441.347 ±  118.895  ops/s
RandomUtilBenchmarks.SampleBenchmarks.sampleSeqToVector                  1000  thrpt    8  20337.082 ±  463.728  ops/s
RandomUtilBenchmarks.SampleBenchmarks.sampleSeqToVector                 10000  thrpt    8   2789.902 ±   91.961  ops/s
RandomUtilBenchmarks.SampleBenchmarks.sampleVector                       1000  thrpt    8  34982.044 ±  360.904  ops/s
RandomUtilBenchmarks.SampleBenchmarks.sampleVector                      10000  thrpt    8   3644.083 ±  101.226  ops/s
```

These results indicate that calling code using either `Array` or `Vector` types will be more than 200% faster than code passing in a `Seq` or `List` of items.

Also includes some minor formatting cleanup in the `RandomUtil` object.

@jq @saurfang 