### PR TITLE
Build aerosolve using Scala 2.12 and Spark 3

### DIFF
--- a/airlearner/airlearner-strategy/build.gradle
+++ b/airlearner/airlearner-strategy/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.jfrog.bintray'
 
 // Includes 'scala' plugin
-apply from: "$rootDir/airlearner/configs/scala211.gradle"
+apply from: "$rootDir/airlearner/configs/scala212.gradle"
 
 repositories {
   mavenLocal()
@@ -10,9 +10,9 @@ repositories {
 dependencies {
   compile libraries.typesafe_config
 
-  provided "org.apache.spark:spark-core_2.11:${sparkVersion}"
-  provided "org.apache.spark:spark-hive_2.11:${sparkVersion}"
-  provided "org.apache.spark:spark-mllib_2.11:${sparkVersion}"
+  provided "org.apache.spark:spark-core_2.12:${sparkVersion}"
+  provided "org.apache.spark:spark-hive_2.12:${sparkVersion}"
+  provided "org.apache.spark:spark-mllib_2.12:${sparkVersion}"
 
   compile project(':airlearner:airlearner-utils')
 

--- a/airlearner/airlearner-utils/build.gradle
+++ b/airlearner/airlearner-utils/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'java'
 apply plugin: 'com.jfrog.bintray'
 
 // Includes 'scala' plugin
-apply from: "$rootDir/airlearner/configs/scala211.gradle"
+apply from: "$rootDir/airlearner/configs/scala212.gradle"
 
 repositories {
   mavenLocal()
@@ -20,8 +20,8 @@ dependencies {
   compile libraries.slf4j_simple
   compile libraries.typesafe_config
 
-  provided "org.apache.spark:spark-core_2.11:${sparkVersion}"
-  provided "org.apache.spark:spark-hive_2.11:${sparkVersion}"
+  provided "org.apache.spark:spark-core_2.12:${sparkVersion}"
+  provided "org.apache.spark:spark-hive_2.12:${sparkVersion}"
 }
 
 bintray {

--- a/airlearner/airlearner-utils/src/main/scala/com/airbnb/common/ml/util/ScalaLogging.scala
+++ b/airlearner/airlearner-utils/src/main/scala/com/airbnb/common/ml/util/ScalaLogging.scala
@@ -1,7 +1,7 @@
 package com.airbnb.common.ml.util
 
 // scalastyle:off ban.logger.factory
-import com.typesafe.scalalogging.slf4j.Logger
+import com.typesafe.scalalogging.Logger
 import org.slf4j.LoggerFactory
 
 

--- a/airlearner/airlearner-xgboost/build.gradle
+++ b/airlearner/airlearner-xgboost/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.jfrog.bintray'
 
 // Includes 'scala' plugin
-apply from: "$rootDir/airlearner/configs/scala211.gradle"
+apply from: "$rootDir/airlearner/configs/scala212.gradle"
 
 repositories {
   mavenLocal()
@@ -10,9 +10,9 @@ repositories {
 dependencies {
   compile libraries.typesafe_config
 
-  provided "org.apache.spark:spark-core_2.11:${sparkVersion}"
-  provided "org.apache.spark:spark-hive_2.11:${sparkVersion}"
-  provided "org.apache.spark:spark-mllib_2.11:${sparkVersion}"
+  provided "org.apache.spark:spark-core_2.12:${sparkVersion}"
+  provided "org.apache.spark:spark-hive_2.12:${sparkVersion}"
+  provided "org.apache.spark:spark-mllib_2.12:${sparkVersion}"
 
   compile project(':airlearner:airlearner-utils')
   compile files('local-lib/xgboost4j-0.7.jar')

--- a/airlearner/configs/scala210.gradle
+++ b/airlearner/configs/scala210.gradle
@@ -9,8 +9,6 @@ ext {
 // Language support
 apply plugin: 'java'
 apply plugin: 'scala'
-// Tooling support
-apply plugin: 'scalaStyle'
 
 
 /**
@@ -58,18 +56,6 @@ tasks.withType(ScalaCompile) {
     debugLevel = 'vars'
     additionalParameters = getScalaCompileAdditionalParameters()
   }
-}
-
-
-/**
- * Automated Scala style checking as part of the build check task
- */
-check.dependsOn << ['scalaStyle']
-scalaStyle {
-  configLocation = "$rootDir/airlearner/configs/scalastyle_config.xml"
-  source = 'src/main/scala'
-  testSource = 'src/test/scala'
-  includeTestSourceDirectory = true
 }
 
 

--- a/airlearner/configs/scala212.gradle
+++ b/airlearner/configs/scala212.gradle
@@ -3,7 +3,7 @@
  */
 
 ext {
-    scala211Version = '2.11.8'
+    scala212Version = '2.12.7'
 }
 
 // Language support
@@ -19,9 +19,9 @@ apply plugin: 'scala'
  * Additionally, don't include domain specific libraries such as Spark.
  */
 dependencies {
-    compile libraries.scala_library_211
-    compile libraries.scala_logging_slf4j_211
-    compile libraries.org_scala_lang_modules_scala_java8_compat_2_11
+    compile libraries.scala_library_212
+    compile libraries.scala_logging_slf4j_212
+    compile libraries.org_scala_lang_modules_scala_java8_compat_2_12
 }
 
 /**
@@ -66,7 +66,7 @@ tasks.withType(ScalaCompile) {
  */
 task repl(type: JavaExec) {
     dependencies {
-        compile group: 'org.scala-lang', name: 'scala-compiler', version: scala211Version
+        compile group: 'org.scala-lang', name: 'scala-compiler', version: scala212Version
     }
     main = 'scala.tools.nsc.MainGenericRunner'
     classpath = sourceSets.main.runtimeClasspath

--- a/airlearner/libraries.gradle
+++ b/airlearner/libraries.gradle
@@ -1,18 +1,21 @@
 allprojects {
   ext {
-    sparkVersion = '2.3.0'
+    sparkVersion = '3.1.1'
 
     libraries = [
         lombok: 'org.projectlombok:lombok:1.16.8',
         joda_time: 'joda-time:joda-time:2.8.2',
         joda_convert: 'org.joda:joda-convert:1.8',
         scala_library_211: 'org.scala-lang:scala-library:2.11.8',
+        scala_library_212: 'org.scala-lang:scala-library:2.12.7',
         scala_logging_slf4j_211: 'com.typesafe.scala-logging:scala-logging-slf4j_2.11:2.1.2',
+        scala_logging_slf4j_212: 'com.typesafe.scala-logging:scala-logging_2.12:3.9.2',
         slf4j_api: 'org.slf4j:slf4j-api:1.7.9',
         slf4j_simple: 'org.slf4j:slf4j-simple:1.7.9',
         typesafe_config: 'com.typesafe:config:1.3.0',
         org_typelevel_cats_core_2_11_1_0_1: 'org.typelevel:cats-core_2.11:1.0.1',
         org_scala_lang_modules_scala_java8_compat_2_11: 'org.scala-lang.modules:scala-java8-compat_2.11:0.8.0',
+        org_scala_lang_modules_scala_java8_compat_2_12: 'org.scala-lang.modules:scala-java8-compat_2.12:0.8.0',
     ]
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
   repositories {
     jcenter()
     maven { url "https://plugins.gradle.org/m2/" }
+    maven { url "https://repo.grails.org/grails/core/" }
   }
 
   dependencies {
@@ -17,9 +18,6 @@ buildscript {
     classpath group: 'gradle.plugin.com.palantir.gradle.gitversion',
         name: 'gradle-git-version',
         version: '0.7.3'
-    classpath group: 'org.github.ngbinh.scalastyle',
-        name: 'gradle-scalastyle-plugin_2.10',
-        version: '0.8.2'
   }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -39,5 +39,6 @@ dependencies {
   compile 'org.projectlombok:lombok:1.14.8'
   compile 'org.apache.commons:commons-lang3:3.4'
   compile 'org.apache.commons:commons-math3:3.6.1'
+  compile 'org.apache.httpcomponents:httpcore:4.4.16'
   testCompile 'org.slf4j:slf4j-log4j12:1.7.21'
 }

--- a/core/src/main/java/com/airbnb/aerosolve/core/models/LinearModel.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/models/LinearModel.java
@@ -14,12 +14,12 @@ import com.airbnb.aerosolve.core.util.Util;
 import com.google.common.hash.HashCode;
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.http.annotation.NotThreadSafe;
+import org.apache.http.annotation.Contract;
 
 /**
  * A linear model backed by a hash map.
  */
-@NotThreadSafe
+@Contract (threading = org.apache.http.annotation.ThreadingBehavior.UNSAFE)
 public class LinearModel extends AbstractModel {
 
   @Getter @Setter

--- a/core/src/main/java/com/airbnb/aerosolve/core/util/Debug.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/util/Debug.java
@@ -144,8 +144,8 @@ public class Debug  {
   // Save example to path
   // If you hit permission error, touch and chmod the file
   public static void saveExample(Example example, String path) {
-    TSerializer serializer = new TSerializer(new TBinaryProtocol.Factory());
     try {
+      TSerializer serializer = new TSerializer(new TBinaryProtocol.Factory());
       byte[] buf = serializer.serialize(example);
       FileOutputStream fos = new FileOutputStream(path);
       fos.write(buf);

--- a/core/src/main/java/com/airbnb/aerosolve/core/util/Util.java
+++ b/core/src/main/java/com/airbnb/aerosolve/core/util/Util.java
@@ -49,8 +49,8 @@ public class Util implements Serializable {
   // manipulate in spark. e.g. if we  wanted to see the 50 weights in a model
   // val top50 = sc.textFile("model.bz2").map(Util.decodeModel).sortBy(x => -x.weight).take(50);
   public static String encode(TBase obj) {
-    TSerializer serializer = new TSerializer();
     try {
+      TSerializer serializer = new TSerializer();
       byte[] bytes = serializer.serialize(obj);
       return new String(Base64.encodeBase64(bytes));
     } catch (Exception e) {

--- a/thrift-cli.gradle
+++ b/thrift-cli.gradle
@@ -1,7 +1,7 @@
 apply plugin: "java"
 
 dependencies {
-  compile 'org.apache.thrift:libthrift:0.9.1'
+  compile 'org.apache.thrift:libthrift:0.20.0'
 }
 
 def genJavaDir = new File("${->buildDir}/gen-java")

--- a/training/build.gradle
+++ b/training/build.gradle
@@ -31,7 +31,7 @@ bintray {
 }
 
 dependencies {
-  compile 'org.scala-lang:scala-library:2.11.8'
+  compile 'org.scala-lang:scala-library:2.12.7'
   compile project(':core')
 
   compile ('org.apache.avro:avro:1.7.7') {
@@ -41,18 +41,18 @@ dependencies {
     transitive = false
   }
 
-  compile 'com.fasterxml.jackson.module:jackson-module-scala_2.11:2.7.8'
+  compile 'com.fasterxml.jackson.module:jackson-module-scala_2.12:2.11.4'
   compile 'joda-time:joda-time:2.5'
   compile 'org.apache.hadoop:hadoop-client:2.2.0'
   compile 'com.databricks:spark-csv_2.10:1.4.0'
 
-  provided 'org.apache.spark:spark-core_2.11:2.3.0'
-  provided 'org.apache.spark:spark-hive_2.11:2.3.0'
+  provided 'org.apache.spark:spark-core_2.12:3.1.1'
+  provided 'org.apache.spark:spark-hive_2.12:3.1.1'
 
-  testCompile 'org.apache.spark:spark-core_2.11:2.3.0'
-  testCompile 'org.apache.spark:spark-core_2.11:2.3.0:tests'
+  testCompile 'org.apache.spark:spark-core_2.12:3.1.1'
+  testCompile 'org.apache.spark:spark-core_2.12:3.1.1:tests'
   testCompile 'org.scalatest:scalatest_2.11:3.0.5'
-  testCompile 'org.apache.spark:spark-hive_2.11:2.3.0'
+  testCompile 'org.apache.spark:spark-hive_2.12:3.1.1'
   testCompile 'org.mockito:mockito-all:1.9.5'
   testCompile 'org.slf4j:slf4j-log4j12:1.7.21'
 }


### PR DESCRIPTION
Migrate the `aerosolve` package to Scala 2.12 and Spark 3.