### PR TITLE
[travis] remove php in thrift 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - sudo apt-get install libboost-dev libboost-test-dev libboost-program-options-dev libevent-dev automake libtool flex bison pkg-config g++ libssl-dev
   - wget https://archive.apache.org/dist/thrift/0.9.1/thrift-0.9.1.tar.gz
   - tar xfz thrift-0.9.1.tar.gz
-  - cd thrift-0.9.1 && ./configure --without-cpp --without-c_glib --without-python --without-ruby --without-go --without-erlang --without-java && sudo make install && cd ..
+  - cd thrift-0.9.1 && ./configure --without-php --without-php_extension --without-cpp --without-c_glib --without-python --without-ruby --without-go --without-erlang --without-java && sudo make install && cd ..
 
 script:
   - test "${TRAVIS_TAG}" || ./gradlew check # only run check on non-tag build because of flaky tests


### PR DESCRIPTION
the travis build is failing https://travis-ci.org/airbnb/aerosolve/builds/463016575

I suspect this is related to PHP, in this PR we remove php see if it will work

to: @saurfang @jieyingchen 